### PR TITLE
Refactored match-name.js into class

### DIFF
--- a/src/fuzzy-matching/match-name.js
+++ b/src/fuzzy-matching/match-name.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const FuzzySet = require('fuzzyset.js');
 const {
     promisify
@@ -10,20 +11,26 @@ const dependencies = {
     GetNames: promisify(GetBulkNames)
 };
 
-function FilterNames(names) {
+function MatchName(params) {
+    _.bindAll(this, Object.keys(MatchName.prototype));
+}
+
+MatchName.prototype._filterNames = function (names) {
     return names.map((record) => {
         return record.name;
     });
 }
 
-async function Match(cleanText, dirtyText = '') {
+MatchName.prototype.Match = async function (cleanText, dirtyText = '') {
     let names = await dependencies.GetNames();
-    let filteredNames = FilterNames(names);
+    let filteredNames = this._filterNames(names);
     let fuzzy = FuzzySet(filteredNames);
     return fuzzy.get(cleanText);
 }
 
 module.exports = {
-    Match,
+    create: function (params) {
+        return new MatchName(params);
+    },
     dependencies
 };

--- a/src/processor/processor.js
+++ b/src/processor/processor.js
@@ -25,7 +25,7 @@ const {
 const NeedsAttention = require('../models/needs-attention');
 
 const dependencies = {
-    MatchName
+    MatchName: MatchName.create()
 }
 
 const Scan = promisify(textExtraction.ScanImage);

--- a/test/fuzzy/name-match.spec.js
+++ b/test/fuzzy/name-match.spec.js
@@ -3,15 +3,14 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const assert = require('assert');
 const {
-    CreateMatchName,
+    create,
     dependencies
 } = require('../../src/fuzzy-matching/match-name');
 
 describe('FuzzyMatching::', () => {
     let sandbox = {};
     let stubs = {};
-    let MatchName = CreateMatchName();
-    let Match = MatchName.Match;
+    let Match = create().Match;
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();

--- a/test/fuzzy/name-match.spec.js
+++ b/test/fuzzy/name-match.spec.js
@@ -3,13 +3,16 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const assert = require('assert');
 const {
-    Match,
+    CreateMatchName,
     dependencies
 } = require('../../src/fuzzy-matching/match-name');
 
 describe('FuzzyMatching::', () => {
     let sandbox = {};
     let stubs = {};
+    let MatchName = CreateMatchName();
+    let Match = MatchName.Match;
+
     beforeEach(() => {
         sandbox = sinon.createSandbox();
         stubs.BulkNamesStub = sandbox.stub(dependencies, "GetNames").returns([{


### PR DESCRIPTION
As requested in issue #18, this is an attempt to refactor the name matching in match-name.js into a MatchName class.  The refactored class mirrors the format of the SingleProcessor class in processor.js.