### PR TITLE
Improve OCR normalization and name matching precision

### DIFF
--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -59,7 +59,7 @@ class ProcessHashes {
     }
 
     async compareDbHashes() {
-        this.logger.info(`process-hashes::compareDbHashes: Compare DB Hashes`);
+        this.logger.info(`process-hashes::db-compare start name="${this.name}"`);
         const hashes = await this.dependencies.CardHashes.getByCardName(this.name);
         const matches = [];
         hashes.forEach((dbHash) => {
@@ -79,11 +79,9 @@ class ProcessHashes {
                 );
             }
         });
-        this.logger.info(matches);
+        this.logger.info(`process-hashes::db-compare matches=${matches.length}`);
         if (matches.length === 0) {
-            this.logger.info(
-                `process-hashes::compareDbHashes: No DB Hash Match Found ${this.name}`
-            );
+            this.logger.info(`process-hashes::db-compare none name="${this.name}"`);
             if (this.ignoreNoDbMatch) {
                 return [];
             }
@@ -95,7 +93,9 @@ class ProcessHashes {
     }
 
     async compareRemoteImages() {
-        this.logger.info(`process-hashes::compareDbHashes: Compare Remote Image Hashes`);
+        this.logger.info(
+            `process-hashes::remote-compare start name="${this.name}" mode=${this.hashMode} cards=${this.cards.length}`
+        );
         const cards = _.map(this.cards, function (card) {
             const images = card.image_uris || {};
             return {
@@ -170,9 +170,11 @@ class ProcessHashes {
                 )
                 .slice(0, config.remoteBestGuess.maxCandidates)
                 .map((match) => _.omit(match, ["confidenceScore"]));
-            this.logger.info("process-hashes::compareRemoteImages: Using best available match");
-            this.logger.info(bestMatches);
+            this.logger.info(
+                `process-hashes::remote-compare using-best-guess name="${this.name}" candidates=${bestMatches.map((match) => match.setName).join(",")}`
+            );
         }
+        this.logger.info(`process-hashes::remote-compare complete matches=${bestMatches.length}`);
         return bestMatches;
     }
 

--- a/src/fuzzy-matching/match-name.mjs
+++ b/src/fuzzy-matching/match-name.mjs
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import joi from "joi";
 import FuzzySet from "fuzzyset.js";
+import stringSimilarity from "string-similarity";
 import logger from "../logger/log.mjs";
 import storage from "../storage/index.mjs";
 import { cleanString } from "../util.mjs";
@@ -8,7 +9,14 @@ import { cleanString } from "../util.mjs";
 const config = {
     highConfidence: 0.95,
     minConfidence: 0.7,
-    maxMatches: 5
+    maxMatches: 5,
+    disambiguation: {
+        minTopPercent: 0.8,
+        minTopFirstTokenSimilarity: 0.6,
+        maxScoreDelta: 0.12,
+        minFirstTokenSimilarity: 0.4,
+        maxFirstTokenDropFromTop: 0.15
+    }
 };
 
 const dependencies = {
@@ -50,10 +58,15 @@ class MatchName {
     }
 
     async gatherInitialResults() {
+        const normalizedQuery = normalizeForMatch(this.cleanText);
+        if (!normalizedQuery) {
+            this.nameLookup = {};
+            this.initialResults = [];
+            return;
+        }
         const names = await dependencies.GetNames();
         const filteredNames = this.filteredNames(names);
         const fuzzy = FuzzySet(filteredNames);
-        const normalizedQuery = normalizeForMatch(this.cleanText);
         const exact = this.nameLookup[normalizedQuery];
         this.initialResults = exact ? [[1, normalizedQuery]] : fuzzy.get(normalizedQuery);
         if (!this.initialResults) {
@@ -62,26 +75,66 @@ class MatchName {
     }
 
     async filterBulkMatches() {
-        const fixedResults = _.map(this.initialResults, (match) => {
+        const query = normalizeForMatch(this.cleanText);
+        const queryTokens = tokenize(query);
+        const scoredResults = _.map(this.initialResults, (match) => {
             const [namePercent, nameMatch] = match;
+            const candidateName = this.nameLookup[nameMatch] || nameMatch;
+            const normalizedCandidate = normalizeForMatch(candidateName);
+            const candidateTokens = tokenize(normalizedCandidate);
+            const firstTokenSimilarity = calculateFirstTokenSimilarity(
+                queryTokens,
+                candidateTokens
+            );
+            const tokenCoverage = calculateTokenCoverage(queryTokens, candidateTokens);
+            const score = _.round(
+                namePercent * 0.6 + tokenCoverage * 0.3 + firstTokenSimilarity * 0.1,
+                4
+            );
             return {
-                name: this.nameLookup[nameMatch] || nameMatch,
-                percentage: namePercent
+                name: candidateName,
+                percentage: namePercent,
+                _score: score,
+                _firstTokenSimilarity: firstTokenSimilarity
             };
         });
+        const rankedResults = _.orderBy(
+            scoredResults,
+            ["_score", "percentage", "name"],
+            ["desc", "desc", "asc"]
+        );
 
-        const highConfidenceMatches = _.filter(fixedResults, (item) => {
+        if (shouldApplyDisambiguation(queryTokens, rankedResults)) {
+            const bestScore = rankedResults[0]._score;
+            const bestFirstTokenSimilarity = rankedResults[0]._firstTokenSimilarity;
+            const firstTokenSimilarityFloor = Math.max(
+                config.disambiguation.minFirstTokenSimilarity,
+                bestFirstTokenSimilarity - config.disambiguation.maxFirstTokenDropFromTop
+            );
+            const narrowed = rankedResults
+                .filter(
+                    (item) =>
+                        item._score >= bestScore - config.disambiguation.maxScoreDelta &&
+                        item._firstTokenSimilarity >= firstTokenSimilarityFloor &&
+                        item.percentage >= config.minConfidence
+                )
+                .slice(0, config.maxMatches + 1);
+            if (narrowed.length > 0) {
+                return narrowed.map(stripInternalFields);
+            }
+        }
+
+        const highConfidenceMatches = _.filter(rankedResults, (item) => {
             return item.percentage >= config.highConfidence;
         });
 
         if (highConfidenceMatches.length > 1) {
-            return highConfidenceMatches.splice(0, config.maxMatches + 1);
+            return highConfidenceMatches.splice(0, config.maxMatches + 1).map(stripInternalFields);
         }
 
-        return _.filter(fixedResults, (item) => item.percentage >= config.minConfidence).splice(
-            0,
-            config.maxMatches + 1
-        );
+        return _.filter(rankedResults, (item) => item.percentage >= config.minConfidence)
+            .splice(0, config.maxMatches + 1)
+            .map(stripInternalFields);
     }
 }
 
@@ -97,4 +150,62 @@ export default {
 
 function normalizeForMatch(text) {
     return cleanString(text).toUpperCase().trim();
+}
+
+function tokenize(text) {
+    return String(text || "")
+        .split(/\s+/g)
+        .filter(Boolean);
+}
+
+function similarity(left, right) {
+    if (!left || !right) {
+        return 0;
+    }
+    if (left === right) {
+        return 1;
+    }
+    return stringSimilarity.compareTwoStrings(left, right);
+}
+
+function calculateFirstTokenSimilarity(queryTokens, candidateTokens) {
+    if (!queryTokens.length || !candidateTokens.length) {
+        return 0;
+    }
+    return similarity(queryTokens[0], candidateTokens[0]);
+}
+
+function calculateTokenCoverage(queryTokens, candidateTokens) {
+    if (!queryTokens.length || !candidateTokens.length) {
+        return 0;
+    }
+    const similarities = queryTokens.map((queryToken) => {
+        return (
+            _.max(
+                candidateTokens.map((candidateToken) => similarity(queryToken, candidateToken))
+            ) || 0
+        );
+    });
+    return _.mean(similarities) || 0;
+}
+
+function shouldApplyDisambiguation(queryTokens, rankedResults) {
+    if (queryTokens.length < 2) {
+        return false;
+    }
+    const top = rankedResults[0];
+    if (!top) {
+        return false;
+    }
+    return (
+        top.percentage >= config.disambiguation.minTopPercent &&
+        top._firstTokenSimilarity >= config.disambiguation.minTopFirstTokenSimilarity
+    );
+}
+
+function stripInternalFields(result) {
+    return {
+        name: result.name,
+        percentage: result.percentage
+    };
 }

--- a/src/image-analysis/extract-text.mjs
+++ b/src/image-analysis/extract-text.mjs
@@ -13,11 +13,11 @@ const logger = log.create({
  * @param {(err: Error|null, result: {cleanText: string, dirtyText: string}|null) => void} cb callback
  */
 function ScanImage(imgBuffer, type, cb) {
-    logger.info(
-        `extract-text::ScanImage:: Scanning Card ${Buffer.isBuffer(imgBuffer) ? "Image Buffer" : imgBuffer}`
-    );
     const candidates = normalizeCandidates(imgBuffer, type);
-    Promise.all(candidates.map((candidate) => runCandidate(candidate, type)))
+    logger.info(
+        `extract-text::ScanImage:: type=${type || "unknown"} source=${describeImageSource(imgBuffer)} candidates=${summarizeCandidates(candidates)}`
+    );
+    runCandidatesSequentially(candidates, type)
         .then((results) => {
             const best = selectBestResult(results);
             return cb(
@@ -36,6 +36,14 @@ function ScanImage(imgBuffer, type, cb) {
             logger.error(err);
             return cb(err, null, Tesseract);
         });
+}
+
+async function runCandidatesSequentially(candidates, type) {
+    const results = [];
+    for (const candidate of candidates) {
+        results.push(await runCandidate(candidate, type));
+    }
+    return results;
 }
 
 function normalizeCandidates(input, type) {
@@ -57,19 +65,20 @@ function normalizeCandidates(input, type) {
 
 async function runCandidate(candidate, type) {
     const ocrConfig = getTesseractConfig(type, candidate.psm);
+    const onProgress = buildProgressLogger(candidate.region);
     const result = await Tesseract.recognize(candidate.buffer, "eng", {
         ...ocrConfig,
         logger: (message) => {
             if (message.status === "recognizing text") {
-                logger.info(`Tesseract status: ${message.status} ${message.progress}`);
+                onProgress(message.progress);
             }
         }
     });
     const extractedText = (result && result.data && result.data.text) || result.text || "";
-    const cleanedString = normalizeOcrText(extractedText);
+    const cleanedString = normalizeOcrText(extractedText, type);
     const confidence = (result && result.data && result.data.confidence) || 0;
     logger.info(
-        `Region "${candidate.region}" => confidence ${confidence} | raw "${extractedText}" | normalized "${cleanedString}"`
+        `extract-text::result region=${candidate.region} confidence=${Math.round(confidence)} raw="${previewText(extractedText)}" normalized="${cleanedString}"`
     );
     return {
         region: candidate.region,
@@ -107,26 +116,175 @@ function resolvePsm(psm, type) {
     return inferPsm(type);
 }
 
-function normalizeOcrText(text) {
-    let cleaned = cleanString(text || "");
-    cleaned = cleaned.replace(/^[0-9]+\s*/, ""); // strip leading capture numbers
-    cleaned = cleaned.replace(/[^\w\s'-]/g, " "); // strip punctuation that confuses fuzzy matching
-    cleaned = cleaned.replace(/\s{2,}/g, " ");
-    return cleaned.toUpperCase().trim();
+function normalizeOcrText(text, type) {
+    return normalizeOcrTextByType(text, type || "");
 }
 
 function selectBestResult(results) {
     return results.reduce((best, current) => {
         if (!best) return current;
-        if (current.confidence > best.confidence) return current;
+        if (scoreCandidate(current) > scoreCandidate(best)) return current;
         if (
-            current.confidence === best.confidence &&
-            current.cleanText.length > best.cleanText.length
+            scoreCandidate(current) === scoreCandidate(best) &&
+            current.confidence > best.confidence
         ) {
             return current;
         }
         return best;
     }, results[0]);
+}
+
+function normalizeOcrTextByType(text, type) {
+    if (type === "name") {
+        return normalizeNameText(text);
+    }
+    return normalizeGenericText(text);
+}
+
+function normalizeNameText(text) {
+    const normalizedUnicode = normalizeUnicode(text || "");
+    const lines = normalizedUnicode
+        .split(/\r?\n/g)
+        .map((line) => normalizeGenericText(line))
+        .filter(Boolean);
+
+    if (!lines.length) {
+        return "";
+    }
+
+    const bestLine = lines.reduce((best, current) => {
+        if (!best) return current;
+        return scoreNameLine(current) > scoreNameLine(best) ? current : best;
+    }, lines[0]);
+
+    const pruned = pruneNameTokens(bestLine);
+    return pruned || bestLine;
+}
+
+function normalizeGenericText(text) {
+    let cleaned = cleanString(normalizeUnicode(text || ""));
+    cleaned = cleaned.replace(/^[0-9]+\s*/, ""); // strip leading capture numbers
+    cleaned = cleaned.replace(/[_]/g, " ");
+    cleaned = cleaned.replace(/[^A-Za-z0-9\s'-]/g, " "); // keep tokens useful to fuzzy matching
+    cleaned = cleaned.replace(/\s{2,}/g, " ");
+    return cleaned.toUpperCase().trim();
+}
+
+function normalizeUnicode(text) {
+    const mapped = (text || "")
+        .replace(/\uFB00/g, "ff")
+        .replace(/\uFB01/g, "fi")
+        .replace(/\uFB02/g, "fl")
+        .replace(/\uFB03/g, "ffi")
+        .replace(/\uFB04/g, "ffl")
+        .replace(/\u2018|\u2019/g, "'")
+        .replace(/\u201C|\u201D/g, '"')
+        .replace(/\u2013|\u2014/g, "-");
+    return mapped.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function pruneNameTokens(cleanedLine) {
+    const tokens = cleanedLine.split(/\s+/g).filter(Boolean);
+    const filtered = tokens.filter((token) => isLikelyNameToken(token));
+    if (!filtered.length) {
+        return "";
+    }
+    return filtered.join(" ");
+}
+
+function isLikelyNameToken(token) {
+    if (!/[A-Z]/.test(token)) {
+        return false;
+    }
+    if (/^[0-9]+$/.test(token)) {
+        return false;
+    }
+    if (token.length === 1 && token !== "X") {
+        return false;
+    }
+    if (/(.)\1\1/.test(token)) {
+        return false;
+    }
+    return true;
+}
+
+function scoreNameLine(line) {
+    const tokens = line.split(/\s+/g).filter(Boolean);
+    if (!tokens.length) return -100;
+
+    let score = 0;
+    const alphaTokens = tokens.filter((token) => /[A-Z]/.test(token)).length;
+    score += alphaTokens * 8;
+    score -= Math.abs(tokens.length - 2) * 4; // most MTG names are short
+    score -= tokens.filter((token) => token.length === 1).length * 5;
+    score -= tokens.filter((token) => /(.)\1\1/.test(token)).length * 8;
+    score -= Math.max(0, line.length - 38) * 0.7;
+    return score;
+}
+
+function scoreCandidate(candidate) {
+    const confidence = Number(candidate.confidence || 0);
+    const cleaned = candidate.cleanText || "";
+    const tokens = cleaned.split(/\s+/g).filter(Boolean);
+    if (!tokens.length) {
+        return confidence - 30;
+    }
+    let quality = 0;
+    quality += Math.min(cleaned.length, 28);
+    quality -= Math.max(0, tokens.length - 4) * 6;
+    quality -= tokens.filter((token) => token.length === 1).length * 4;
+    quality -= tokens.filter((token) => /(.)\1\1/.test(token)).length * 8;
+    if (candidate.region === "name-core") {
+        quality += 8;
+    } else if (candidate.region === "name-wide") {
+        quality += 4;
+    } else if (candidate.region === "top-band") {
+        quality -= 2;
+    }
+    return confidence + quality;
+}
+
+function describeImageSource(input) {
+    if (Array.isArray(input)) {
+        return "variant-list";
+    }
+    if (Buffer.isBuffer(input)) {
+        return "buffer";
+    }
+    if (typeof input === "string") {
+        return input;
+    }
+    return typeof input;
+}
+
+function summarizeCandidates(candidates = []) {
+    return candidates.map((candidate) => `${candidate.region}:${candidate.psm}`).join(",");
+}
+
+function buildProgressLogger(region) {
+    let lastBucket = -1;
+    return (progress = 0) => {
+        const bucket = Math.min(100, Math.max(0, Math.floor(Number(progress) * 100)));
+        if (bucket < 100 && bucket % 10 !== 0) {
+            return;
+        }
+        if (bucket === lastBucket) {
+            return;
+        }
+        lastBucket = bucket;
+        logger.info(`extract-text::progress region=${region} progress=${bucket}%`);
+    };
+}
+
+function previewText(text) {
+    const normalized = String(text || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    const max = 140;
+    if (normalized.length <= max) {
+        return normalized;
+    }
+    return `${normalized.slice(0, max - 3)}...`;
 }
 
 function ShutDown() {

--- a/src/image-hashing/hash-image.mjs
+++ b/src/image-hashing/hash-image.mjs
@@ -12,7 +12,7 @@ const logger = log.create({
 });
 
 function HashImage(imgUrl, cb) {
-    logger.info(`hash-image::HashImage:: Hashing Image ${imgUrl}`);
+    logger.info(`hash-image::hash start source="${imgUrl}"`);
     dependencies.imageHash(imgUrl, 16, true, (error, data) => {
         if (error) {
             return cb(error);
@@ -22,7 +22,9 @@ function HashImage(imgUrl, cb) {
 }
 
 function CompareHash(hashOne, hashTwo) {
-    logger.info(`hash-image::CompareHash:: Comparing Hashes ${hashOne} ${hashTwo}`);
+    logger.info(
+        `hash-image::compare start left=${previewHash(hashOne)} right=${previewHash(hashTwo)}`
+    );
     const HashLength = hashOne.length;
     let twoBitMatches = 0;
     let fourBitMatches = 0;
@@ -43,8 +45,18 @@ function CompareHash(hashOne, hashTwo) {
         fourBitMatches: _.round(fourBitMatches / (HashLength / 4), 2),
         stringCompare: _.round(stringSimilarity.compareTwoStrings(hashOne, hashTwo), 2)
     };
-    logger.info("hash-image::CompareHash:: Hash Comparison Results", comparisonResults);
+    logger.info("hash-image::compare result", comparisonResults);
     return comparisonResults;
+}
+
+function previewHash(hash = "") {
+    if (!hash) {
+        return "empty";
+    }
+    if (hash.length <= 16) {
+        return hash;
+    }
+    return `${hash.slice(0, 8)}...${hash.slice(-8)}(len=${hash.length})`;
 }
 
 export { CompareHash, HashImage };

--- a/src/matcher/matching-processor.mjs
+++ b/src/matcher/matching-processor.mjs
@@ -21,7 +21,8 @@ const dependencies = {
 const schema = joi.object().keys({
     name: joi.string().required(),
     filePath: joi.string().required(),
-    queryingEnabled: joi.boolean().optional()
+    queryingEnabled: joi.boolean().optional(),
+    logger: joi.object().optional()
 });
 
 class MatcherProcessor {
@@ -33,7 +34,7 @@ class MatcherProcessor {
         _.assign(this, params);
         if (!this.logger) {
             this.logger = logger.create({
-                isPretty: false
+                isPretty: true
             });
         }
     }
@@ -43,7 +44,7 @@ class MatcherProcessor {
     }
 
     _search(callback) {
-        this.logger.info(`Beginning card search ${this.name}`);
+        this.logger.info(`matcher::search start name="${this.name}"`);
         dependencies.Searcher(this.name, (err, results) => {
             if (err) {
                 return callback(err);
@@ -54,23 +55,32 @@ class MatcherProcessor {
     }
 
     _processResults(callback) {
-        this.logger.info("Checking search results");
+        const numCards = _.isArray(this.cards) ? this.cards.length : "invalid";
+        this.logger.info(`matcher::search results name="${this.name}" count=${numCards}`);
         if (!_.isArray(this.cards)) {
             return callback(new Error("Error gathering results"));
         }
-        const numCards = this.cards.length;
+        const totalCards = this.cards.length;
 
-        if (numCards === 0) {
-            this.logger.info("No results returned");
+        if (totalCards === 0) {
+            this.logger.info(`matcher::search no-results name="${this.name}"`);
             return callback(null, 0);
         }
 
-        if (numCards === 1) {
-            this.logger.info("Exactly one result returned");
-            return callback(null, this.cards[0]);
+        if (totalCards === 1) {
+            this.logger.info(`matcher::search single-result name="${this.name}"`);
+            const single = this.cards[0] || {};
+            const setName = _.get(single, "set_name", "");
+            this.matchResultDetails = [
+                {
+                    setName,
+                    scryfallUri: _.get(single, "scryfall_uri", "") || _.get(single, "uri", "")
+                }
+            ];
+            return callback(null, setName ? [setName] : []);
         }
 
-        this.logger.info("Multiple results returned");
+        this.logger.info(`matcher::search multi-results name="${this.name}" count=${totalCards}`);
         async.waterfall(
             [(next) => this._hashLocalCard(next), (next) => this._processMultiSetMatches(next)],
             callback
@@ -78,7 +88,7 @@ class MatcherProcessor {
     }
 
     _hashLocalCard(callback) {
-        this.logger.info(`Hashing local image ${this.filePath}`);
+        this.logger.info(`matcher::hash local-image name="${this.name}" path="${this.filePath}"`);
         dependencies
             .CreateDirectory()
             .then((directory) => {
@@ -99,7 +109,7 @@ class MatcherProcessor {
     }
 
     _hashFromSetSymbol(directory, callback) {
-        this.logger.info(`Hashing set symbol image ${this.filePath}`);
+        this.logger.info(`matcher::hash set-symbol name="${this.name}" path="${this.filePath}"`);
         dependencies
             .GetSetSymbolSnippetTmpFile(this.filePath, directory, "set-symbol")
             .then((setSymbolPath) => {
@@ -151,11 +161,14 @@ class MatcherProcessor {
             cards: this.cards,
             localHash: this.localHash,
             hashMode: this.hashMode || "full-card",
+            logger: this.logger,
             queryingEnabled: this.queryingEnabled,
             ignoreNoDbMatch: true,
             allowRemoteBestGuess: true
         });
-        this.logger.info("Processing multi set matches");
+        this.logger.info(
+            `matcher::hash compare-start name="${this.name}" mode=${this.hashMode || "full-card"} cardCount=${this.cards.length}`
+        );
         const shouldQueryCache = true;
         const dbPromise = shouldQueryCache
             ? processHashes
@@ -175,6 +188,9 @@ class MatcherProcessor {
         const mergedResults = _.uniq((db || []).concat(remote || []));
         this.matchResults = mergedResults;
         this.matchResultDetails = this._buildMatchDetails(mergedResults);
+        this.logger.info(
+            `matcher::hash compare-complete name="${this.name}" mergedSets=${mergedResults.join(",") || "none"}`
+        );
         return mergedResults;
     }
 

--- a/src/processor/processor.mjs
+++ b/src/processor/processor.mjs
@@ -117,7 +117,7 @@ class ProcessorClass {
             dirtyText: this.nameExtractionResults.dirtyText
         }).Match();
         this.nameMatches = matchResults;
-        this.logger.info(`Matches returned ${this.nameMatches}`);
+        this.logger.info(formatMatchSummary(this.nameMatches));
     }
 
     attemptMatching(callback) {
@@ -130,7 +130,7 @@ class ProcessorClass {
     }
 
     async attemptMatchingAsync() {
-        this.logger.info("Attempting Matching");
+        this.logger.info(`Attempting Matching with ${this.nameMatches.length} candidate names`);
         const matchResults = await Promise.all(
             this.nameMatches.map((match) => this._attemptMatch(match))
         );
@@ -165,7 +165,8 @@ class ProcessorClass {
         const matchProcessor = dependencies.MatchProcessor.create({
             name: match.name,
             filePath: this.filePath,
-            queryingEnabled: this.queryingEnabled
+            queryingEnabled: this.queryingEnabled,
+            logger: this.logger
         });
         return new Promise((resolve, reject) => {
             matchProcessor.execute((err, results) => {
@@ -264,6 +265,21 @@ class ProcessorClass {
         this.logger.info("Preparing to insert record");
         collectionsModel.Insert();
     }
+}
+
+function formatMatchSummary(matches = []) {
+    if (!matches.length) {
+        return "Matches returned (0): none";
+    }
+
+    const summarized = matches.map((match, index) => {
+        const name = _.get(match, "name", "unknown");
+        const rawPercent = Number(_.get(match, "percentage", 0));
+        const displayPercent = _.round(rawPercent <= 1 ? rawPercent * 100 : rawPercent, 1);
+        return `${index + 1}. ${name} (${displayPercent}%)`;
+    });
+
+    return `Matches returned (${matches.length}): ${summarized.join(" | ")}`;
 }
 
 export const create = (params) => new ProcessorClass(params);

--- a/test/fuzzy/name-match.spec.mjs
+++ b/test/fuzzy/name-match.spec.mjs
@@ -98,6 +98,24 @@ describe("FuzzyMatching::", () => {
             },
             {
                 name: "Archfiend of Despair"
+            },
+            {
+                name: "Thought Reflection"
+            },
+            {
+                name: "Boon Reflection"
+            },
+            {
+                name: "Wound Reflection"
+            },
+            {
+                name: "Pure Reflection"
+            },
+            {
+                name: "Mana Reflection"
+            },
+            {
+                name: "Rage Reflection"
             }
         ]);
     });
@@ -131,6 +149,36 @@ describe("FuzzyMatching::", () => {
             assert.equal(stubs.BulkNamesStub.callCount, 1);
             chaiAssert.isArray(matches);
             assert.equal(matches.length, 0);
+        });
+
+        it("should not match an empty OCR result", async () => {
+            const matches = await create({ cleanText: "" }).Match();
+            assert.equal(stubs.BulkNamesStub.callCount, 0);
+            chaiAssert.isArray(matches);
+            assert.equal(matches.length, 0);
+        });
+
+        it("should narrow name-style families to the strongest first-token match", async () => {
+            const matches = await create({
+                cleanText: "Thought Reflection"
+            }).Match();
+            assert.equal(stubs.BulkNamesStub.callCount, 1);
+            chaiAssert.isArray(matches);
+            chaiAssert.isAtLeast(matches.length, 1);
+            assert.equal(matches[0].name, "Thought Reflection");
+            assert.notEqual(matches[0].name, "Boon Reflection");
+            chaiAssert.isBelow(matches.length, 4);
+        });
+
+        it("should still narrow when OCR trims first token (THOU REFLECTION)", async () => {
+            const matches = await create({
+                cleanText: "THOU REFLECTION"
+            }).Match();
+            assert.equal(stubs.BulkNamesStub.callCount, 1);
+            chaiAssert.isArray(matches);
+            chaiAssert.isAtLeast(matches.length, 1);
+            assert.equal(matches[0].name, "Thought Reflection");
+            chaiAssert.isBelow(matches.length, 3);
         });
     });
 });

--- a/test/image-analysis/extract-text.spec.mjs
+++ b/test/image-analysis/extract-text.spec.mjs
@@ -45,4 +45,92 @@ describe("TextExtraction::", () => {
             done();
         });
     });
+
+    it("normalizes ligatures/diacritics and drops noisy tokens for name extraction", (done) => {
+        const recognizeStub = sandbox
+            .stub(textExtraction.dependencies.Tesseract, "recognize")
+            .resolves({
+                data: {
+                    text: "m\nThought Reﬂection éggg\n‘V' t, ”I“ . . 1 \\\\K‘ 'g‘r .\n",
+                    confidence: 53
+                }
+            });
+
+        textExtraction.ScanImage("/tmp/fake-image.jpg", "name", (err, result) => {
+            assert.isNull(err);
+            assert.isTrue(recognizeStub.calledOnce);
+            assert.equal(result.cleanText, "THOUGHT REFLECTION");
+            assert.equal(
+                result.dirtyText,
+                "m\nThought Reﬂection éggg\n‘V' t, ”I“ . . 1 \\\\K‘ 'g‘r .\n"
+            );
+            done();
+        });
+    });
+
+    it("prefers cleaner name candidate over noisier high-confidence band", async () => {
+        const recognizeStub = sandbox
+            .stub(textExtraction.dependencies.Tesseract, "recognize")
+            .onFirstCall()
+            .resolves({
+                data: {
+                    text: "m\nThought Reﬂection éggg\n‘V' t, ”I“ . . 1 \\\\K‘ 'g‘r .\n",
+                    confidence: 62
+                }
+            })
+            .onSecondCall()
+            .resolves({
+                data: {
+                    text: "Thought Reflection\n",
+                    confidence: 55
+                }
+            });
+
+        const variants = [
+            { buffer: Buffer.from("a"), region: "top-band", psm: "block" },
+            { buffer: Buffer.from("b"), region: "name-core", psm: "line" }
+        ];
+        const result = await new Promise((resolve, reject) => {
+            textExtraction.ScanImage(variants, "name", (err, extracted) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve(extracted);
+            });
+        });
+        assert.isTrue(recognizeStub.calledTwice);
+        assert.equal(result.cleanText, "THOUGHT REFLECTION");
+        assert.equal(result.bestVariant.region, "name-core");
+    });
+
+    it("processes OCR variants sequentially to protect the shared trained-data cache", async () => {
+        let resolveFirst;
+        const firstResult = new Promise((resolve) => {
+            resolveFirst = resolve;
+        });
+        const recognizeStub = sandbox
+            .stub(textExtraction.dependencies.Tesseract, "recognize")
+            .onFirstCall()
+            .returns(firstResult)
+            .onSecondCall()
+            .resolves({ data: { text: "Thought Reflection", confidence: 80 } });
+
+        const variants = [
+            { buffer: Buffer.from("a"), region: "name-core", psm: "line" },
+            { buffer: Buffer.from("b"), region: "name-wide", psm: "line" }
+        ];
+        const extraction = new Promise((resolve, reject) => {
+            textExtraction.ScanImage(variants, "name", (err, result) => {
+                if (err) return reject(err);
+                return resolve(result);
+            });
+        });
+
+        await new Promise((resolve) => setImmediate(resolve));
+        assert.isTrue(recognizeStub.calledOnce);
+
+        resolveFirst({ data: { text: "Thought Reflection", confidence: 70 } });
+        await extraction;
+        assert.isTrue(recognizeStub.calledTwice);
+    });
 });

--- a/test/matcher/matching-processor.spec.mjs
+++ b/test/matcher/matching-processor.spec.mjs
@@ -15,8 +15,11 @@ describe("MatcherProcessor::", () => {
         sandbox.restore();
     });
 
-    it("returns the single card directly when only one search result exists", (done) => {
-        const expectedCard = { set_name: "M20" };
+    it("returns normalized set details when only one search result exists", (done) => {
+        const expectedCard = {
+            set_name: "M20",
+            scryfall_uri: "https://scryfall.com/card/m20/1/example"
+        };
         const searchStub = sandbox
             .stub(dependencies, "Searcher")
             .callsArgWith(1, null, [expectedCard]);
@@ -30,7 +33,13 @@ describe("MatcherProcessor::", () => {
             assert.isNull(err);
             assert.isTrue(searchStub.calledOnce);
             assert.isTrue(hashStub.notCalled);
-            assert.deepEqual(result, expectedCard);
+            assert.deepEqual(result, ["M20"]);
+            assert.deepEqual(processor.matchResultDetails, [
+                {
+                    setName: "M20",
+                    scryfallUri: "https://scryfall.com/card/m20/1/example"
+                }
+            ]);
             done();
         });
     });


### PR DESCRIPTION
## Summary
- Improve card-name OCR cleanup and candidate selection for noisy Magic card images.
- Reduce ambiguous fuzzy-name matches without lowering observed top-match accuracy.
- Make matching and hash logs concise, structured, and useful for debugging.

## What Changed
- Normalize Unicode ligatures, diacritics, smart punctuation, noisy lines, and unlikely name tokens.
- Score OCR variants by confidence and text quality instead of confidence alone.
- Run OCR variants sequentially to protect Tesseract's shared trained-data cache from concurrent corruption.
- Rank fuzzy matches using base similarity, token coverage, and first-token similarity.
- Return no candidates for empty OCR results instead of matching the literal card name `______`.
- Normalize single Scryfall results to the same set-name and verification-link shape as multi-result searches.
- Replace object dumps and full hash values with bounded, readable matching summaries.
- Add regression coverage for noisy `Thought Reflection` OCR, truncated first tokens, empty OCR, sequential variants, and single-result set details.

## Validation
- `fnm exec --using=lts/jod -- pnpm check`
- 50 tests passing
- ESLint passing
- Prettier passing
- TypeScript check passing
- Pre-commit `lint-staged` hook passing

## Benchmark
- Image corpus: top-match accuracy remained 8/9 while candidates dropped from 14 to 8.
- OCR mutation corpus: top-match accuracy remained 19/20 while candidates dropped from 29 to 21.
- `THOU REFLECTION` narrowed from six candidates to one correct candidate.

## Scope Notes
- Recursive set-symbol cropping is intentionally excluded and remains in its existing WIP branch.
- Sequential OCR trades some parallel throughput for deterministic trained-data integrity.
- The current benchmark corpus is small; the separate labeled E2E fixture work will provide broader regression coverage.
