### PR TITLE
Test coverage tooling, CONTRIBUTING guide, central config (#17, #30, #31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,8 @@ Thumbs.db:encryptable
 ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
+
+# Local app config (machine-specific paths) -- see mtg.config.example.json
+mtg.config.json
+
+yarn.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Thanks for looking at MTG Card Analyzer. This doc covers how to set up, work on, and submit changes. See [README.md](README.md) for what the project does and how to run it.
+
+## Setup
+
+- Node >= 20 (repo is developed/tested on Node 22)
+- [pnpm](https://pnpm.io/) >= 8: `corepack enable` or `npm i -g pnpm`
+- Clone and install:
+
+```bash
+git clone https://github.com/dills122/MTG-Card-Analyzer.git
+cd MTG-Card-Analyzer
+pnpm install
+```
+
+`pnpm install` also runs `lefthook install` (via the `prepare` script), which wires up git hooks for lint-staged.
+
+## Branching & Commits
+
+- Branch off `master`. Use a short descriptive branch name (e.g. `fix/image-too-small-error`, `feat/multi-image-scan`).
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`). Keep the subject line under ~50 chars; add a body when the "why" isn't obvious from the diff alone.
+
+## Before Opening a PR
+
+Run the full local gate — it's what CI checks:
+
+```bash
+pnpm check
+```
+
+That's `lint` + `prettier:check` + `typecheck` + `test`. Individual pieces (`pnpm lint:fix`, `pnpm format`) can autofix most issues.
+
+For anything touching logic, also run coverage and take a look at what's newly uncovered:
+
+```bash
+pnpm coverage
+```
+
+No coverage threshold is enforced yet (see [#31](https://github.com/dills122/MTG-Card-Analyzer/issues/31)), but new code shouldn't make the picture worse.
+
+## Tests
+
+- Tests live in `test/**/*.spec.mjs` and mirror the `src/` structure.
+- Tests stub external calls (Scryfall API, MySQL/RDS, filesystem where practical) — no live network or DB access required to run the suite.
+- Use `proxyquire`/`sinon` (already deps) for stubbing module dependencies, consistent with existing specs.
+
+## Project Layout
+
+Quick orientation — see individual `index.mjs` files in each folder for the public surface of that module:
+
+- `src/image-processing/`, `src/image-analysis/` — image prep + OCR
+- `src/fuzzy-matching/`, `src/matcher/` — name/type matching + decision logic
+- `src/scryfall-api/` — Scryfall HTTP client
+- `src/db-local/`, `src/storage/` — local NeDB-backed cache + storage adapter abstraction
+- `src/rds/` — legacy/optional MySQL adapter, not used by default
+- `src/processor/` — orchestrates the end-to-end scan pipeline
+- `index.mjs` — CLI entry point
+
+## Picking Up an Issue
+
+Open issues are the source of truth for planned work. If an issue looks stale, out of date, or you're not sure it still applies, comment on it (or open a new one) before starting — don't assume.
+
+## Reporting Bugs
+
+Include: Node version, OS, the exact command run, and full error output. For OCR/matching issues, attach (or point at) the input image if possible — behavior is very image-dependent.

--- a/Readme.md
+++ b/Readme.md
@@ -128,6 +128,18 @@ npm test
 
 Tests stub external calls; no MySQL required.
 
+### Test Coverage
+
+```bash
+# Run tests with coverage report (text + html + lcov, written to coverage/)
+pnpm coverage
+
+# Same, but fail the run if thresholds in the "c8" package.json block aren't met
+pnpm coverage:check
+```
+
+No coverage thresholds are enforced yet — baseline is being established, see [#31](https://github.com/dills122/MTG-Card-Analyzer/issues/31).
+
 ### Quality Commands
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -83,6 +83,10 @@ node index.mjs scan ./src/test-images/PlatinumAngel.jpg
     - flags:
         - `--query` or `-q`: enable additional persistence flows used by legacy paths (default `false`).
         - `--pretty` or `-p`: pretty logging (default `true`).
+        - `--storage-adapter <nedb|rds>`: storage adapter to use for this run.
+        - `--card-names-db <path>`: path (dir or `.db` file) for the local card names DB.
+        - `--card-hash-db <path>`: path (dir or `.db` file) for the local card hash cache DB.
+        - `--config <path>`: path to a JSON config file (see [Configuration](#configuration)).
 
 ### Local Storage (NeDB)
 
@@ -102,9 +106,24 @@ node index.mjs scan ./src/test-images/PlatinumAngel.jpg
 - The app now uses a storage abstraction layer.
 - Default adapter: `nedb`
 - Alternate adapter available: `rds` (legacy/optional)
-- Select adapter with:
-    - `STORAGE_ADAPTER=nedb` (default)
-    - `STORAGE_ADAPTER=rds`
+- Select adapter with (in order of precedence, highest wins):
+    - CLI flag: `--storage-adapter rds`
+    - env var: `STORAGE_ADAPTER=rds`
+    - config file: `{ "storageAdapter": "rds" }`
+    - default: `nedb`
+
+### Configuration
+
+All runtime settings resolve through a single config module ([src/config/index.mjs](src/config/index.mjs)). Precedence, highest wins:
+
+1. CLI flags (e.g. `--storage-adapter`, `--card-names-db`, `--card-hash-db`)
+2. Env vars (`STORAGE_ADAPTER`, `CARD_NAMES_DB_PATH`, `CARD_HASH_DB_PATH`)
+3. Config file (JSON)
+4. Built-in defaults
+
+Config file is picked up from, in order: an explicit `--config <path>`, then `MTG_CONFIG_PATH` env var, then `./mtg.config.json` (cwd), then `~/.mtg-card-analyzer/config.json`. See [mtg.config.example.json](mtg.config.example.json) for the shape — copy it to `mtg.config.json` and edit.
+
+Note: MySQL/RDS credentials (host/user/password/database) are separate, in `secure.config.cjs` at repo root (loaded by [src/rds/connection.mjs](src/rds/connection.mjs)) — kept out of the general config file/repo since they're secrets, not app settings.
 
 Test images are provided at `src\test-images`
 

--- a/index.mjs
+++ b/index.mjs
@@ -2,6 +2,7 @@ import { access } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { Command } from "commander";
 import processorModule from "./src/processor/index.mjs";
+import { getConfig, KNOWN_STORAGE_ADAPTERS } from "./src/config/index.mjs";
 
 const { Processor } = processorModule;
 
@@ -23,6 +24,13 @@ function buildCli(argv) {
         .description("Scan an image file and process MTG card info")
         .option("-q, --query", "Enable DB writes (off by default)", false)
         .option("-p, --pretty", "Pretty logging (on by default)", true)
+        .option(
+            "--storage-adapter <adapter>",
+            `Storage adapter to use (${KNOWN_STORAGE_ADAPTERS.join("|")})`
+        )
+        .option("--card-names-db <path>", "Path (dir or .db file) for the local card names DB")
+        .option("--card-hash-db <path>", "Path (dir or .db file) for the local card hash cache DB")
+        .option("--config <path>", "Path to a JSON config file (see mtg.config.json)")
         .action((filePath, options) => {
             parsed.filePath = filePath;
             parsed.flags = options || {};
@@ -33,6 +41,8 @@ function buildCli(argv) {
         `
 Examples:
   $ scan ./img-path --query
+  $ scan ./img-path --storage-adapter rds
+  $ scan ./img-path --card-names-db ./data --config ./mtg.config.json
 `
     );
 
@@ -87,6 +97,29 @@ export async function run(options = {}) {
 
     try {
         await ensureFileAccessible(fsAccess, filePath);
+    } catch (err) {
+        logger.log(err?.message || String(err));
+        return;
+    }
+
+    // CLI flags win over env vars / config file (see src/config/index.mjs precedence).
+    // getConfig() here both validates the flags early (bad --storage-adapter fails fast)
+    // and resolves the config file, then we bridge the result into process.env so the
+    // rest of the pipeline -- which resolves config lazily on first DB use -- picks it up.
+    try {
+        const config = getConfig({
+            storageAdapter: flags.storageAdapter,
+            cardNamesDbPath: flags.cardNamesDb,
+            cardHashDbPath: flags.cardHashDb,
+            configPath: flags.config
+        });
+        process.env.STORAGE_ADAPTER = config.storageAdapter;
+        if (config.cardNamesDbPath) {
+            process.env.CARD_NAMES_DB_PATH = config.cardNamesDbPath;
+        }
+        if (config.cardHashDbPath) {
+            process.env.CARD_HASH_DB_PATH = config.cardHashDbPath;
+        }
     } catch (err) {
         logger.log(err?.message || String(err));
         return;

--- a/mtg.config.example.json
+++ b/mtg.config.example.json
@@ -1,0 +1,5 @@
+{
+    "storageAdapter": "nedb",
+    "cardNamesDbPath": "",
+    "cardHashDbPath": ""
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     },
     "scripts": {
         "test": "mocha \"./test/**/*.spec.mjs\"",
+        "coverage": "c8 pnpm test",
+        "coverage:check": "c8 --check-coverage pnpm test",
         "lint": "eslint . --ext js,mjs",
         "lint:fix": "pnpm lint --fix",
         "lint-staged": "lint-staged",
@@ -33,6 +35,26 @@
         "email": "dylansteele57@gmail.com"
     },
     "license": "MIT",
+    "c8": {
+        "all": true,
+        "src": "src",
+        "include": [
+            "src/**/*.mjs",
+            "index.mjs"
+        ],
+        "exclude": [
+            "src/test-images/**",
+            "src/data/**",
+            "**/*.spec.mjs",
+            "test/**"
+        ],
+        "reporter": [
+            "text",
+            "html",
+            "lcov"
+        ],
+        "reports-dir": "coverage"
+    },
     "dependencies": {
         "@dills1220/nedb": "^1.9.1",
         "async": "^3.2.6",
@@ -57,6 +79,7 @@
     "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@types/node": "^25.9.1",
+        "c8": "^12.0.0",
         "chai": "^6.2.2",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 4.0.4
       tesseract.js:
         specifier: ^3.0.3
-        version: 3.0.3(eslint@10.8.0)
+        version: 3.0.3(eslint@10.8.1)
       tmp:
         specifier: ^0.2.7
         version: 0.2.7
@@ -72,15 +72,18 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      c8:
+        specifier: ^12.0.0
+        version: 12.0.0
       chai:
         specifier: ^6.2.2
         version: 6.2.2
       eslint:
         specifier: ^10.8.0
-        version: 10.8.0
+        version: 10.8.1
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.8.0)
+        version: 10.1.8(eslint@10.8.1)
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -149,6 +152,10 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
@@ -161,8 +168,8 @@ packages:
   '@dills1220/nedb@1.9.1':
     resolution: {integrity: sha512-S1976mWqHnqbiQA5K2Av5YJ7GD51IEdG61a/m3B5QCn0oUbQE/jq/nhWGSlXgV1J8LucDLwrG814lQUPW0pO6Q==}
 
-  '@eslint-community/eslint-utils@4.10.1':
-    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -215,16 +222,12 @@ packages:
   '@hapi/topo@6.0.2':
     resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
-  '@humanfs/core@0.19.2':
-    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.8':
-    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/types@0.15.0':
-    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -238,6 +241,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
 
   '@jimp/bmp@0.22.12':
     resolution: {integrity: sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g==}
@@ -443,8 +450,11 @@ packages:
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
-  '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -471,6 +481,9 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -546,15 +559,15 @@ packages:
   bmp-js@0.1.0:
     resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
-  brace-expansion@1.1.18:
-    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
-  brace-expansion@2.1.4:
-    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.9:
-    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
-    engines: {node: 20 || >=22}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
@@ -573,6 +586,16 @@ packages:
     resolution: {integrity: sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==}
     engines: {'0': node >=0.10.0}
     hasBin: true
+
+  c8@12.0.0:
+    resolution: {integrity: sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
 
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
@@ -604,6 +627,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -621,6 +648,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -717,8 +747,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.8.0:
-    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -806,8 +836,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  flatted@3.4.4:
-    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
   follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
@@ -842,6 +872,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
@@ -893,6 +927,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-signature@1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
@@ -995,6 +1032,18 @@ packages:
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -1011,8 +1060,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -1142,6 +1191,10 @@ packages:
     resolution: {integrity: sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
@@ -1161,8 +1214,8 @@ packages:
   min-document@2.19.0:
     resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
 
-  minimatch@10.2.6:
-    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
@@ -1430,6 +1483,11 @@ packages:
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
 
@@ -1480,6 +1538,14 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -1520,6 +1586,10 @@ packages:
 
   tesseract.js@3.0.3:
     resolution: {integrity: sha512-eZ1+OGWvF5IMExAzIwnDf3S3kf2FeC+i4qrMTRvBSlZeHc3ONy0vCmaKmBQz6scjB6C1W2w2x0r4lCEh95qBnw==}
+
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
 
   timm@1.7.1:
     resolution: {integrity: sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==}
@@ -1591,6 +1661,10 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
@@ -1627,6 +1701,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -1661,6 +1739,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
@@ -1668,6 +1750,10 @@ packages:
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1727,6 +1813,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@borewit/text-codec@0.2.2': {}
 
   '@canvas/image-data@1.1.0': {}
@@ -1742,9 +1830,9 @@ snapshots:
       localforage: 1.10.0
       lodash: 4.18.1
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1)':
     dependencies:
-      eslint: 10.8.0
+      eslint: 10.8.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1753,7 +1841,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 10.2.6
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1790,17 +1878,12 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
 
-  '@humanfs/core@0.19.2':
-    dependencies:
-      '@humanfs/types': 0.15.0
+  '@humanfs/core@0.19.1': {}
 
-  '@humanfs/node@0.16.8':
+  '@humanfs/node@0.16.7':
     dependencies:
-      '@humanfs/core': 0.19.2
-      '@humanfs/types': 0.15.0
+      '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
-
-  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -1814,6 +1897,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
 
   '@jimp/bmp@0.22.12(@jimp/custom@0.22.12)':
     dependencies:
@@ -2074,7 +2159,9 @@ snapshots:
 
   '@types/esrecurse@4.3.1': {}
 
-  '@types/estree@1.0.9': {}
+  '@types/estree@1.0.8': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -2095,6 +2182,13 @@ snapshots:
       acorn: 8.18.0
 
   acorn@8.18.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ajv@6.15.0:
     dependencies:
@@ -2135,13 +2229,13 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  babel-eslint@10.1.0(eslint@10.8.0):
+  babel-eslint@10.1.0(eslint@10.8.1):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.5
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
-      eslint: 10.8.0
+      eslint: 10.8.1
       eslint-visitor-keys: 1.3.0
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -2159,17 +2253,17 @@ snapshots:
 
   bmp-js@0.1.0: {}
 
-  brace-expansion@1.1.18:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     optional: true
 
-  brace-expansion@2.1.4:
+  brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.9:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2193,6 +2287,20 @@ snapshots:
       moment: 2.30.1
       mv: 2.1.1
       safe-json-stringify: 1.2.0
+
+  c8@12.0.0:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 8.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 18.1.0
+      yargs-parser: 21.1.1
 
   camelcase@6.3.0: {}
 
@@ -2225,6 +2333,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2239,6 +2353,8 @@ snapshots:
 
   concat-map@0.0.1:
     optional: true
+
+  convert-source-map@2.0.0: {}
 
   core-util-is@1.0.2: {}
 
@@ -2294,14 +2410,14 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.8.0):
+  eslint-config-prettier@10.1.8(eslint@10.8.1):
     dependencies:
-      eslint: 10.8.0
+      eslint: 10.8.1
 
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
@@ -2311,18 +2427,18 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.0:
+  eslint@10.8.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
-      '@humanfs/node': 0.16.8
+      '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -2340,7 +2456,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.6
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -2413,12 +2529,12 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.4
+      flatted: 3.3.3
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
-  flatted@3.4.4: {}
+  flatted@3.3.3: {}
 
   follow-redirects@1.15.9: {}
 
@@ -2445,6 +2561,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.5.0: {}
+
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
@@ -2469,7 +2587,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.6
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -2493,7 +2611,7 @@ snapshots:
 
   har-validator@5.1.5:
     dependencies:
-      ajv: 6.15.0
+      ajv: 6.12.6
       har-schema: 2.0.0
 
   has-flag@4.0.0: {}
@@ -2503,6 +2621,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  html-escaper@2.0.2: {}
 
   http-signature@1.2.0:
     dependencies:
@@ -2596,6 +2716,19 @@ snapshots:
 
   isstream@0.1.2: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -2626,7 +2759,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -2751,6 +2884,10 @@ snapshots:
 
   lru.min@1.1.3: {}
 
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
   merge-descriptors@1.0.3: {}
 
   mime-db@1.52.0: {}
@@ -2765,18 +2902,18 @@ snapshots:
     dependencies:
       dom-walk: 0.1.2
 
-  minimatch@10.2.6:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.18
+      brace-expansion: 1.1.15
     optional: true
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.4
+      brace-expansion: 2.1.1
 
   minimist@1.2.8:
     optional: true
@@ -2799,7 +2936,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.3.1
+      js-yaml: 4.3.0
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -3048,6 +3185,8 @@ snapshots:
 
   sax@1.4.1: {}
 
+  semver@7.8.5: {}
+
   seq-queue@0.0.5: {}
 
   serialize-javascript@6.0.2:
@@ -3101,6 +3240,17 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -3136,9 +3286,9 @@ snapshots:
 
   tesseract.js-core@3.0.2: {}
 
-  tesseract.js@3.0.3(eslint@10.8.0):
+  tesseract.js@3.0.3(eslint@10.8.1):
     dependencies:
-      babel-eslint: 10.1.0(eslint@10.8.0)
+      babel-eslint: 10.1.0(eslint@10.8.1)
       bmp-js: 0.1.0
       file-type: 12.4.2
       idb-keyval: 3.2.0
@@ -3155,6 +3305,12 @@ snapshots:
       - encoding
       - eslint
       - supports-color
+
+  test-exclude@8.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 13.0.6
+      minimatch: 10.2.5
 
   timm@1.7.1: {}
 
@@ -3212,6 +3368,12 @@ snapshots:
 
   uuid@3.4.0: {}
 
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
   verror@1.10.0:
     dependencies:
       assert-plus: 1.0.0
@@ -3249,6 +3411,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2:
     optional: true
 
@@ -3277,6 +3445,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs-unparser@2.0.0:
     dependencies:
       camelcase: 6.3.0
@@ -3293,6 +3463,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.1
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
 

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Single source of truth for app-wide runtime settings.
+//
+// Precedence (highest wins): explicit overrides (CLI flags) > env vars > config file > defaults.
+const DEFAULTS = Object.freeze({
+    storageAdapter: "nedb",
+    pretty: true,
+    querying: false,
+    cardNamesDbPath: "",
+    cardHashDbPath: "",
+    configPath: ""
+});
+
+const KNOWN_STORAGE_ADAPTERS = ["nedb", "rds"];
+
+function compact(obj = {}) {
+    return Object.fromEntries(
+        Object.entries(obj).filter(
+            ([, value]) => value !== undefined && value !== "" && value !== null
+        )
+    );
+}
+
+function readJsonFile(filePath) {
+    let raw;
+    try {
+        raw = fs.readFileSync(filePath, "utf8");
+    } catch (err) {
+        if (err.code === "ENOENT") {
+            return {};
+        }
+        throw new Error(`Config file at "${filePath}" could not be read: ${err.message}`);
+    }
+    try {
+        return JSON.parse(raw);
+    } catch (err) {
+        throw new Error(`Config file at "${filePath}" is not valid JSON: ${err.message}`);
+    }
+}
+
+// Where a config file lives if the caller didn't say explicitly:
+// MTG_CONFIG_PATH env var, then ./mtg.config.json, then ~/.mtg-card-analyzer/config.json.
+function resolveConfigFilePath(explicitPath) {
+    if (explicitPath) {
+        return explicitPath;
+    }
+    if (process.env.MTG_CONFIG_PATH) {
+        return process.env.MTG_CONFIG_PATH;
+    }
+    const cwdConfig = path.join(process.cwd(), "mtg.config.json");
+    if (fs.existsSync(cwdConfig)) {
+        return cwdConfig;
+    }
+    const homeConfig = path.join(os.homedir(), ".mtg-card-analyzer", "config.json");
+    if (fs.existsSync(homeConfig)) {
+        return homeConfig;
+    }
+    return "";
+}
+
+function readEnvConfig() {
+    return compact({
+        storageAdapter: process.env.STORAGE_ADAPTER,
+        cardNamesDbPath: process.env.CARD_NAMES_DB_PATH,
+        cardHashDbPath: process.env.CARD_HASH_DB_PATH
+    });
+}
+
+function validate(config) {
+    if (!KNOWN_STORAGE_ADAPTERS.includes(config.storageAdapter)) {
+        throw new Error(
+            `Invalid storageAdapter "${config.storageAdapter}". Expected one of: ${KNOWN_STORAGE_ADAPTERS.join(", ")}`
+        );
+    }
+    return config;
+}
+
+// overrides: highest-precedence values, meant for CLI flags passed explicitly by the caller.
+// Re-reads env/file every call (cheap, tiny JSON) so CLI flags applied at runtime are honored
+// by anything that resolves config lazily (see src/db-local/db.mjs, card-hash-cache.mjs).
+function getConfig(overrides = {}) {
+    const cleanOverrides = compact(overrides);
+    const configFilePath = resolveConfigFilePath(cleanOverrides.configPath);
+    const fileConfig = configFilePath ? compact(readJsonFile(configFilePath)) : {};
+    const envConfig = readEnvConfig();
+
+    const merged = {
+        ...DEFAULTS,
+        ...fileConfig,
+        ...envConfig,
+        ...cleanOverrides,
+        configPath: configFilePath || ""
+    };
+
+    return validate(merged);
+}
+
+export { getConfig, DEFAULTS, KNOWN_STORAGE_ADAPTERS };
+
+export default {
+    getConfig,
+    DEFAULTS,
+    KNOWN_STORAGE_ADAPTERS
+};

--- a/src/db-local/card-hash-cache.mjs
+++ b/src/db-local/card-hash-cache.mjs
@@ -2,6 +2,7 @@ import Datastore from "@dills1220/nedb";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { getConfig } from "../config/index.mjs";
 
 function toDbFilePath(basePath, fileName) {
     if (!basePath) {
@@ -29,9 +30,9 @@ function resolveDbFilename() {
     const home = process.env.HOME || os.tmpdir();
     const legacyPreferencesPath =
         process.platform === "darwin" ? path.join(home, "Library/Preferences") : "";
+    const config = getConfig();
     const candidates = [
-        process.env.CARD_HASH_DB_PATH,
-        process.env.CARD_NAMES_DB_PATH,
+        config.cardHashDbPath || config.cardNamesDbPath,
         process.env.APPDATA,
         legacyPreferencesPath,
         process.platform !== "darwin" ? path.join(home, ".local/share") : "",
@@ -49,15 +50,32 @@ function resolveDbFilename() {
     return path.join(os.tmpdir(), "mtg-card-analyzer", "card-hashes.db");
 }
 
-const dbFilename = resolveDbFilename();
+// Resolved lazily on first real use (not at import time) so config sourced from
+// CLI flags -- applied to process.env by index.mjs before the pipeline runs -- is honored.
+let dbInstance;
 
-const db = new Datastore({
-    filename: dbFilename,
-    autoload: true
-});
+function getDbInstance() {
+    if (!dbInstance) {
+        dbInstance = new Datastore({
+            filename: resolveDbFilename(),
+            autoload: true
+        });
+        dbInstance.ensureIndex({ fieldName: "lookupKey", unique: true });
+        dbInstance.ensureIndex({ fieldName: "cardName" });
+    }
+    return dbInstance;
+}
 
-db.ensureIndex({ fieldName: "lookupKey", unique: true });
-db.ensureIndex({ fieldName: "cardName" });
+const db = new Proxy(
+    {},
+    {
+        get(_target, prop) {
+            const instance = getDbInstance();
+            const value = instance[prop];
+            return typeof value === "function" ? value.bind(instance) : value;
+        }
+    }
+);
 
 function toLookupKey(record) {
     const cardName = String(record.cardName || "").trim();

--- a/src/db-local/db.mjs
+++ b/src/db-local/db.mjs
@@ -2,6 +2,7 @@ import Datastore from "@dills1220/nedb";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { getConfig } from "../config/index.mjs";
 
 function toDbFilePath(basePath, fileName) {
     if (!basePath) {
@@ -30,7 +31,7 @@ function resolveDbFilename() {
     const legacyPreferencesPath =
         process.platform === "darwin" ? path.join(home, "Library/Preferences") : "";
     const candidates = [
-        process.env.CARD_NAMES_DB_PATH,
+        getConfig().cardNamesDbPath,
         process.env.APPDATA,
         legacyPreferencesPath,
         process.platform !== "darwin" ? path.join(home, ".local/share") : "",
@@ -48,14 +49,32 @@ function resolveDbFilename() {
     return path.join(os.tmpdir(), "mtg-card-analyzer", "cardNames.db");
 }
 
-const dbFilename = resolveDbFilename();
+// Resolved lazily on first real use (not at import time) so config sourced from
+// CLI flags -- applied to process.env by index.mjs before the pipeline runs -- is honored.
+let dbInstance;
 
-const db = new Datastore({
-    filename: dbFilename,
-    autoload: true
-});
+function getDbInstance() {
+    if (!dbInstance) {
+        dbInstance = new Datastore({
+            filename: resolveDbFilename(),
+            autoload: true
+        });
+    }
+    return dbInstance;
+}
 
-export { db };
+const db = new Proxy(
+    {},
+    {
+        get(_target, prop) {
+            const instance = getDbInstance();
+            const value = instance[prop];
+            return typeof value === "function" ? value.bind(instance) : value;
+        }
+    }
+);
+
+export { db, resolveDbFilename };
 
 export default {
     db

--- a/src/storage/create-storage.mjs
+++ b/src/storage/create-storage.mjs
@@ -1,5 +1,6 @@
 import nedbAdapter from "./adapters/nedb-adapter.mjs";
 import rdsAdapter from "./adapters/rds-adapter.mjs";
+import { getConfig } from "../config/index.mjs";
 
 const adapterFactories = {
     nedb: nedbAdapter.createNedbAdapter,
@@ -7,7 +8,7 @@ const adapterFactories = {
 };
 
 function createStorage(params = {}) {
-    const adapterName = (params.adapterName || process.env.STORAGE_ADAPTER || "nedb").toLowerCase();
+    const adapterName = (params.adapterName || getConfig().storageAdapter).toLowerCase();
     const factory = adapterFactories[adapterName] || adapterFactories.nedb;
     return factory();
 }

--- a/test/config/config.spec.mjs
+++ b/test/config/config.spec.mjs
@@ -1,0 +1,97 @@
+import { assert } from "chai";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getConfig, DEFAULTS } from "../../src/config/index.mjs";
+
+describe("config::index", () => {
+    const envKeys = [
+        "STORAGE_ADAPTER",
+        "CARD_NAMES_DB_PATH",
+        "CARD_HASH_DB_PATH",
+        "MTG_CONFIG_PATH"
+    ];
+    let savedEnv;
+    let tmpDir;
+
+    beforeEach(() => {
+        savedEnv = {};
+        envKeys.forEach((key) => {
+            savedEnv[key] = process.env[key];
+            delete process.env[key];
+        });
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mtg-config-test-"));
+    });
+
+    afterEach(() => {
+        envKeys.forEach((key) => {
+            if (savedEnv[key] === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = savedEnv[key];
+            }
+        });
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns defaults when nothing else is set", () => {
+        const config = getConfig();
+        assert.equal(config.storageAdapter, DEFAULTS.storageAdapter);
+        assert.equal(config.pretty, DEFAULTS.pretty);
+        assert.equal(config.configPath, "");
+    });
+
+    it("env vars override defaults", () => {
+        process.env.STORAGE_ADAPTER = "rds";
+        process.env.CARD_NAMES_DB_PATH = "/tmp/names";
+        const config = getConfig();
+        assert.equal(config.storageAdapter, "rds");
+        assert.equal(config.cardNamesDbPath, "/tmp/names");
+    });
+
+    it("config file overrides defaults when no env var is set", () => {
+        const configFile = path.join(tmpDir, "mtg.config.json");
+        fs.writeFileSync(configFile, JSON.stringify({ storageAdapter: "rds" }));
+        const config = getConfig({ configPath: configFile });
+        assert.equal(config.storageAdapter, "rds");
+    });
+
+    it("env vars still win over config file (env > file precedence)", () => {
+        process.env.STORAGE_ADAPTER = "rds";
+        const configFile = path.join(tmpDir, "mtg.config.json");
+        fs.writeFileSync(configFile, JSON.stringify({ storageAdapter: "nedb" }));
+        const config = getConfig({ configPath: configFile });
+        assert.equal(
+            config.storageAdapter,
+            "rds",
+            "env still wins over file per documented precedence"
+        );
+    });
+
+    it("explicit overrides (CLI) win over everything", () => {
+        process.env.STORAGE_ADAPTER = "rds";
+        const configFile = path.join(tmpDir, "mtg.config.json");
+        fs.writeFileSync(configFile, JSON.stringify({ storageAdapter: "rds" }));
+        const config = getConfig({ configPath: configFile, storageAdapter: "nedb" });
+        assert.equal(config.storageAdapter, "nedb");
+    });
+
+    it("throws a clear error for an unknown storage adapter", () => {
+        assert.throws(
+            () => getConfig({ storageAdapter: "mongo" }),
+            /Invalid storageAdapter "mongo"/
+        );
+    });
+
+    it("throws a clear error for malformed config file JSON", () => {
+        const configFile = path.join(tmpDir, "mtg.config.json");
+        fs.writeFileSync(configFile, "{not valid json");
+        assert.throws(() => getConfig({ configPath: configFile }), /not valid JSON/);
+    });
+
+    it("returns empty file config when the resolved config file doesn't exist", () => {
+        const missingFile = path.join(tmpDir, "does-not-exist.json");
+        const config = getConfig({ configPath: missingFile });
+        assert.equal(config.storageAdapter, DEFAULTS.storageAdapter);
+    });
+});

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -6,15 +6,29 @@ describe("CLI::index.mjs", () => {
     let sandbox;
     let consoleLogStub;
     let processExitStub;
+    let savedEnv;
+    const envKeys = ["STORAGE_ADAPTER", "CARD_NAMES_DB_PATH", "CARD_HASH_DB_PATH"];
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
         consoleLogStub = sandbox.stub();
         processExitStub = sandbox.stub();
+        savedEnv = {};
+        envKeys.forEach((key) => {
+            savedEnv[key] = process.env[key];
+            delete process.env[key];
+        });
     });
 
     afterEach(() => {
         sandbox.restore();
+        envKeys.forEach((key) => {
+            if (savedEnv[key] === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = savedEnv[key];
+            }
+        });
     });
 
     async function runCli(cliOverrides = {}, accessImpl) {
@@ -71,5 +85,45 @@ describe("CLI::index.mjs", () => {
         });
         assert.isTrue(executeStub.calledOnce);
         assert.isTrue(processExitStub.calledWith(0));
+    });
+
+    it("applies --storage-adapter / --card-names-db / --card-hash-db to the environment before running", async () => {
+        const { executeStub } = await runCli({
+            filePath: "./some-path.jpg",
+            flags: {
+                q: false,
+                query: false,
+                p: true,
+                pretty: true,
+                storageAdapter: "rds",
+                cardNamesDb: "/tmp/names.db",
+                cardHashDb: "/tmp/hashes.db"
+            }
+        });
+
+        assert.equal(process.env.STORAGE_ADAPTER, "rds");
+        assert.equal(process.env.CARD_NAMES_DB_PATH, "/tmp/names.db");
+        assert.equal(process.env.CARD_HASH_DB_PATH, "/tmp/hashes.db");
+        assert.isTrue(executeStub.calledOnce);
+        assert.isTrue(processExitStub.calledWith(0));
+    });
+
+    it("bails out with a clear error and does not run when --storage-adapter is unknown", async () => {
+        const { processorCreateStub } = await runCli({
+            filePath: "./some-path.jpg",
+            flags: {
+                q: false,
+                query: false,
+                p: true,
+                pretty: true,
+                storageAdapter: "mongo"
+            }
+        });
+
+        assert.isTrue(
+            consoleLogStub.calledWithMatch(sinon.match(/Invalid storageAdapter "mongo"/))
+        );
+        assert.isFalse(processorCreateStub.called);
+        assert.isFalse(processExitStub.called);
     });
 });


### PR DESCRIPTION
## Summary

Two pieces of work from the GitHub issues triage:

**Coverage + contribution docs (#31, #30)**
- Wire up `c8` for coverage reporting: `pnpm coverage` / `pnpm coverage:check`
- No threshold enforced yet — baseline established, see #31 for follow-up on setting a goal
- Add `CONTRIBUTING.md`: setup, branching/commits, PR gate, project layout

**Central config module (#17)**
- `src/config/index.mjs` — single source of truth for `storageAdapter`, DB paths, pretty/querying defaults
- Precedence: CLI flag > env var > JSON config file > default
- Config file resolved from `--config`, `MTG_CONFIG_PATH`, `./mtg.config.json`, or `~/.mtg-card-analyzer/config.json` — see `mtg.config.example.json`
- New `scan` flags: `--storage-adapter`, `--card-names-db`, `--card-hash-db`, `--config`
- Invalid `--storage-adapter` now fails fast with a clear error
- `db-local/db.mjs` and `card-hash-cache.mjs` made lazy (Proxy-wrapped, first-use init) so CLI-set config actually takes effect before the pipeline touches storage — previously the nedb path was resolved at import time, before CLI flags were even parsed
- RDS credentials stay separate in `secure.config.cjs` (secret, not app config) — documented the split in README

## Testing

- `pnpm check` (lint + prettier + typecheck + test) — green, 54 passing
- `pnpm coverage` — baseline: 63.19% stmts / 74.39% branch / 54.37% funcs / 63.19% lines
- New tests: `test/config/config.spec.mjs` (precedence + validation), plus 2 new CLI tests in `test/index.spec.mjs`

## Issues addressed

Closes #30. Progresses #17 (close on merge) and #31 (coverage tooling landed; threshold/goal is a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)