### PR TITLE
chore: integrate AI Central tooling

### DIFF
--- a/.codex/AI_CENTRAL.md
+++ b/.codex/AI_CENTRAL.md
@@ -1,0 +1,82 @@
+# AI Central Integration
+
+This repository uses the sibling `ai-central` checkout for reusable AI steering, skills, and custom
+agents. The integration follows the hybrid Wap Labs, Reef, and Capsule Corp pattern.
+
+## Ownership Model
+
+Real, tracked, repository-specific files:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.codex/AI_CENTRAL.md`
+- `.codex/ai-central-pin.json`
+- `.codex/steering/repository-steering.md`
+- `.codex/steering/testing-quality-gates-steering.md`
+- `scripts/setup-ai-context.mjs` and its tests
+
+Local, ignored symlinks:
+
+- `.codex/steering/javascript-typescript-steering.md`
+- `.codex/skills/*`
+- `.claude/skills`
+- `.agents/skills`
+- `.claude/agents/*`
+
+Root `AGENTS.md` and the project-owned steering files are authoritative. Shared content must not
+change project scope, weaken input/resource boundaries, require hosted infrastructure for local
+tests, or override the verification gates.
+
+## Installed Selection
+
+- Profiles: `base`, `javascript-typescript`
+- Skill bundles: `core`, `brevity`, `engineering`, `planning`, `workflow`
+- Additional Caveman skill: `cavecrew`
+- Custom agents: `cavecrew-investigator`, `cavecrew-builder`, `cavecrew-reviewer`, `code-reviewer`,
+  `security-auditor`, and `test-engineer`
+
+The selected skills cover planning, TDD, debugging, review, security, performance, API/storage
+design, documentation, delivery, and token-efficient Caveman workflows. Framework-specific Vue,
+React, Rust, JVM, Terraform, and product/marketing bundles are intentionally not selected.
+
+## Refresh And Validation
+
+AI Central defaults to `../ai-central`. Override it with `AI_CENTRAL_HOME`, pointing to either the
+repository root or its `templates` directory.
+
+```sh
+# Preview link changes
+pnpm ai:setup -- --dry-run
+
+# Create or repair links
+pnpm ai:setup
+
+# Validate the pinned revision, required files, and managed links
+pnpm ai:check
+```
+
+The setup command preserves real repo-owned files. It invokes AI Central's non-overwriting setup for
+profiles and bundles, then repairs this repository's managed Claude/Agents aliases and custom-agent
+links.
+
+## Provenance Pin
+
+`.codex/ai-central-pin.json` records the reviewed AI Central commit. Setup and validation refuse to
+continue when the checkout has drifted or contains tracked uncommitted changes. After reviewing an
+intentional AI Central update:
+
+```sh
+pnpm ai:setup -- --record-pin
+pnpm ai:setup
+pnpm ai:check
+```
+
+The pin and clean-worktree check detect local checkout drift; they do not independently vet upstream
+content. Third-party source attribution and licenses remain in AI Central because shared content is
+linked rather than copied.
+
+## Portability
+
+The symlinks are deliberately ignored and are not present in a fresh clone. Repository instructions
+remain usable without AI Central, but shared skills and custom agents require a local AI Central
+checkout followed by `pnpm ai:setup`.

--- a/.codex/ai-central-pin.json
+++ b/.codex/ai-central-pin.json
@@ -1,0 +1,4 @@
+{
+    "expectedCommit": "0248f5b22ec1b5e53b0c5c3be39d150932e0821d",
+    "note": "Reviewed AI Central revision used by pnpm ai:setup. Update only with --record-pin after review."
+}

--- a/.codex/steering/repository-steering.md
+++ b/.codex/steering/repository-steering.md
@@ -1,0 +1,48 @@
+# Repository Scope And Priorities
+
+MTG Card Analyzer is a local-first OCR and matching CLI for cataloguing Magic: The Gathering cards.
+
+## Primary Deliverables
+
+- extract candidate card names and types from supplied images
+- resolve likely card names and printings with fuzzy and image-hash matching
+- persist reusable local name and hash data without requiring a hosted service
+- provide deterministic unit and image-regression evidence for matching quality
+
+## Core Priorities
+
+- correct, explainable matches before heuristic cleverness
+- offline-first operation and tests
+- bounded resource usage for images, OCR, network calls, and caches
+- stable CLI, configuration, storage, and fixture contracts
+- actionable errors without secret or local-path leakage
+
+## Active Boundaries
+
+- `index.mjs` owns CLI parsing and presentation, not matching or persistence rules.
+- `src/config/` owns configuration precedence and validation.
+- `src/image-analysis/` and `src/image-processing/` own OCR and image transformation.
+- `src/fuzzy-matching/`, `src/matcher/`, and `src/processor/` own matching decisions and workflow.
+- `src/scryfall-api/` owns remote Scryfall interaction and response translation.
+- `src/storage/` owns the adapter contract; `src/db-local/` and `src/rds/` implement persistence.
+- `test/regression/` owns benchmark labels, expectations, and reporting policy.
+
+## Safe Refactor Boundaries
+
+Do not change these without explicit intent and matching tests/docs:
+
+- CLI command names, flags, output shape, or exit codes
+- configuration precedence or environment-variable names
+- local database locations, record semantics, or storage-adapter behavior
+- normalization and fuzzy-match thresholds
+- regression fixture labels or expected card/printing identities
+- default local-first behavior or optional status of RDS
+
+Safe defaults are focused validation, cleanup, diagnostics, typing, tests, and documentation within
+one boundary. Update contracts first when a change must cross boundaries.
+
+## Shared Steering Placeholder Resolution
+
+For `.codex/steering/javascript-typescript-steering.md`, the project root is `.` and the canonical
+commands are `pnpm prettier:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm audit`.
+There is no separate production build step.

--- a/.codex/steering/testing-quality-gates-steering.md
+++ b/.codex/steering/testing-quality-gates-steering.md
@@ -1,0 +1,39 @@
+# Testing And Quality Gates
+
+Testing must protect CLI contracts, configuration precedence, matching behavior, cleanup, storage
+boundaries, and OCR regression quality.
+
+## Default Expectations
+
+- Add or update focused Mocha tests for behavior changes and fixed defects.
+- Cover invalid and boundary input, rejected promises, cleanup, and adapter failures.
+- Keep unit tests offline and deterministic; stub Scryfall, OCR, filesystem, and database boundaries.
+- Use temporary directories for persistence tests and remove them in teardown.
+- Treat committed image fixtures and regression expectations as reviewed evidence, not snapshots to
+  rewrite automatically.
+- Run the image regression gate for OCR preprocessing, hashing, normalization, fuzzy matching, or
+  print-selection changes.
+
+## Required Commands
+
+Run the smallest relevant checks first, then the full applicable gate:
+
+- Formatting: `pnpm prettier:check`
+- Lint: `pnpm lint`
+- Typecheck: `pnpm typecheck`
+- Unit tests: `pnpm test`
+- OCR regression: `pnpm test:regression`
+- Full standard gate: `pnpm check`
+- Coverage gate when test coverage changes: `pnpm coverage:check`
+- AI integration changes: `pnpm ai:check` and `pnpm test -- --grep "AI Central"`
+
+## Quality Gates
+
+- No new lint, typecheck, unit-test, or formatting failures.
+- No live network or MySQL dependency in default unit tests.
+- No leaked handles, temporary files, or mutable shared fixture state.
+- No unrelated formatting, lockfile, database, image, coverage, or benchmark churn.
+- Public CLI/config/storage contracts and docs updated with behavior changes.
+- Regression misses are investigated and reported; expected results are not weakened to force green.
+
+If a command cannot run locally, report the exact blocker and remaining risk.

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,14 @@ secure.config.*
 *.swo
 *~
 
+# Local AI Central links (repository-owned AI files remain tracked)
+.agents/
+.claude/agents/
+.claude/skills
+.claude/worktrees/
+.codex/skills/
+.codex/steering/javascript-typescript-steering.md
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,8 @@ node_modules
 dist
 build
 coverage
+.claude/worktrees
+.codex/skills
 pnpm-lock.yaml
 eng.traineddata
 src/test-images

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS
+
+Repository-wide AI coding guidance for MTG Card Analyzer.
+
+## Purpose
+
+MTG Card Analyzer is a local-first Node.js CLI that identifies Magic: The Gathering cards from
+images using OCR, fuzzy name matching, and image-hash print matching.
+
+Optimize for:
+
+- reliable card identification across clean scans and degraded photos
+- deterministic, offline-first tests and regression fixtures
+- bounded image, OCR, network, and storage work with explicit cleanup
+- stable CLI, configuration, and storage contracts
+- small, explicit changes over broad refactors
+- tests and documentation when behavior, contracts, setup, or commands change
+
+## Start Here
+
+Before changing behavior, read:
+
+- `Readme.md` for supported workflows and current architecture
+- `CONTRIBUTING.md` for contribution and quality expectations
+- `docs/regression-testing.md` for benchmark fixtures and regression policy
+- `.codex/steering/repository-steering.md` for ownership boundaries
+- `.codex/steering/testing-quality-gates-steering.md` for verification requirements
+- `.codex/steering/javascript-typescript-steering.md` for shared JS/TS guidance
+
+The root instructions and project-owned steering files take precedence over linked AI Central
+content when they conflict.
+
+## Architecture Boundaries
+
+Primary areas:
+
+- `index.mjs`: thin CLI boundary; parse options, resolve configuration, invoke workflows, report
+  results, and set exit behavior
+- `src/config/`: configuration resolution and precedence
+- `src/image-analysis/` and `src/image-processing/`: OCR extraction and bounded image transforms
+- `src/fuzzy-matching/`, `src/matcher/`, and `src/processor/`: matching and orchestration logic
+- `src/scryfall-api/`: external Scryfall boundary
+- `src/storage/` and `src/db-local/`: storage abstraction and local NeDB persistence
+- `src/rds/`: optional legacy MySQL/RDS adapter; do not make it a default dependency
+- `test/` and `test-images/`: deterministic behavior tests and committed image fixtures
+
+Keep pure matching decisions separate from image, network, filesystem, and database adapters. When
+a change spans boundaries, update the shared contract first and keep entrypoints thin.
+
+## Contract-First Files
+
+Treat these as interfaces before implementation details:
+
+- `package.json` scripts, engines, package-manager declaration, and CLI entrypoint
+- `mtg.config.example.json` and configuration precedence documented in `Readme.md`
+- `src/config/index.mjs`
+- `src/storage/create-storage.mjs` and `src/storage/adapters/`
+- `test/regression/fixtures/manifest.json`
+- public CLI commands, flags, output shape, and exit codes in `index.mjs`
+
+If behavior changes, update the relevant tests, examples, and documentation in the same change.
+
+## Scope And Safety
+
+- Treat image paths, config files, environment variables, CLI input, OCR output, API responses, and
+  stored records as untrusted data.
+- Constrain file access and temporary artifacts; clean up snippets on success and failure.
+- Bound image dimensions, buffers, OCR work, network requests, retries, and concurrent operations.
+- Never commit credentials, local databases, generated OCR snippets, coverage, or benchmark output.
+- Keep `secure.config.cjs` local-only. Maintain `secure.config.template.cjs` as the documented shape.
+- Do not require MySQL/RDS for the default local workflow or unit test suite.
+- Do not refresh or relabel committed regression expectations merely to make a regression pass.
+- Avoid unrelated dependency, formatting, fixture, or generated-artifact churn.
+
+## JavaScript And TypeScript
+
+The linked shared JS/TS steering uses template placeholders. Resolve them for this repository as:
+
+- `JAVASCRIPT_TYPESCRIPT_ROOT`: `.` with primary runtime code under `index.mjs`, `src/`, and
+  `scripts/`
+- format: `pnpm prettier:check`
+- lint: `pnpm lint`
+- typecheck/build: `pnpm typecheck` (the project emits no build artifact)
+- tests: `pnpm test`
+- dependency audit: `pnpm audit`
+
+Repository reality wins where generic guidance assumes a TypeScript-only codebase: this project is
+ESM JavaScript with incremental TypeScript checking through `allowJs` and `checkJs`.
+
+## Testing And Fixtures
+
+- Add focused Mocha tests for behavior and failure-path changes.
+- Mock network and database boundaries in unit tests; default tests must remain offline.
+- For OCR or matching quality changes, run `pnpm test:regression` and inspect both benchmark outputs.
+- Keep regression fixtures explicit and deterministic. New fixtures remain disabled until labels and
+  offline print references are reviewed.
+- Use temporary directories for filesystem tests and clean them up reliably.
+
+## Useful Commands
+
+- Install dependencies: `pnpm install --frozen-lockfile`
+- Fast quality gate: `pnpm check:fast`
+- Unit tests: `pnpm test`
+- OCR regression gate: `pnpm test:regression`
+- Full local gate: `pnpm check`
+- Coverage: `pnpm coverage:check`
+- Refresh local AI links: `pnpm ai:setup`
+- Validate AI integration: `pnpm ai:check`
+
+## AI Central Integration
+
+Repository-specific files are real and tracked. Reusable steering, skills, and custom agents are
+local symlinks recreated from the sibling `ai-central` checkout. See `.codex/AI_CENTRAL.md` for the
+selection, provenance pin, refresh workflow, and portability notes.
+
+## Branch And PR Metadata
+
+- Use feature branches for behavior, contract, test, or documentation changes.
+- Do not commit directly to `master`.
+- When work is ready, provide a branch name, concise commit message, PR title and summary, and exact
+  verification evidence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude project instructions
+
+Read and follow `AGENTS.md` first. It is the authoritative repository-wide guide and indexes the
+project architecture, contracts, safety boundaries, and verification commands.
+
+Reusable Claude-compatible skills are linked locally at `.claude/skills/`, and reviewed custom
+agents are linked at `.claude/agents/`. They supplement `AGENTS.md`; they do not override it.
+
+See `.codex/AI_CENTRAL.md` to recreate or validate the local links.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,20 @@ pnpm install
 
 `pnpm install` also runs `lefthook install` (via the `prepare` script), which wires up git hooks for lint-staged.
 
+## AI-Assisted Development
+
+Repository-specific guidance is tracked in `AGENTS.md` and `CLAUDE.md`. Optional shared steering,
+skills, and custom agents come from a sibling `ai-central` checkout and remain ignored local
+symlinks:
+
+```bash
+pnpm ai:setup
+pnpm ai:check
+```
+
+See `.codex/AI_CENTRAL.md` for the selected bundles, pinned revision, custom-agent list, and refresh
+workflow. A normal build does not require AI Central.
+
 ## Branching & Commits
 
 - Branch off `master`. Use a short descriptive branch name (e.g. `fix/image-too-small-error`, `feat/multi-image-scan`).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,13 @@ import globals from "globals";
 
 export default [
     {
-        ignores: ["node_modules/**", "dist/**", "coverage/**"]
+        ignores: [
+            "node_modules/**",
+            "dist/**",
+            "coverage/**",
+            ".claude/worktrees/**",
+            ".codex/skills/**"
+        ]
     },
     {
         files: ["**/*.mjs", "**/*.js"],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
         "pnpm": ">=8.0.0"
     },
     "scripts": {
+        "ai:check": "node scripts/setup-ai-context.mjs --check",
+        "ai:setup": "node scripts/setup-ai-context.mjs",
         "test": "mocha \"./test/**/*.spec.mjs\"",
         "test:regression": "node scripts/run-regression.mjs",
         "regression": "node scripts/run-regression.mjs --no-fail-on-regression",

--- a/scripts/setup-ai-context.mjs
+++ b/scripts/setup-ai-context.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const pinPath = path.join(repositoryRoot, ".codex", "ai-central-pin.json");
+const isEntrypoint = Boolean(
+    process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+);
+
+const profiles = "base,javascript-typescript";
+const bundles = "core,brevity,engineering,planning,workflow";
+
+function usage() {
+    process.stdout.write(`Usage: node scripts/setup-ai-context.mjs [option]
+
+Create, repair, or validate local links to the sibling AI Central checkout.
+
+Options:
+  --dry-run     Preview changes without writing.
+  --check       Validate the pin, repository-owned files, and managed links.
+  --record-pin  Record the current reviewed AI Central commit, then exit.
+  --help        Show this help.
+
+Environment:
+  AI_CENTRAL_HOME  AI Central repository root or templates directory.
+                   Defaults to ../ai-central.
+`);
+}
+
+export function resolveAiCentralLayout(input, projectRoot = repositoryRoot) {
+    const requested = input ?? path.resolve(projectRoot, "../ai-central");
+    const absolute = path.resolve(requested);
+
+    if (path.basename(absolute) === "templates") {
+        return { aiCentralRoot: path.dirname(absolute), templatesRoot: absolute };
+    }
+
+    return { aiCentralRoot: absolute, templatesRoot: path.join(absolute, "templates") };
+}
+
+async function pathExists(target) {
+    try {
+        await fs.lstat(target);
+        return true;
+    } catch (error) {
+        if (error.code === "ENOENT") {
+            return false;
+        }
+        throw error;
+    }
+}
+
+export async function findGitRoot(startDirectory) {
+    let current = path.resolve(startDirectory);
+
+    for (;;) {
+        if (await pathExists(path.join(current, ".git"))) {
+            return current;
+        }
+
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return undefined;
+        }
+        current = parent;
+    }
+}
+
+export async function resolveAiCentralCommit(templatesRoot) {
+    const gitRoot = await findGitRoot(templatesRoot);
+    if (!gitRoot) {
+        return undefined;
+    }
+
+    try {
+        const { stdout } = await execFileAsync("git", ["-C", gitRoot, "rev-parse", "HEAD"]);
+        return stdout.trim();
+    } catch {
+        return undefined;
+    }
+}
+
+export async function hasTrackedAiCentralChanges(templatesRoot) {
+    const gitRoot = await findGitRoot(templatesRoot);
+    if (!gitRoot) {
+        return false;
+    }
+
+    try {
+        const { stdout } = await execFileAsync("git", [
+            "-C",
+            gitRoot,
+            "status",
+            "--porcelain",
+            "--untracked-files=no"
+        ]);
+        return stdout.trim().length > 0;
+    } catch {
+        return false;
+    }
+}
+
+export async function readPin(filePath = pinPath) {
+    try {
+        return JSON.parse(await fs.readFile(filePath, "utf8"));
+    } catch (error) {
+        if (error.code === "ENOENT") {
+            return { expectedCommit: null };
+        }
+        throw error;
+    }
+}
+
+export function evaluatePin(pin, currentCommit, { dirty = false } = {}) {
+    if (!pin.expectedCommit) {
+        return { status: "unpinned" };
+    }
+    if (!currentCommit) {
+        return { status: "not-git" };
+    }
+    if (dirty) {
+        return { status: "dirty" };
+    }
+    if (pin.expectedCommit !== currentCommit) {
+        return { status: "mismatch" };
+    }
+    return { status: "ok" };
+}
+
+async function writePin(filePath, expectedCommit) {
+    const payload = {
+        expectedCommit,
+        note: "Reviewed AI Central revision used by pnpm ai:setup. Update only with --record-pin after review."
+    };
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, `${JSON.stringify(payload, null, 4)}\n`);
+}
+
+export async function ensureSymlink(linkPath, target, { dryRun = false } = {}) {
+    const absoluteTarget = path.resolve(target);
+    let existing;
+
+    try {
+        existing = await fs.lstat(linkPath);
+    } catch (error) {
+        if (error.code !== "ENOENT") {
+            throw error;
+        }
+    }
+
+    if (existing && !existing.isSymbolicLink()) {
+        return { action: "preserved", linkPath, target: absoluteTarget };
+    }
+
+    if (existing?.isSymbolicLink()) {
+        const currentTarget = await fs.readlink(linkPath);
+        const resolvedCurrent = path.resolve(path.dirname(linkPath), currentTarget);
+        if (resolvedCurrent === absoluteTarget) {
+            return { action: "unchanged", linkPath, target: absoluteTarget };
+        }
+        if (!dryRun) {
+            await fs.unlink(linkPath);
+        }
+    }
+
+    if (!dryRun) {
+        await fs.mkdir(path.dirname(linkPath), { recursive: true });
+        await fs.symlink(absoluteTarget, linkPath);
+    }
+
+    return { action: existing ? "updated" : "created", linkPath, target: absoluteTarget };
+}
+
+function managedLinks(layout) {
+    const cavemanRoot = path.join(layout.templatesRoot, "skills", "imported", "caveman");
+    const personaRoot = path.join(layout.aiCentralRoot, "external", "agent-skills", "agents");
+
+    return [
+        {
+            linkPath: path.join(repositoryRoot, ".codex", "skills", "cavecrew"),
+            target: path.join(cavemanRoot, "skills", "cavecrew")
+        },
+        {
+            linkPath: path.join(repositoryRoot, ".claude", "skills"),
+            target: path.join(repositoryRoot, ".codex", "skills")
+        },
+        {
+            linkPath: path.join(repositoryRoot, ".agents", "skills"),
+            target: path.join(repositoryRoot, ".codex", "skills")
+        },
+        ...["cavecrew-investigator", "cavecrew-builder", "cavecrew-reviewer"].map((name) => ({
+            linkPath: path.join(repositoryRoot, ".claude", "agents", `${name}.md`),
+            target: path.join(cavemanRoot, "agents", `${name}.md`)
+        })),
+        ...["code-reviewer", "security-auditor", "test-engineer"].map((name) => ({
+            linkPath: path.join(repositoryRoot, ".claude", "agents", `${name}.md`),
+            target: path.join(personaRoot, `${name}.md`)
+        }))
+    ];
+}
+
+async function assertCentralLayout(layout) {
+    const setupScript = path.join(layout.aiCentralRoot, "scripts", "setup-ai-context.sh");
+    if (!(await pathExists(setupScript))) {
+        throw new Error(
+            `AI Central setup script not found at ${setupScript}. Set AI_CENTRAL_HOME correctly.`
+        );
+    }
+    return setupScript;
+}
+
+async function assertPin(layout) {
+    const pin = await readPin();
+    const currentCommit = await resolveAiCentralCommit(layout.templatesRoot);
+    const dirty = await hasTrackedAiCentralChanges(layout.templatesRoot);
+    const evaluation = evaluatePin(pin, currentCommit, { dirty });
+
+    if (evaluation.status === "unpinned") {
+        throw new Error(
+            "AI Central is not pinned. Run `pnpm ai:setup -- --record-pin` after review."
+        );
+    }
+    if (evaluation.status === "not-git") {
+        throw new Error(`AI Central at ${layout.aiCentralRoot} is not a Git checkout.`);
+    }
+    if (evaluation.status === "dirty") {
+        throw new Error(
+            `AI Central at ${layout.aiCentralRoot} has tracked uncommitted changes; the pinned bytes cannot be verified.`
+        );
+    }
+    if (evaluation.status === "mismatch") {
+        throw new Error(
+            `AI Central commit ${currentCommit} does not match pinned commit ${pin.expectedCommit}. ` +
+                "Review the update, then run `pnpm ai:setup -- --record-pin`, or restore the pin."
+        );
+    }
+
+    return currentCommit;
+}
+
+async function runCentralSetup(setupScript, dryRun) {
+    const args = [
+        repositoryRoot,
+        "--profiles",
+        profiles,
+        "--bundles",
+        bundles,
+        "--yes",
+        "--mode",
+        "link"
+    ];
+    if (dryRun) {
+        args.push("--dry-run");
+    }
+
+    const { stdout, stderr } = await execFileAsync(setupScript, args, {
+        cwd: path.dirname(path.dirname(setupScript))
+    });
+    process.stdout.write(stdout);
+    process.stderr.write(stderr);
+}
+
+async function validateOwnedFiles() {
+    const ownedFiles = [
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".codex/AI_CENTRAL.md",
+        ".codex/ai-central-pin.json",
+        ".codex/steering/repository-steering.md",
+        ".codex/steering/testing-quality-gates-steering.md",
+        "scripts/setup-ai-context.mjs"
+    ];
+
+    for (const relativePath of ownedFiles) {
+        const absolutePath = path.join(repositoryRoot, relativePath);
+        if (!(await pathExists(absolutePath))) {
+            throw new Error(`Missing repository-owned AI file: ${relativePath}`);
+        }
+
+        const contents = await fs.readFile(absolutePath, "utf8");
+        if (/\{\{[^}]+\}\}/u.test(contents)) {
+            throw new Error(`Unresolved scaffold placeholder in ${relativePath}`);
+        }
+    }
+}
+
+async function validateSymlink(linkPath, expectedTarget) {
+    let stat;
+    try {
+        stat = await fs.lstat(linkPath);
+    } catch (error) {
+        if (error.code === "ENOENT") {
+            throw new Error(`Missing managed symlink: ${path.relative(repositoryRoot, linkPath)}`);
+        }
+        throw error;
+    }
+
+    if (!stat.isSymbolicLink()) {
+        throw new Error(
+            `Managed path is not a symlink: ${path.relative(repositoryRoot, linkPath)}`
+        );
+    }
+
+    const actual = path.resolve(path.dirname(linkPath), await fs.readlink(linkPath));
+    if (actual !== path.resolve(expectedTarget)) {
+        throw new Error(
+            `Managed symlink has wrong target: ${path.relative(repositoryRoot, linkPath)} -> ${actual}`
+        );
+    }
+    if (!(await pathExists(actual))) {
+        throw new Error(`Managed symlink is broken: ${path.relative(repositoryRoot, linkPath)}`);
+    }
+}
+
+async function validateSkillLinks(layout) {
+    const requiredSkills = [
+        "github-keychain-auth",
+        "planning-files-lite",
+        "caveman",
+        "caveman-help",
+        "caveman-commit",
+        "caveman-review",
+        "caveman-compress",
+        "cavecrew",
+        "code-simplification",
+        "claude-ship-gate",
+        "planning-with-files",
+        "toolkit-qa-test-planner"
+    ];
+
+    for (const skill of requiredSkills) {
+        const skillPath = path.join(repositoryRoot, ".codex", "skills", skill);
+        const stat = await fs.lstat(skillPath).catch(() => undefined);
+        if (!stat?.isSymbolicLink() || !(await pathExists(path.join(skillPath, "SKILL.md")))) {
+            throw new Error(`Missing or invalid required skill link: ${skill}`);
+        }
+    }
+
+    const entries = await fs.readdir(path.join(repositoryRoot, ".codex", "skills"), {
+        withFileTypes: true
+    });
+    for (const entry of entries) {
+        const skillPath = path.join(repositoryRoot, ".codex", "skills", entry.name);
+        const stat = await fs.lstat(skillPath);
+        if (stat.isSymbolicLink() && !(await pathExists(skillPath))) {
+            throw new Error(`Broken skill link: ${entry.name}`);
+        }
+    }
+
+    await validateSymlink(
+        path.join(repositoryRoot, ".codex", "steering", "javascript-typescript-steering.md"),
+        path.join(layout.templatesRoot, "steering", "javascript-typescript-steering.md")
+    );
+}
+
+async function checkIntegration(layout) {
+    await assertCentralLayout(layout);
+    const commit = await assertPin(layout);
+    await validateOwnedFiles();
+    await validateSkillLinks(layout);
+    for (const link of managedLinks(layout)) {
+        await validateSymlink(link.linkPath, link.target);
+    }
+    process.stdout.write(`AI integration valid at AI Central commit ${commit}.\n`);
+}
+
+async function main() {
+    const args = new Set(process.argv.slice(2).filter((argument) => argument !== "--"));
+    const allowed = new Set(["--dry-run", "--check", "--record-pin", "--help", "-h"]);
+    const unknown = [...args].find((argument) => !allowed.has(argument));
+    if (unknown) {
+        throw new Error(`Unknown option: ${unknown}`);
+    }
+    if (args.has("--help") || args.has("-h")) {
+        usage();
+        return;
+    }
+
+    const modes = ["--dry-run", "--check", "--record-pin"].filter((mode) => args.has(mode));
+    if (modes.length > 1) {
+        throw new Error(`Choose only one mode: ${modes.join(", ")}`);
+    }
+
+    const layout = resolveAiCentralLayout(process.env.AI_CENTRAL_HOME);
+    const setupScript = await assertCentralLayout(layout);
+
+    if (args.has("--record-pin")) {
+        const commit = await resolveAiCentralCommit(layout.templatesRoot);
+        if (!commit) {
+            throw new Error(`Cannot resolve an AI Central Git commit at ${layout.aiCentralRoot}.`);
+        }
+        if (await hasTrackedAiCentralChanges(layout.templatesRoot)) {
+            throw new Error("Refusing to pin AI Central while it has tracked uncommitted changes.");
+        }
+        await writePin(pinPath, commit);
+        process.stdout.write(`Recorded AI Central pin: ${commit}\n`);
+        return;
+    }
+
+    if (args.has("--check")) {
+        await checkIntegration(layout);
+        return;
+    }
+
+    await assertPin(layout);
+    const dryRun = args.has("--dry-run");
+    await runCentralSetup(setupScript, dryRun);
+
+    const results = [];
+    for (const link of managedLinks(layout)) {
+        results.push(await ensureSymlink(link.linkPath, link.target, { dryRun }));
+    }
+
+    for (const result of results.filter(
+        (item) => !["unchanged", "preserved"].includes(item.action)
+    )) {
+        process.stdout.write(
+            `${result.action}: ${path.relative(repositoryRoot, result.linkPath)} -> ${result.target}\n`
+        );
+    }
+
+    const preserved = results.filter((result) => result.action === "preserved");
+    if (preserved.length > 0) {
+        throw new Error(
+            `Refused to replace non-symlink managed paths: ${preserved
+                .map((result) => path.relative(repositoryRoot, result.linkPath))
+                .join(", ")}`
+        );
+    }
+
+    process.stdout.write(`Managed AI links checked: ${results.length}.\n`);
+}
+
+if (isEntrypoint) {
+    main().catch((error) => {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/test/ai-context.spec.mjs
+++ b/test/ai-context.spec.mjs
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+    ensureSymlink,
+    evaluatePin,
+    resolveAiCentralLayout
+} from "../scripts/setup-ai-context.mjs";
+
+describe("AI Central setup", () => {
+    it("accepts either the AI Central root or templates directory", () => {
+        expect(resolveAiCentralLayout("/tmp/example/ai-central", "/tmp/project")).to.deep.equal({
+            aiCentralRoot: "/tmp/example/ai-central",
+            templatesRoot: "/tmp/example/ai-central/templates"
+        });
+        expect(
+            resolveAiCentralLayout("/tmp/example/ai-central/templates", "/tmp/project")
+        ).to.deep.equal({
+            aiCentralRoot: "/tmp/example/ai-central",
+            templatesRoot: "/tmp/example/ai-central/templates"
+        });
+    });
+
+    it("classifies pin state", () => {
+        expect(evaluatePin({ expectedCommit: null }, "abc").status).to.equal("unpinned");
+        expect(evaluatePin({ expectedCommit: "abc" }, undefined).status).to.equal("not-git");
+        expect(evaluatePin({ expectedCommit: "abc" }, "abc", { dirty: true }).status).to.equal(
+            "dirty"
+        );
+        expect(evaluatePin({ expectedCommit: "abc" }, "def").status).to.equal("mismatch");
+        expect(evaluatePin({ expectedCommit: "abc" }, "abc").status).to.equal("ok");
+    });
+
+    it("creates, preserves, and repairs managed symlinks", async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), "mtg-ai-context-"));
+        try {
+            const firstTarget = path.join(root, "first");
+            const secondTarget = path.join(root, "second");
+            const linkPath = path.join(root, "nested", "skill");
+            await fs.mkdir(firstTarget);
+            await fs.mkdir(secondTarget);
+
+            expect((await ensureSymlink(linkPath, firstTarget)).action).to.equal("created");
+            expect((await ensureSymlink(linkPath, firstTarget)).action).to.equal("unchanged");
+            expect((await ensureSymlink(linkPath, secondTarget)).action).to.equal("updated");
+            expect(path.resolve(path.dirname(linkPath), await fs.readlink(linkPath))).to.equal(
+                secondTarget
+            );
+
+            await fs.unlink(linkPath);
+            await fs.writeFile(linkPath, "repo-owned\n");
+            expect((await ensureSymlink(linkPath, firstTarget)).action).to.equal("preserved");
+            expect(await fs.readFile(linkPath, "utf8")).to.equal("repo-owned\n");
+        } finally {
+            await fs.rm(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- add repository-owned `AGENTS.md`, `CLAUDE.md`, and MTG-specific steering
- add a pinned, reproducible AI Central setup and validation workflow
- link selected core, Caveman, engineering, planning, and workflow skills plus six custom agents
- keep reusable AI Central content as ignored local symlinks
- add focused setup tests and exclude local AI worktrees/skills from lint and formatting scans

## Why

This gives contributors consistent, project-specific AI guidance while keeping shared skills and
generic steering centrally maintained. The revision pin and clean-worktree check make linked
content reviewable and prevent silent local drift.

## Validation

- `pnpm ai:check`
- `pnpm check:fast`
- `pnpm test -- --grep "AI Central"` — 3 passing
- pre-commit lint-staged hook under Node 22
- full `pnpm test` — 81 passing, 1 existing environment-sensitive failure because the ignored
  local `secure.config.cjs` is present while the missing-config RDS test expects it to be absent

## Notes

- AI Central is optional for normal build and runtime workflows.
- A fresh clone can recreate local links with `pnpm ai:setup`.
- Commands were verified with the Node 22 runtime pinned by `.nvmrc`.
