### PR TITLE
fix: CLI crash on bare invoke + --help doesn't list log command

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -7,6 +7,7 @@ import storage from "./src/storage/index.mjs";
 
 const { Processor } = processorModule;
 const KNOWN_COMMANDS = ["scan", "log"];
+const HELP_TOKENS = ["--help", "-h", "help"];
 
 function buildCli(argv) {
     const program = new Command();
@@ -84,7 +85,11 @@ Examples:
     try {
         program.parse(argv, { from: "user" });
     } catch (err) {
-        if (err.code === "commander.helpDisplayed") {
+        // showHelpAfterError() + exitOverride() mean commander has already printed
+        // appropriate output for every commander.* error (help text, or "error: missing
+        // required argument" + usage) -- not just the explicit --help case. Swallow all of
+        // them here so run() doesn't also dump the raw CommanderError/stack on top.
+        if (err.code && err.code.startsWith("commander.")) {
             parsed.helpRequested = true;
         } else {
             throw err;
@@ -203,13 +208,19 @@ export async function run(options = {}) {
         logger = console
     } = options;
 
-    const normalizedArgv = KNOWN_COMMANDS.includes(argv[0]) ? argv : ["scan", ...argv];
+    // Bare filepath args ("node index.mjs ./card.jpg") implicitly mean `scan` for backward
+    // compatibility. Empty argv, --help/-h, and known commands must NOT get that prefix --
+    // otherwise `node index.mjs --help` silently becomes `scan --help` and the top-level
+    // help (which lists `log` at all) never shows.
+    const shouldPrefixScan =
+        argv.length > 0 && !KNOWN_COMMANDS.includes(argv[0]) && !HELP_TOKENS.includes(argv[0]);
+    const normalizedArgv = shouldPrefixScan ? ["scan", ...argv] : argv;
 
     const cli = await commanderFactory(normalizedArgv);
     const flags = cli.flags || {};
 
     if (cli.helpRequested) {
-        logger.log("Try running --help for more info");
+        // commander already printed the relevant help/usage/error text itself.
         return;
     }
 

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -235,4 +235,75 @@ describe("CLI::index.mjs buildCli (real commander wiring)", () => {
         const parsed = buildCli(["log", "stats"]);
         assert.equal(parsed.command, "log-stats");
     });
+
+    it("does not throw on empty argv -- commander shows top-level help instead", () => {
+        const parsed = buildCli([]);
+        assert.equal(parsed.helpRequested, true);
+    });
+
+    it("does not throw on `scan` with a missing required filePath argument", () => {
+        // Regression: commander.missingArgument used to propagate as a raw uncaught
+        // CommanderError instead of being handled the same way as --help.
+        const parsed = buildCli(["scan"]);
+        assert.equal(parsed.helpRequested, true);
+    });
+
+    it("does not throw on an unknown flag", () => {
+        const parsed = buildCli(["scan", "./card.jpg", "--not-a-real-flag"]);
+        assert.equal(parsed.helpRequested, true);
+    });
+});
+
+describe("CLI::index.mjs run() argv normalization (real buildCli)", () => {
+    let sandbox;
+    let processExitStub;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        processExitStub = sandbox.stub();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    async function runReal(argv) {
+        const consoleLogStub = sandbox.stub();
+        const processorCreateStub = sandbox.stub().returns({
+            execute: sandbox.stub().callsFake((cb) => cb && cb())
+        });
+        await run({
+            argv,
+            fsAccess: sandbox.stub().resolves(),
+            processorFactory: processorCreateStub,
+            exit: processExitStub,
+            logger: { log: consoleLogStub }
+        });
+        return { consoleLogStub, processorCreateStub };
+    }
+
+    it("bare invoke (no args) does not crash and does not invoke the processor", async () => {
+        const { processorCreateStub } = await runReal([]);
+        assert.isFalse(processorCreateStub.called);
+        assert.isFalse(processExitStub.called);
+    });
+
+    it("--help does not get silently prefixed into `scan --help`", async () => {
+        // Commander writes help straight to process.stdout, bypassing the injected logger --
+        // capture the real stream to verify the top-level command list (scan + log) is shown,
+        // not just scan's own options.
+        const writeStub = sandbox.stub(process.stdout, "write");
+        await runReal(["--help"]);
+        const printed = writeStub
+            .getCalls()
+            .map((call) => call.args[0])
+            .join("");
+        assert.match(printed, /log\s+Inspect the local operations log/);
+    });
+
+    it("an unknown flag does not crash the process", async () => {
+        const { processorCreateStub } = await runReal(["scan", "./x.jpg", "--not-a-real-flag"]);
+        assert.isFalse(processorCreateStub.called);
+        assert.isFalse(processExitStub.called);
+    });
 });


### PR DESCRIPTION
## Summary

Two CLI bugs found while reviewing what's left in the persistence area (#159/#162 merged) — `log`'s discoverability was the direct trigger.

- **`node index.mjs` (no args) crashed** with a raw CommanderError stack trace instead of a clean message. `buildCli`'s try/catch only handled `commander.helpDisplayed`; `commander.missingArgument` (and other commander error codes) propagated uncaught. Commander already prints an appropriate error+usage block for all of these via `showHelpAfterError()` — broadened the catch to swallow any `commander.*` code.
- **`node index.mjs --help` silently became `scan --help`** — only showed scan's own options, never the top-level command list, so `log` was invisible unless you already knew it existed. The argv-prefixing logic unconditionally prepended `scan` to anything not literally `scan`/`log`, including `--help`/`-h`/empty argv. Now only prefixes when argv looks like an actual scan target (bare-filepath backward compat preserved).

Bonus: also killed a pre-existing double-print on `scan --help` (commander's help text followed by a redundant "Try running --help for more info" line).

## Testing

- `pnpm check` — green, 110 passing (was 104)
- 6 new tests: `buildCli()` directly (empty argv / missing filePath / unknown flag all handled cleanly, no throw) + `run()` through the real commander wiring (bare invoke doesn't touch the processor, `--help`'s actual stdout output lists the `log` command)
- Manually verified every case against the real CLI: bare invoke, `--help`, `scan --help`, `log --help`, unknown command, bare-filepath backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
