### PR TITLE
feat: collection update/remove commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,13 +99,17 @@ node index.mjs scan ./test-images/PlatinumAngel.jpg
     - flags: `--config <path>`
 - `migrate` : one-shot migration of local nedb collection/needs-attention data to another backend (currently only `nedb -> rds`; always reads from local nedb regardless of the active `--storage-adapter`). Idempotent by default -- an entry already present on the target is skipped, not double-counted; `--force` re-migrates collection entries anyway (adds local quantity on top of whatever's already there). Needs-attention entries are always deduped by the target's own unique constraint.
     - flags: `--to <rds>` (required), `--dry-run` (preview without writing), `--force`, `--card-names-db <path>`, `--config <path>`
+- `collection update <cardName> <cardSet>` : manually set a collection entry's quantity to an exact value (unlike scanning, this overwrites rather than adds). Errors if the entry doesn't exist -- use a scan to create one first. `estValue` is rescaled proportionally from the existing per-unit value.
+    - flags: `--quantity <n>` (required), `--storage-adapter <nedb|rds>`, `--config <path>`
+- `collection remove <cardName> <cardSet>` : delete a collection entry outright. Permanent, no confirmation prompt.
+    - flags: `--storage-adapter <nedb|rds>`, `--config <path>`
 
 ### Persistence Architecture
 
 Two deliberately separate tiers:
 
 1. **Cache tier** — always on by default (turn off with `--no-local-cache` / `LOCAL_CACHE_ENABLED=false`), always local nedb, never `STORAGE_ADAPTER`-selected. Holds the card names dictionary, the image hash cache, and the local [operations log](#operations-log). Its job is speed (skip re-querying Scryfall, skip re-hashing known cards) and local diagnostics — not being a source of truth. The names dictionary specifically is unaffected by `--no-local-cache`: it's a required local index, not an optional cache, since there's no remote alternative.
-2. **Persistence tier** — selected by `STORAGE_ADAPTER` (`nedb` | `rds`, default `nedb`). This is where your actual collection and needs-attention records live. Scanning the same card twice adds to its quantity (`delta`, default 1) rather than overwriting it — both backends compute the resulting `estValue` from the final quantity.
+2. **Persistence tier** — selected by `STORAGE_ADAPTER` (`nedb` | `rds`, default `nedb`). This is where your actual collection and needs-attention records live. Scanning the same card twice adds to its quantity (`delta`, default 1) rather than overwriting it — both backends compute the resulting `estValue` from the final quantity. Made a mistake, or want to correct/remove an entry by hand? `collection update`/`collection remove` (see [Current Commands](#current-commands)) go through the same tier.
 
 Local cache DB files:
 

--- a/index.mjs
+++ b/index.mjs
@@ -7,7 +7,7 @@ import storage from "./src/storage/index.mjs";
 import migrate from "./src/migrate/nedb-to-rds.mjs";
 
 const { Processor } = processorModule;
-const KNOWN_COMMANDS = ["scan", "log", "migrate"];
+const KNOWN_COMMANDS = ["scan", "log", "migrate", "collection"];
 const HELP_TOKENS = ["--help", "-h", "help"];
 
 function buildCli(argv) {
@@ -90,6 +90,41 @@ function buildCli(argv) {
             parsed.flags = options || {};
         });
 
+    const collectionCommand = program
+        .command("collection")
+        .description("Manually correct a collection entry (persistence tier)");
+
+    collectionCommand
+        .command("update")
+        .description("Set a collection entry's quantity to an exact value")
+        .argument("<cardName>")
+        .argument("<cardSet>")
+        .requiredOption("--quantity <n>", "Exact quantity to set")
+        .option(
+            "--storage-adapter <adapter>",
+            `Storage adapter to use (${KNOWN_STORAGE_ADAPTERS.join("|")})`
+        )
+        .option("--config <path>", "Path to a JSON config file")
+        .action((cardName, cardSet, options) => {
+            parsed.command = "collection-update";
+            parsed.flags = { cardName, cardSet, ...options };
+        });
+
+    collectionCommand
+        .command("remove")
+        .description("Delete a collection entry outright")
+        .argument("<cardName>")
+        .argument("<cardSet>")
+        .option(
+            "--storage-adapter <adapter>",
+            `Storage adapter to use (${KNOWN_STORAGE_ADAPTERS.join("|")})`
+        )
+        .option("--config <path>", "Path to a JSON config file")
+        .action((cardName, cardSet, options) => {
+            parsed.command = "collection-remove";
+            parsed.flags = { cardName, cardSet, ...options };
+        });
+
     program.addHelpText(
         "after",
         `
@@ -102,6 +137,8 @@ Examples:
   $ log stats
   $ migrate --to rds --dry-run
   $ migrate --to rds
+  $ collection update "Pacifism" M20 --quantity 3
+  $ collection remove "Pacifism" M20
 `
     );
 
@@ -248,6 +285,45 @@ async function runMigrate(flags, logger, migrateFn) {
     }
 }
 
+async function runCollectionUpdate(flags, logger) {
+    const err = applyConfigOverrides(flags, logger);
+    if (err) {
+        return 1;
+    }
+    const quantity = Number(flags.quantity);
+    if (!Number.isFinite(quantity) || quantity < 0) {
+        logger.log(`--quantity must be a non-negative number, got "${flags.quantity}"`);
+        return 1;
+    }
+    try {
+        const doc = await storage.collection.setQuantity(flags.cardName, flags.cardSet, quantity);
+        logger.log(JSON.stringify(doc, null, 2));
+        return 0;
+    } catch (updateErr) {
+        logger.log(updateErr?.message || String(updateErr));
+        return 1;
+    }
+}
+
+async function runCollectionRemove(flags, logger) {
+    const err = applyConfigOverrides(flags, logger);
+    if (err) {
+        return 1;
+    }
+    try {
+        const removed = await storage.collection.remove(flags.cardName, flags.cardSet);
+        if (!removed) {
+            logger.log(`No collection entry for "${flags.cardName}" (${flags.cardSet})`);
+            return 1;
+        }
+        logger.log(JSON.stringify(removed, null, 2));
+        return 0;
+    } catch (removeErr) {
+        logger.log(removeErr?.message || String(removeErr));
+        return 1;
+    }
+}
+
 export async function run(options = {}) {
     const {
         argv = process.argv.slice(2),
@@ -262,7 +338,7 @@ export async function run(options = {}) {
     // Bare filepath args ("node index.mjs ./card.jpg") implicitly mean `scan` for backward
     // compatibility. Empty argv, --help/-h, and known commands must NOT get that prefix --
     // otherwise `node index.mjs --help` silently becomes `scan --help` and the top-level
-    // help (which lists `log`/`migrate` at all) never shows.
+    // help (which lists `log`/`migrate`/`collection` at all) never shows.
     const shouldPrefixScan =
         argv.length > 0 && !KNOWN_COMMANDS.includes(argv[0]) && !HELP_TOKENS.includes(argv[0]);
     const normalizedArgv = shouldPrefixScan ? ["scan", ...argv] : argv;
@@ -287,6 +363,16 @@ export async function run(options = {}) {
 
     if (cli.command === "migrate") {
         exit(await runMigrate(flags, logger, migrateFn));
+        return;
+    }
+
+    if (cli.command === "collection-update") {
+        exit(await runCollectionUpdate(flags, logger));
+        return;
+    }
+
+    if (cli.command === "collection-remove") {
+        exit(await runCollectionRemove(flags, logger));
         return;
     }
 

--- a/src/db-local/collection-store.mjs
+++ b/src/db-local/collection-store.mjs
@@ -112,10 +112,71 @@ function GetAll(cb) {
     });
 }
 
-export { GetQuantity, Upsert, GetAll };
+// Manual correction -- sets quantity to an exact value instead of adding to it (unlike
+// Upsert, which is what scans call). Errors if the entry doesn't exist; use a scan (or
+// Upsert directly) to create one. estValue is rescaled proportionally from the existing
+// per-unit value when possible (we don't persist priceUsd itself, only the last computed
+// estValue), otherwise left as-is rather than guessing.
+function SetQuantity(name, set, quantity, cb) {
+    const db = getDbInstance();
+    const lookupKey = toLookupKey(name, set);
+
+    db.findOne({ lookupKey }, (findErr, existing) => {
+        if (findErr) {
+            return cb(findErr, null);
+        }
+        if (!existing) {
+            return cb(new Error(`No collection entry for "${name}" (${set})`), null);
+        }
+
+        const estValue =
+            typeof existing.estValue === "number" && existing.quantity > 0
+                ? _.round((existing.estValue / existing.quantity) * quantity, 4)
+                : existing.estValue;
+        const now = new Date();
+
+        return db.update(
+            { lookupKey },
+            { $set: { quantity, estValue, updatedAt: now } },
+            {},
+            (updateErr) => {
+                if (updateErr) {
+                    return cb(updateErr, null);
+                }
+                return cb(null, { ...existing, quantity, estValue, updatedAt: now });
+            }
+        );
+    });
+}
+
+// Deletes a collection entry outright. Returns the removed doc (or null if nothing matched)
+// so callers can report what was actually removed.
+function Remove(name, set, cb) {
+    const db = getDbInstance();
+    const lookupKey = toLookupKey(name, set);
+
+    db.findOne({ lookupKey }, (findErr, existing) => {
+        if (findErr) {
+            return cb(findErr, null);
+        }
+        if (!existing) {
+            return cb(null, null);
+        }
+        return db.remove({ lookupKey }, {}, (removeErr) => {
+            if (removeErr) {
+                return cb(removeErr, null);
+            }
+            return cb(null, existing);
+        });
+    });
+}
+
+export { GetQuantity, Upsert, GetAll, SetQuantity, Remove };
 
 export default {
     GetQuantity,
     Upsert,
-    GetAll
+    GetAll,
+    SetQuantity,
+    Remove
 };

--- a/src/rds/collection.mjs
+++ b/src/rds/collection.mjs
@@ -99,10 +99,89 @@ function UpsertRecord(record, cb) {
     });
 }
 
-export { GetQuantity, InsertRecord, UpsertRecord };
+// Manual correction -- sets quantity to an exact value instead of adding to it. Errors if the
+// entry doesn't exist (affectedRows is a reliable existence check regardless of whether the
+// new value happens to equal the old one, unlike changedRows). estValue is rescaled
+// proportionally from the existing per-unit value when possible.
+//
+// The estValue expression MUST be assigned before quantity in the SET list: MySQL evaluates
+// UPDATE's SET list left-to-right, and a column already assigned earlier is read at its NEW
+// value by later expressions in the same statement -- same rule that bit UpsertRecord's
+// estValue expression. Verified against a real MySQL 8 instance: reversing this order silently
+// computes a no-op ratio instead of the intended rescale.
+function SetQuantity(name, set, quantity, cb) {
+    const connection = CreateConnection();
+    connection.connect((err) => {
+        if (err) {
+            return cb(err, null);
+        }
+        connection.query(
+            `UPDATE CardCollection
+             SET estValue = CASE WHEN quantity > 0 THEN ROUND((estValue / quantity) * ?, 4) ELSE estValue END,
+                 quantity = ?
+             WHERE cardName = ? AND cardSet = ?`,
+            [quantity, quantity, name, set],
+            (err, results) => {
+                if (err) {
+                    logger.error(err);
+                    return cb(err, null);
+                }
+                connection.end();
+                if (!results.affectedRows) {
+                    return cb(new Error(`No collection entry for "${name}" (${set})`), null);
+                }
+                return cb(null, results);
+            }
+        );
+    });
+}
+
+// Deletes a collection entry outright. Returns the removed row (or null if nothing matched)
+// so callers can report what was actually removed.
+function DeleteRecord(name, set, cb) {
+    const connection = CreateConnection();
+    connection.connect((err) => {
+        if (err) {
+            return cb(err, null);
+        }
+        connection.query(
+            `SELECT cardName, cardType, cardSet, quantity, estValue, automated, magicId, imageUrl
+             FROM CardCollection WHERE cardName = ? AND cardSet = ? LIMIT 1`,
+            [name, set],
+            (selectErr, rows) => {
+                if (selectErr) {
+                    logger.error(selectErr);
+                    connection.end();
+                    return cb(selectErr, null);
+                }
+                const existing = rows && rows[0];
+                if (!existing) {
+                    connection.end();
+                    return cb(null, null);
+                }
+                connection.query(
+                    "DELETE FROM CardCollection WHERE cardName = ? AND cardSet = ?",
+                    [name, set],
+                    (deleteErr) => {
+                        connection.end();
+                        if (deleteErr) {
+                            logger.error(deleteErr);
+                            return cb(deleteErr, null);
+                        }
+                        return cb(null, existing);
+                    }
+                );
+            }
+        );
+    });
+}
+
+export { GetQuantity, InsertRecord, UpsertRecord, SetQuantity, DeleteRecord };
 
 export default {
     GetQuantity,
     InsertRecord,
-    UpsertRecord
+    UpsertRecord,
+    SetQuantity,
+    DeleteRecord
 };

--- a/src/storage/adapters/nedb-adapter.mjs
+++ b/src/storage/adapters/nedb-adapter.mjs
@@ -28,6 +28,28 @@ function upsertCollection(record) {
     });
 }
 
+function setQuantity(name, set, quantity) {
+    return new Promise((resolve, reject) => {
+        collectionStore.SetQuantity(name, set, quantity, (err, doc) => {
+            if (err) {
+                return reject(err);
+            }
+            return resolve(doc);
+        });
+    });
+}
+
+function removeCollection(name, set) {
+    return new Promise((resolve, reject) => {
+        collectionStore.Remove(name, set, (err, doc) => {
+            if (err) {
+                return reject(err);
+            }
+            return resolve(doc);
+        });
+    });
+}
+
 function insertNeedsAttention(record) {
     return new Promise((resolve, reject) => {
         needsAttentionStore.Insert(record, (err, doc) => {
@@ -44,7 +66,9 @@ function createNedbAdapter() {
         adapterName: "nedb",
         collection: {
             getQuantity,
-            upsert: upsertCollection
+            upsert: upsertCollection,
+            setQuantity,
+            remove: removeCollection
         },
         needsAttention: {
             insert: insertNeedsAttention

--- a/src/storage/adapters/rds-adapter.mjs
+++ b/src/storage/adapters/rds-adapter.mjs
@@ -27,6 +27,28 @@ function upsertCollection(record) {
     });
 }
 
+function setQuantity(name, set, quantity) {
+    return new Promise((resolve, reject) => {
+        rds.Collection.SetQuantity(name, set, quantity, (err, results) => {
+            if (err) {
+                return reject(err);
+            }
+            return resolve(results);
+        });
+    });
+}
+
+function removeCollection(name, set) {
+    return new Promise((resolve, reject) => {
+        rds.Collection.DeleteRecord(name, set, (err, results) => {
+            if (err) {
+                return reject(err);
+            }
+            return resolve(results);
+        });
+    });
+}
+
 function insertNeedsAttention(record) {
     return new Promise((resolve, reject) => {
         rds.NDAttn.InsertRecord(record, (err, results) => {
@@ -43,7 +65,9 @@ function createRdsAdapter() {
         adapterName: "rds",
         collection: {
             getQuantity,
-            upsert: upsertCollection
+            upsert: upsertCollection,
+            setQuantity,
+            remove: removeCollection
         },
         needsAttention: {
             insert: insertNeedsAttention

--- a/src/storage/index.mjs
+++ b/src/storage/index.mjs
@@ -95,7 +95,9 @@ const storage = {
     // Persistence tier -- STORAGE_ADAPTER-selected (nedb | rds).
     collection: {
         getQuantity: (...args) => getAdapter().collection.getQuantity(...args),
-        upsert: (...args) => getAdapter().collection.upsert(...args)
+        upsert: (...args) => getAdapter().collection.upsert(...args),
+        setQuantity: (...args) => getAdapter().collection.setQuantity(...args),
+        remove: (...args) => getAdapter().collection.remove(...args)
     },
     needsAttention: {
         insert: (...args) => getAdapter().needsAttention.insert(...args)

--- a/test/db-local/collection-store.spec.mjs
+++ b/test/db-local/collection-store.spec.mjs
@@ -134,4 +134,70 @@ describe("db-local::collection-store", () => {
             assert.deepEqual(all, []);
         });
     });
+
+    describe("SetQuantity", () => {
+        it("overwrites quantity and rescales estValue proportionally", async () => {
+            const store = await freshStore();
+            const record = { cardName: "Pacifism", cardSet: "M20", priceUsd: 2.5 };
+            await new Promise((resolve, reject) => {
+                store.Upsert(record, (err, d) => (err ? reject(err) : resolve(d)));
+            });
+            await new Promise((resolve, reject) => {
+                store.Upsert(record, (err, d) => (err ? reject(err) : resolve(d)));
+            }); // quantity=2, estValue=5
+
+            const updated = await new Promise((resolve, reject) => {
+                store.SetQuantity("Pacifism", "M20", 10, (err, d) =>
+                    err ? reject(err) : resolve(d)
+                );
+            });
+            assert.equal(updated.quantity, 10);
+            assert.equal(updated.estValue, 25, "(5/2)*10 = 25");
+        });
+
+        it("errors on a card/set that doesn't exist -- won't silently create one", async () => {
+            const store = await freshStore();
+            let caught;
+            try {
+                await new Promise((resolve, reject) => {
+                    store.SetQuantity("Nonexistent", "XYZ", 5, (err, d) =>
+                        err ? reject(err) : resolve(d)
+                    );
+                });
+            } catch (err) {
+                caught = err;
+            }
+            assert.instanceOf(caught, Error);
+            assert.match(caught.message, /No collection entry/);
+        });
+    });
+
+    describe("Remove", () => {
+        it("deletes the entry and returns the removed doc", async () => {
+            const store = await freshStore();
+            await new Promise((resolve, reject) => {
+                store.Upsert({ cardName: "Pacifism", cardSet: "M20" }, (err, d) =>
+                    err ? reject(err) : resolve(d)
+                );
+            });
+
+            const removed = await new Promise((resolve, reject) => {
+                store.Remove("Pacifism", "M20", (err, d) => (err ? reject(err) : resolve(d)));
+            });
+            assert.equal(removed.cardName, "Pacifism");
+
+            const qty = await new Promise((resolve, reject) => {
+                store.GetQuantity("Pacifism", "M20", (err, q) => (err ? reject(err) : resolve(q)));
+            });
+            assert.equal(qty, 0);
+        });
+
+        it("returns null (no error) when nothing matches", async () => {
+            const store = await freshStore();
+            const removed = await new Promise((resolve, reject) => {
+                store.Remove("Nonexistent", "XYZ", (err, d) => (err ? reject(err) : resolve(d)));
+            });
+            assert.isNull(removed);
+        });
+    });
 });

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -276,6 +276,87 @@ describe("CLI::index.mjs", () => {
             assert.isTrue(processExitStub.calledWith(1));
         });
     });
+
+    describe("collection subcommands", () => {
+        it("collection update sets quantity and exits 0", async () => {
+            const setQuantityStub = sandbox
+                .stub(storage.collection, "setQuantity")
+                .resolves({ cardName: "Pacifism", quantity: 5 });
+
+            await runCli({
+                command: "collection-update",
+                flags: { cardName: "Pacifism", cardSet: "M20", quantity: "5" }
+            });
+
+            assert.isTrue(setQuantityStub.calledOnceWith("Pacifism", "M20", 5));
+            assert.isTrue(processExitStub.calledWith(0));
+        });
+
+        it("collection update rejects a non-numeric --quantity without calling storage", async () => {
+            const setQuantityStub = sandbox.stub(storage.collection, "setQuantity");
+
+            await runCli({
+                command: "collection-update",
+                flags: { cardName: "Pacifism", cardSet: "M20", quantity: "notanumber" }
+            });
+
+            assert.isFalse(setQuantityStub.called);
+            assert.isTrue(consoleLogStub.calledWithMatch(sinon.match(/--quantity must be/)));
+            assert.isTrue(processExitStub.calledWith(1));
+        });
+
+        it("collection update rejects a negative --quantity without calling storage", async () => {
+            const setQuantityStub = sandbox.stub(storage.collection, "setQuantity");
+
+            await runCli({
+                command: "collection-update",
+                flags: { cardName: "Pacifism", cardSet: "M20", quantity: "-1" }
+            });
+
+            assert.isFalse(setQuantityStub.called);
+            assert.isTrue(processExitStub.calledWith(1));
+        });
+
+        it("collection update exits 1 with the error message when the entry doesn't exist", async () => {
+            sandbox
+                .stub(storage.collection, "setQuantity")
+                .rejects(new Error("No collection entry"));
+
+            await runCli({
+                command: "collection-update",
+                flags: { cardName: "Nonexistent", cardSet: "XYZ", quantity: "5" }
+            });
+
+            assert.isTrue(consoleLogStub.calledWithMatch(sinon.match(/No collection entry/)));
+            assert.isTrue(processExitStub.calledWith(1));
+        });
+
+        it("collection remove deletes the entry and exits 0", async () => {
+            const removeStub = sandbox
+                .stub(storage.collection, "remove")
+                .resolves({ cardName: "Pacifism", cardSet: "M20" });
+
+            await runCli({
+                command: "collection-remove",
+                flags: { cardName: "Pacifism", cardSet: "M20" }
+            });
+
+            assert.isTrue(removeStub.calledOnceWith("Pacifism", "M20"));
+            assert.isTrue(processExitStub.calledWith(0));
+        });
+
+        it("collection remove exits 1 when nothing matched", async () => {
+            sandbox.stub(storage.collection, "remove").resolves(null);
+
+            await runCli({
+                command: "collection-remove",
+                flags: { cardName: "Nonexistent", cardSet: "XYZ" }
+            });
+
+            assert.isTrue(consoleLogStub.calledWithMatch(sinon.match(/No collection entry/)));
+            assert.isTrue(processExitStub.calledWith(1));
+        });
+    });
 });
 
 describe("CLI::index.mjs buildCli (real commander wiring)", () => {
@@ -332,6 +413,26 @@ describe("CLI::index.mjs buildCli (real commander wiring)", () => {
 
     it("does not throw when `migrate` is missing --to", () => {
         const parsed = buildCli(["migrate"]);
+        assert.equal(parsed.helpRequested, true);
+    });
+
+    it("parses `collection update <name> <set> --quantity 3`", () => {
+        const parsed = buildCli(["collection", "update", "Pacifism", "M20", "--quantity", "3"]);
+        assert.equal(parsed.command, "collection-update");
+        assert.equal(parsed.flags.cardName, "Pacifism");
+        assert.equal(parsed.flags.cardSet, "M20");
+        assert.equal(parsed.flags.quantity, "3");
+    });
+
+    it("parses `collection remove <name> <set>`", () => {
+        const parsed = buildCli(["collection", "remove", "Pacifism", "M20"]);
+        assert.equal(parsed.command, "collection-remove");
+        assert.equal(parsed.flags.cardName, "Pacifism");
+        assert.equal(parsed.flags.cardSet, "M20");
+    });
+
+    it("does not throw when `collection update` is missing --quantity", () => {
+        const parsed = buildCli(["collection", "update", "Pacifism", "M20"]);
         assert.equal(parsed.helpRequested, true);
     });
 });

--- a/test/rds/collection.spec.mjs
+++ b/test/rds/collection.spec.mjs
@@ -1,7 +1,13 @@
 import { assert } from "chai";
 import sinon from "sinon";
 import mysql from "mysql2";
-import { GetQuantity, InsertRecord, UpsertRecord } from "../../src/rds/collection.mjs";
+import {
+    GetQuantity,
+    InsertRecord,
+    UpsertRecord,
+    SetQuantity,
+    DeleteRecord
+} from "../../src/rds/collection.mjs";
 
 describe("rds::collection", () => {
     let sandbox;
@@ -112,5 +118,68 @@ describe("rds::collection", () => {
                 done();
             }
         );
+    });
+
+    describe("SetQuantity", () => {
+        it("assigns estValue before quantity in the SET list (order matters -- see comment in source)", (done) => {
+            fakeConnection.query.callsFake((sql, params, cb) => cb(null, { affectedRows: 1 }));
+
+            SetQuantity("Urza's Tower", "M20", 10, (err) => {
+                assert.isNull(err);
+                const [sql, params] = fakeConnection.query.firstCall.args;
+                assert.notInclude(sql, "Urza's Tower");
+                const estValueIdx = sql.indexOf("estValue =");
+                const quantityIdx = sql.indexOf("quantity = ?");
+                assert.isBelow(
+                    estValueIdx,
+                    quantityIdx,
+                    "estValue must be assigned before quantity or it reads the already-updated value"
+                );
+                assert.deepEqual(params, [10, 10, "Urza's Tower", "M20"]);
+                done();
+            });
+        });
+
+        it("errors when no row matched (affectedRows === 0)", (done) => {
+            fakeConnection.query.callsFake((sql, params, cb) => cb(null, { affectedRows: 0 }));
+
+            SetQuantity("Nonexistent", "XYZ", 5, (err) => {
+                assert.instanceOf(err, Error);
+                assert.match(err.message, /No collection entry/);
+                done();
+            });
+        });
+    });
+
+    describe("DeleteRecord", () => {
+        it("selects with explicit camelCase aliases (not SELECT *, which returns PascalCase column names)", (done) => {
+            const row = { cardName: "Urza's Tower", cardSet: "M20", quantity: 2 };
+            fakeConnection.query.onFirstCall().callsFake((sql, params, cb) => cb(null, [row]));
+            fakeConnection.query.onSecondCall().callsFake((sql, params, cb) => cb(null, {}));
+
+            DeleteRecord("Urza's Tower", "M20", (err, removed) => {
+                assert.isNull(err);
+                assert.deepEqual(removed, row);
+                const [selectSql] = fakeConnection.query.firstCall.args;
+                assert.notMatch(selectSql, /SELECT \*/);
+                const [deleteSql] = fakeConnection.query.secondCall.args;
+                assert.match(deleteSql, /^DELETE FROM CardCollection/);
+                done();
+            });
+        });
+
+        it("returns null (no error) when nothing matches", (done) => {
+            fakeConnection.query.callsFake((sql, params, cb) => cb(null, []));
+
+            DeleteRecord("Nonexistent", "XYZ", (err, removed) => {
+                assert.isNull(err);
+                assert.isNull(removed);
+                assert.isTrue(
+                    fakeConnection.query.calledOnce,
+                    "should not issue a DELETE when nothing was found"
+                );
+                done();
+            });
+        });
     });
 });

--- a/test/storage/adapters/collection-edit-delete.spec.mjs
+++ b/test/storage/adapters/collection-edit-delete.spec.mjs
@@ -1,0 +1,100 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import collectionStore from "../../../src/db-local/collection-store.mjs";
+import rds from "../../../src/rds/index.mjs";
+import { createNedbAdapter } from "../../../src/storage/adapters/nedb-adapter.mjs";
+import { createRdsAdapter } from "../../../src/storage/adapters/rds-adapter.mjs";
+
+// Covers just the new setQuantity/remove methods on both adapters -- the rest of each
+// adapter's surface (getQuantity/upsert/needsAttention.insert) is covered separately.
+describe("storage/adapters::collection edit/delete", () => {
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe("nedb adapter", () => {
+        const adapter = createNedbAdapter();
+
+        it("collection.setQuantity delegates to collectionStore.SetQuantity", async () => {
+            const stub = sandbox
+                .stub(collectionStore, "SetQuantity")
+                .callsFake((name, set, qty, cb) => cb(null, { quantity: qty }));
+
+            const result = await adapter.collection.setQuantity("Pacifism", "M20", 5);
+
+            assert.deepEqual(result, { quantity: 5 });
+            assert.isTrue(stub.calledOnceWith("Pacifism", "M20", 5));
+        });
+
+        it("collection.setQuantity rejects on error", async () => {
+            sandbox
+                .stub(collectionStore, "SetQuantity")
+                .callsFake((name, set, qty, cb) => cb(new Error("not found")));
+
+            let caught;
+            try {
+                await adapter.collection.setQuantity("Nonexistent", "XYZ", 5);
+            } catch (err) {
+                caught = err;
+            }
+            assert.instanceOf(caught, Error);
+        });
+
+        it("collection.remove delegates to collectionStore.Remove", async () => {
+            const stub = sandbox
+                .stub(collectionStore, "Remove")
+                .callsFake((name, set, cb) => cb(null, { cardName: name }));
+
+            const result = await adapter.collection.remove("Pacifism", "M20");
+
+            assert.deepEqual(result, { cardName: "Pacifism" });
+            assert.isTrue(stub.calledOnceWith("Pacifism", "M20"));
+        });
+    });
+
+    describe("rds adapter", () => {
+        const adapter = createRdsAdapter();
+
+        it("collection.setQuantity delegates to rds.Collection.SetQuantity", async () => {
+            const stub = sandbox
+                .stub(rds.Collection, "SetQuantity")
+                .callsFake((name, set, qty, cb) => cb(null, { affectedRows: 1 }));
+
+            const result = await adapter.collection.setQuantity("Pacifism", "M20", 5);
+
+            assert.deepEqual(result, { affectedRows: 1 });
+            assert.isTrue(stub.calledOnceWith("Pacifism", "M20", 5));
+        });
+
+        it("collection.setQuantity rejects on error", async () => {
+            sandbox
+                .stub(rds.Collection, "SetQuantity")
+                .callsFake((name, set, qty, cb) => cb(new Error("not found")));
+
+            let caught;
+            try {
+                await adapter.collection.setQuantity("Nonexistent", "XYZ", 5);
+            } catch (err) {
+                caught = err;
+            }
+            assert.instanceOf(caught, Error);
+        });
+
+        it("collection.remove delegates to rds.Collection.DeleteRecord", async () => {
+            const stub = sandbox
+                .stub(rds.Collection, "DeleteRecord")
+                .callsFake((name, set, cb) => cb(null, { cardName: name }));
+
+            const result = await adapter.collection.remove("Pacifism", "M20");
+
+            assert.deepEqual(result, { cardName: "Pacifism" });
+            assert.isTrue(stub.calledOnceWith("Pacifism", "M20"));
+        });
+    });
+});


### PR DESCRIPTION
## Summary

#3 from the persistence-area follow-up list. Scanning can only add to a collection entry's quantity; there was no way to fix a wrong entry or remove one without editing the db file/table by hand.

- `node index.mjs collection update <cardName> <cardSet> --quantity <n>` — sets quantity to an exact value (unlike scans, which add). `estValue` is rescaled proportionally from the existing per-unit value. Errors if the entry doesn't exist rather than silently creating one.
- `node index.mjs collection remove <cardName> <cardSet>` — deletes an entry outright. Permanent, no confirmation prompt.

Both go through the same `STORAGE_ADAPTER`-selected persistence tier as everything else (`nedb` default, `rds` opt-in).

## Bugs found via testing against a live MySQL 8 container

Same class as what Phase 2 caught — real bugs, not mocked away:

- MySQL's left-to-right `SET`-list evaluation (already known from `UpsertRecord`'s `estValue` expression) applies to plain `UPDATE` too, not just `ON DUPLICATE KEY UPDATE`. `SetQuantity`'s first draft assigned `quantity` before `estValue`, so the `estValue` expression read the already-updated (new) quantity instead of the old one — silently computed a no-op ratio. Verified the bug and the fix against real MySQL by resetting state between each attempt (my first "confirmation" was accidentally testing against already-mutated state — caught that too before trusting the result).
- `DeleteRecord`'s `SELECT *` returned PascalCase column names (`CardName`, not `cardName`) — inconsistent with the rest of the app's camelCase convention and with what the nedb-backed `Remove` returns. Fixed with explicit column aliases.

## Note on #163

This branch predates #163 (CLI crash fix) merging, and the new `--quantity` required option reproduced the exact same crash the moment it existed — so I reapplied that fix directly here too. Should dedupe cleanly on rebase once #163 merges.

## Testing

- `pnpm check` — green, 127 passing (was 104 on this branch's base)
- 23 new tests: store-level (both backends), adapter-level, CLI-level (including real `buildCli` parsing)
- Coverage on touched files: `collection-store.mjs` 90%, `rds/collection.mjs` 84%, `index.mjs` 91.6%
- Manually verified end-to-end against real nedb (update/remove happy path + not-found errors) and real MySQL (`SetQuantity` math, `DeleteRecord` casing) before writing this up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
