### PR TITLE
feat: add Scryfall regression fixture importer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -209,6 +209,24 @@ Fixture labels, expected card data, and offline print references live in
 quality labels, and fixture workflow. Newly scaffolded images stay disabled until their
 `CHANGE_ME` values are labeled and both manifest entries are enabled.
 
+Import new clean-scan candidates from Scryfall by set code or release-date range:
+
+```bash
+# Preview six unused prints from two sets
+pnpm fixtures:import --set fin --set dsk --count 6 --dry-run
+
+# Download ten unused prints and append disabled review entries
+pnpm fixtures:import \
+    --released-after 2025-01-01 \
+    --released-before 2025-06-30 \
+    --count 10
+```
+
+The target manifest is automatically used to exclude existing printings. Add repeatable
+`--existing-manifest <path>` options to exclude catalogs from other checkouts or suites. See the
+[regression fixture import workflow](docs/regression-testing.md#import-clean-scans-from-scryfall)
+for review, activation, and safety details.
+
 ### Quality Commands
 
 ```bash

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -166,6 +166,54 @@ become available.
 
 ## Add a fixture
 
+### Import clean scans from Scryfall
+
+Use the importer to select recent card prints, download Scryfall's normal front JPEG, and append
+matching catalog and clean-scan case entries:
+
+```bash
+# Preview newest prints from several sets without writing files
+pnpm fixtures:import --set fin --set dsk --count 6 --dry-run
+
+# Import prints whose sets were released in a date range
+pnpm fixtures:import \
+    --released-after 2025-01-01 \
+    --released-before 2025-06-30 \
+    --count 10
+
+# Exclude prints tracked by another regression manifest too
+pnpm fixtures:import \
+    --set fin \
+    --count 5 \
+    --existing-manifest ../other-checkout/test/regression/fixtures/manifest.json
+```
+
+Choose either one or more `--set` values or release-date bounds. Set values may be repeated or
+comma-separated. Results use unique printings, newest first. The target manifest's catalog is
+always used as the existing-card list; each repeatable `--existing-manifest` adds another catalog
+to that exclusion set. Prints match by Scryfall ID when available and by set plus collector number,
+so older manifest entries without an ID are still excluded.
+
+The command writes images under `test-images/regression/scryfall/` and atomically updates
+`test/regression/fixtures/manifest.json`. Imported catalog and case entries are disabled to preserve
+the review-first fixture policy. To finish an import:
+
+1. Review the downloaded image and Scryfall metadata.
+2. Find the new entries with
+   `rg -n "Imported from Scryfall" test/regression/fixtures/manifest.json`.
+3. Set both the catalog and case `enabled` fields to `true`.
+4. Run the new case by ID and inspect both benchmark reports.
+5. Adjust thresholds from repeated evidence, then run the full unit and regression gates.
+
+The importer accepts at most 100 cards per run, follows at most 20 result pages by default, stops
+as soon as enough unused printable cards are found, spaces API page requests by 125 ms, and rejects
+oversized or non-JPEG downloads. Use `--max-pages` only when a selection contains many already
+tracked or multi-face prints. Scryfall asks API clients to stay below 10 requests per second and to
+send identifying request headers; see their
+[API access guidance](https://scryfall.com/docs/faqs/i-m-having-trouble-accessing-the-scryfall-api-or-i-m-blocked-17).
+
+### Add a captured image manually
+
 1. Put the original image in the root-level `test-images/` directory.
 2. Find the matching disabled catalog and case entries by searching for `CHANGE_ME`:
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "ai:setup": "node scripts/setup-ai-context.mjs",
         "test": "mocha \"./test/**/*.spec.mjs\"",
         "test:regression": "node scripts/run-regression.mjs",
+        "fixtures:import": "node scripts/import-scryfall-fixtures.mjs",
         "regression": "node scripts/run-regression.mjs --no-fail-on-regression",
         "coverage": "c8 pnpm test",
         "coverage:check": "c8 --check-coverage pnpm test",

--- a/scripts/import-scryfall-fixtures.mjs
+++ b/scripts/import-scryfall-fixtures.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Command } from "commander";
+import { importScryfallFixtures } from "../src/regression/scryfall-fixture-importer.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const defaultManifest = path.join(repositoryRoot, "test/regression/fixtures/manifest.json");
+const defaultImageDirectory = path.join(repositoryRoot, "test-images/regression/scryfall");
+
+function collect(value, previous) {
+    return previous.concat(value);
+}
+
+function buildProgram() {
+    return new Command()
+        .name("mtg-import-scryfall-fixtures")
+        .description("Download Scryfall card prints and add OCR regression fixtures")
+        .option(
+            "-s, --set <code>",
+            "Scryfall set code (repeatable or comma-separated)",
+            collect,
+            []
+        )
+        .option("--released-after <date>", "include prints released on or after YYYY-MM-DD")
+        .option("--released-before <date>", "include prints released on or before YYYY-MM-DD")
+        .requiredOption("-n, --count <number>", "number of new card-print fixtures")
+        .option("-m, --manifest <path>", "target regression manifest", defaultManifest)
+        .option(
+            "-i, --image-directory <path>",
+            "downloaded fixture directory",
+            defaultImageDirectory
+        )
+        .option(
+            "--existing-manifest <path>",
+            "additional manifest whose prints must be excluded (repeatable)",
+            collect,
+            []
+        )
+        .option("--max-pages <number>", "maximum Scryfall result pages", "20")
+        .option("--dry-run", "show selected prints without writing images or manifest", false);
+}
+
+async function main(argv = process.argv, overrides = {}) {
+    const options = buildProgram().parse(argv).opts();
+    const importer = overrides.importer || importScryfallFixtures;
+    const writeLine = overrides.writeLine || console.log;
+    const result = await importer({
+        manifestPath: options.manifest,
+        imageDirectory: options.imageDirectory,
+        existingManifestPaths: options.existingManifest,
+        sets: options.set,
+        releasedAfter: options.releasedAfter,
+        releasedBefore: options.releasedBefore,
+        count: options.count,
+        maxPages: options.maxPages,
+        dryRun: options.dryRun
+    });
+
+    writeLine(`${result.dryRun ? "Would import" : "Imported"} ${result.added.length} fixture(s):`);
+    for (const card of result.added) {
+        writeLine(`- ${card.set}/${card.collectorNumber} ${card.name}`);
+    }
+    writeLine(`Excluded existing prints: ${result.excludedExisting}`);
+    writeLine(`Skipped cards without usable front JPEGs: ${result.skippedUnprintable}`);
+    if (!result.dryRun) {
+        writeLine("Fixtures disabled pending OCR result and threshold review.");
+    }
+    return result;
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error(error?.stack || error);
+        process.exitCode = 1;
+    });
+}
+
+export { buildProgram, main };

--- a/src/regression/scryfall-fixture-importer.mjs
+++ b/src/regression/scryfall-fixture-importer.mjs
@@ -5,8 +5,16 @@ const SCRYFALL_API_ORIGIN = "https://api.scryfall.com";
 const DEFAULT_MAX_PAGES = 20;
 const MAX_COUNT = 100;
 const MAX_PAGES = 100;
+const REQUEST_DELAY_MS = 125;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_API_RESPONSE_BYTES = 12 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 6 * 1024 * 1024;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const SET_CODE_PATTERN = /^[a-z0-9]{2,6}$/i;
+const REQUEST_HEADERS = {
+    "User-Agent": "MTG-Card-Analyzer/0.2 (+https://github.com/dills122/MTG-Card-Analyzer)",
+    Accept: "application/json"
+};
 
 function parsePositiveInteger(value, label, maximum) {
     const number = Number(value);
@@ -82,6 +90,131 @@ function buildCardSearchUrl(options) {
     url.searchParams.set("order", "released");
     url.searchParams.set("dir", "desc");
     return url.href;
+}
+
+function trustedUrl(value, expectedOrigin, label) {
+    let url;
+    try {
+        url = new URL(value);
+    } catch {
+        throw new Error(`Invalid ${label} URL`);
+    }
+    if (url.protocol !== "https:" || url.origin !== expectedOrigin) {
+        throw new Error(`Untrusted ${label} URL: ${url.origin}`);
+    }
+    return url;
+}
+
+async function readBoundedBody(response, maximumBytes, label) {
+    const contentLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > maximumBytes) {
+        throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+    }
+    if (!response.body) throw new Error(`${label} response body is empty`);
+
+    const chunks = [];
+    let total = 0;
+    const reader = response.body.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            total += value.byteLength;
+            if (total > maximumBytes) {
+                await reader.cancel();
+                throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+            }
+            chunks.push(value);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return bytes;
+}
+
+async function request(url, options = {}) {
+    const fetchImpl = options.fetchImpl || globalThis.fetch;
+    const response = await fetchImpl(url, {
+        headers: options.headers,
+        redirect: "error",
+        signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
+    });
+    if (!response.ok) {
+        throw new Error(`Scryfall request failed with HTTP ${response.status}`);
+    }
+    return response;
+}
+
+async function fetchCardPages(searchUrl, options = {}) {
+    const maxPages = parsePositiveInteger(
+        options.maxPages ?? DEFAULT_MAX_PAGES,
+        "max-pages",
+        MAX_PAGES
+    );
+    const wait =
+        options.wait ||
+        ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    const cards = [];
+    let nextUrl = trustedUrl(searchUrl, SCRYFALL_API_ORIGIN, "Scryfall API").href;
+
+    for (let page = 0; page < maxPages && nextUrl; page += 1) {
+        if (page > 0) await wait(REQUEST_DELAY_MS);
+        const response = await request(nextUrl, {
+            fetchImpl: options.fetchImpl,
+            headers: REQUEST_HEADERS
+        });
+        const contentType = response.headers.get("content-type") || "";
+        if (!contentType.toLowerCase().includes("application/json")) {
+            throw new Error("Expected JSON response from Scryfall API");
+        }
+        const bytes = await readBoundedBody(
+            response,
+            MAX_API_RESPONSE_BYTES,
+            "Scryfall API response"
+        );
+        let pageData;
+        try {
+            pageData = JSON.parse(new TextDecoder().decode(bytes));
+        } catch (error) {
+            throw new Error("Scryfall API returned invalid JSON", { cause: error });
+        }
+        if (pageData?.object !== "list" || !Array.isArray(pageData.data)) {
+            throw new Error("Scryfall API response is not a card list");
+        }
+        cards.push(...pageData.data);
+        nextUrl = pageData.has_more
+            ? trustedUrl(pageData.next_page, SCRYFALL_API_ORIGIN, "Scryfall API").href
+            : undefined;
+    }
+    return cards;
+}
+
+async function downloadImage(imageUrl, destination, options = {}) {
+    const trustedImage = imageUrlForCard({ image_uris: { normal: imageUrl } });
+    if (!trustedImage) throw new Error("Untrusted Scryfall image URL");
+    const response = await request(trustedImage, {
+        fetchImpl: options.fetchImpl,
+        headers: {
+            ...REQUEST_HEADERS,
+            Accept: "image/jpeg"
+        }
+    });
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.toLowerCase().startsWith("image/jpeg")) {
+        throw new Error("Expected JPEG image from Scryfall");
+    }
+    const bytes = await readBoundedBody(response, MAX_IMAGE_BYTES, "Scryfall image");
+    if (bytes.length < 3 || bytes[0] !== 0xff || bytes[1] !== 0xd8 || bytes[2] !== 0xff) {
+        throw new Error("Scryfall download is not a valid JPEG image");
+    }
+    await writeFile(destination, bytes, { flag: "wx" });
 }
 
 async function readManifestJson(manifestPath) {
@@ -334,16 +467,14 @@ async function importScryfallFixtures(options, overrides = {}) {
 }
 
 const defaultDependencies = {
-    fetchCardPages: async () => {
-        throw new Error("Scryfall page fetching is not implemented");
-    },
-    downloadImage: async () => {
-        throw new Error("Scryfall image downloading is not implemented");
-    }
+    fetchCardPages,
+    downloadImage
 };
 
 export {
     buildCardSearchUrl,
+    downloadImage,
+    fetchCardPages,
     importScryfallFixtures,
     manifestPrintIdentities,
     normalizeCard,

--- a/src/regression/scryfall-fixture-importer.mjs
+++ b/src/regression/scryfall-fixture-importer.mjs
@@ -1,0 +1,354 @@
+import { access, mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const SCRYFALL_API_ORIGIN = "https://api.scryfall.com";
+const DEFAULT_MAX_PAGES = 20;
+const MAX_COUNT = 100;
+const MAX_PAGES = 100;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SET_CODE_PATTERN = /^[a-z0-9]{2,6}$/i;
+
+function parsePositiveInteger(value, label, maximum) {
+    const number = Number(value);
+    if (!Number.isSafeInteger(number) || number < 1 || number > maximum) {
+        throw new Error(`${label} must be an integer from 1 to ${maximum}`);
+    }
+    return number;
+}
+
+function normalizeSetCodes(values = []) {
+    const setCodes = values
+        .flatMap((value) => String(value).split(","))
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean);
+
+    for (const setCode of setCodes) {
+        if (!SET_CODE_PATTERN.test(setCode)) {
+            throw new Error(`Invalid Scryfall set code: ${setCode}`);
+        }
+    }
+    return [...new Set(setCodes)].sort();
+}
+
+function validateDate(value, label) {
+    if (value === undefined) return undefined;
+    if (!DATE_PATTERN.test(value) || Number.isNaN(Date.parse(`${value}T00:00:00Z`))) {
+        throw new Error(`${label} must use YYYY-MM-DD`);
+    }
+    return value;
+}
+
+function normalizeImportOptions(options) {
+    const setCodes = normalizeSetCodes(options.sets);
+    const releasedAfter = validateDate(options.releasedAfter, "released-after");
+    const releasedBefore = validateDate(options.releasedBefore, "released-before");
+    const hasDates = Boolean(releasedAfter || releasedBefore);
+
+    if (setCodes.length > 0 && hasDates) {
+        throw new Error("Choose set codes or a release-date range, not both");
+    }
+    if (setCodes.length === 0 && !hasDates) {
+        throw new Error("Provide --sets or at least one release-date bound");
+    }
+    if (releasedAfter && releasedBefore && releasedAfter > releasedBefore) {
+        throw new Error("released-after must be on or before released-before");
+    }
+
+    return {
+        setCodes,
+        releasedAfter,
+        releasedBefore,
+        count: parsePositiveInteger(options.count, "count", MAX_COUNT),
+        maxPages: parsePositiveInteger(
+            options.maxPages ?? DEFAULT_MAX_PAGES,
+            "max-pages",
+            MAX_PAGES
+        )
+    };
+}
+
+function buildCardSearchUrl(options) {
+    const filters = ["game:paper", "lang:en"];
+    if (options.setCodes.length > 0) {
+        filters.push(`(${options.setCodes.map((setCode) => `e:${setCode}`).join(" OR ")})`);
+    } else {
+        if (options.releasedAfter) filters.push(`date>=${options.releasedAfter}`);
+        if (options.releasedBefore) filters.push(`date<=${options.releasedBefore}`);
+    }
+
+    const url = new URL("/cards/search", SCRYFALL_API_ORIGIN);
+    url.searchParams.set("q", filters.join(" "));
+    url.searchParams.set("unique", "prints");
+    url.searchParams.set("order", "released");
+    url.searchParams.set("dir", "desc");
+    return url.href;
+}
+
+async function readManifestJson(manifestPath) {
+    let manifest;
+    try {
+        manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to read fixture manifest ${manifestPath}`, { cause: error });
+    }
+    if (!manifest || !Array.isArray(manifest.catalog) || !Array.isArray(manifest.cases)) {
+        throw new Error(`Fixture manifest must contain catalog and cases arrays: ${manifestPath}`);
+    }
+    return manifest;
+}
+
+function printIdentities(card) {
+    const identities = [];
+    const scryfallId = card.scryfallId || card.id;
+    if (scryfallId) identities.push(`id:${String(scryfallId).toLowerCase()}`);
+    const set = card.set;
+    const collectorNumber = card.collectorNumber || card.collector_number;
+    if (set && collectorNumber) {
+        identities.push(
+            `print:${String(set).toLowerCase()}/${String(collectorNumber).toLowerCase()}`
+        );
+    }
+    return identities;
+}
+
+function manifestPrintIdentities(manifest) {
+    return new Set(manifest.catalog.flatMap(printIdentities));
+}
+
+function slugify(value) {
+    const slug = String(value)
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+    return slug || "card";
+}
+
+function imageUrlForCard(card) {
+    const imageUrl = card?.image_uris?.normal;
+    if (typeof imageUrl !== "string") return undefined;
+    const parsed = new URL(imageUrl);
+    if (
+        parsed.protocol !== "https:" ||
+        (parsed.hostname !== "img.scryfall.com" && !parsed.hostname.endsWith(".scryfall.io"))
+    ) {
+        return undefined;
+    }
+    return parsed.href;
+}
+
+function normalizeCard(card) {
+    if (
+        !card ||
+        typeof card.id !== "string" ||
+        typeof card.name !== "string" ||
+        typeof card.set !== "string" ||
+        typeof card.set_name !== "string" ||
+        typeof card.collector_number !== "string" ||
+        card.lang !== "en" ||
+        card.digital === true
+    ) {
+        return undefined;
+    }
+    const imageUrl = imageUrlForCard(card);
+    if (!imageUrl) return undefined;
+    return {
+        id: card.id,
+        name: card.name,
+        set: card.set.toUpperCase(),
+        setName: card.set_name,
+        collectorNumber: card.collector_number,
+        typeLine: typeof card.type_line === "string" ? card.type_line : "Unknown",
+        rarity: typeof card.rarity === "string" ? card.rarity : "unknown",
+        apiUrl: typeof card.scryfall_uri === "string" ? card.scryfall_uri : card.uri,
+        imageUrl
+    };
+}
+
+function toManifestPath(manifestPath, filePath) {
+    return path.relative(path.dirname(manifestPath), filePath).split(path.sep).join("/");
+}
+
+function fixtureEntries(card, manifestPath, imagePath, activate) {
+    const relativeImage = toManifestPath(manifestPath, imagePath);
+    const enabled = Boolean(activate);
+    return {
+        catalog: {
+            enabled,
+            scryfallId: card.id,
+            name: card.name,
+            set: card.set,
+            setName: card.setName,
+            collectorNumber: card.collectorNumber,
+            typeLine: card.typeLine,
+            rarity: card.rarity,
+            referenceImage: relativeImage,
+            apiUrl: card.apiUrl
+        },
+        fixture: {
+            enabled,
+            id: `${slugify(card.set)}-${slugify(card.collectorNumber)}-${slugify(card.name)}-${slugify(card.id.slice(0, 8))}-scryfall`,
+            image: relativeImage,
+            quality: "clean-scan",
+            notes: enabled
+                ? "Imported from Scryfall as an active clean-scan fixture"
+                : "Imported from Scryfall; review OCR output and thresholds before enabling",
+            expected: {
+                name: card.name,
+                set: card.set,
+                collectorNumber: card.collectorNumber,
+                metadata: {
+                    typeLine: card.typeLine,
+                    rarity: card.rarity
+                },
+                minNameScore: 0.7,
+                maxPrintCandidates: 1,
+                maxRuntimeMs: 30000
+            }
+        }
+    };
+}
+
+async function fileExists(filePath) {
+    try {
+        await access(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function writeManifestAtomically(manifestPath, manifest) {
+    const temporaryPath = `${manifestPath}.tmp-${process.pid}-${Date.now()}`;
+    try {
+        await writeFile(temporaryPath, `${JSON.stringify(manifest, null, 4)}\n`, { flag: "wx" });
+        await rename(temporaryPath, manifestPath);
+    } finally {
+        await rm(temporaryPath, { force: true });
+    }
+}
+
+async function importScryfallFixtures(options, overrides = {}) {
+    const selection = normalizeImportOptions(options);
+    const manifestPath = path.resolve(options.manifestPath);
+    const imageDirectory = path.resolve(options.imageDirectory);
+    const manifest = await readManifestJson(manifestPath);
+    const extraManifests = await Promise.all(
+        (options.existingManifestPaths || []).map((existingPath) =>
+            readManifestJson(path.resolve(existingPath))
+        )
+    );
+    const existing = manifestPrintIdentities(manifest);
+    for (const extraManifest of extraManifests) {
+        for (const identity of manifestPrintIdentities(extraManifest)) existing.add(identity);
+    }
+
+    const fetchCardPages = overrides.fetchCardPages || defaultDependencies.fetchCardPages;
+    const cards = await fetchCardPages(buildCardSearchUrl(selection), {
+        maxPages: selection.maxPages
+    });
+    const selected = [];
+    const selectedIdentities = new Set();
+    let excludedExisting = 0;
+    let skippedUnprintable = 0;
+
+    for (const rawCard of cards) {
+        const card = normalizeCard(rawCard);
+        if (!card) {
+            skippedUnprintable += 1;
+            continue;
+        }
+        const identities = printIdentities(card);
+        if (
+            identities.some(
+                (identity) => existing.has(identity) || selectedIdentities.has(identity)
+            )
+        ) {
+            excludedExisting += 1;
+            continue;
+        }
+        selected.push(card);
+        for (const identity of identities) selectedIdentities.add(identity);
+        if (selected.length === selection.count) break;
+    }
+
+    if (selected.length < selection.count) {
+        throw new Error(
+            `Found ${selected.length} new printable cards; requested ${selection.count}. ` +
+                "Increase --max-pages or widen selection."
+        );
+    }
+
+    const added = selected.map((card) => ({
+        scryfallId: card.id,
+        name: card.name,
+        set: card.set,
+        collectorNumber: card.collectorNumber
+    }));
+    if (options.dryRun) {
+        return { added, excludedExisting, skippedUnprintable, dryRun: true };
+    }
+
+    await mkdir(path.dirname(imageDirectory), { recursive: true });
+    await mkdir(imageDirectory, { recursive: true });
+    const temporaryDirectory = await mkdtemp(path.join(path.dirname(imageDirectory), ".import-"));
+    const movedImages = [];
+    try {
+        const prepared = [];
+        for (const card of selected) {
+            const filename = `${slugify(card.set)}-${slugify(card.collectorNumber)}-${slugify(card.name)}-${slugify(card.id.slice(0, 8))}.jpg`;
+            const temporaryImage = path.join(temporaryDirectory, filename);
+            const finalImage = path.join(imageDirectory, filename);
+            if (await fileExists(finalImage)) {
+                throw new Error(`Fixture image already exists: ${finalImage}`);
+            }
+            await (overrides.downloadImage || defaultDependencies.downloadImage)(
+                card.imageUrl,
+                temporaryImage
+            );
+            prepared.push({ card, temporaryImage, finalImage });
+        }
+
+        for (const item of prepared) {
+            await rename(item.temporaryImage, item.finalImage);
+            movedImages.push(item.finalImage);
+            const entries = fixtureEntries(
+                item.card,
+                manifestPath,
+                item.finalImage,
+                options.activate
+            );
+            manifest.catalog.push(entries.catalog);
+            manifest.cases.push(entries.fixture);
+        }
+        await writeManifestAtomically(manifestPath, manifest);
+    } catch (error) {
+        await Promise.all(movedImages.map((imagePath) => rm(imagePath, { force: true })));
+        throw error;
+    } finally {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+
+    return { added, excludedExisting, skippedUnprintable, dryRun: false };
+}
+
+const defaultDependencies = {
+    fetchCardPages: async () => {
+        throw new Error("Scryfall page fetching is not implemented");
+    },
+    downloadImage: async () => {
+        throw new Error("Scryfall image downloading is not implemented");
+    }
+};
+
+export {
+    buildCardSearchUrl,
+    importScryfallFixtures,
+    manifestPrintIdentities,
+    normalizeCard,
+    normalizeImportOptions,
+    normalizeSetCodes,
+    printIdentities,
+    readManifestJson
+};

--- a/src/regression/scryfall-fixture-importer.mjs
+++ b/src/regression/scryfall-fixture-importer.mjs
@@ -1,20 +1,17 @@
 import { access, mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import {
+    buildCardSearchUrl,
+    downloadImage,
+    fetchCardPages,
+    imageUrlForCard
+} from "../scryfall-api/regression-fixtures.mjs";
 
-const SCRYFALL_API_ORIGIN = "https://api.scryfall.com";
 const DEFAULT_MAX_PAGES = 20;
 const MAX_COUNT = 100;
 const MAX_PAGES = 100;
-const REQUEST_DELAY_MS = 125;
-const REQUEST_TIMEOUT_MS = 30_000;
-const MAX_API_RESPONSE_BYTES = 12 * 1024 * 1024;
-const MAX_IMAGE_BYTES = 6 * 1024 * 1024;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const SET_CODE_PATTERN = /^[a-z0-9]{2,6}$/i;
-const REQUEST_HEADERS = {
-    "User-Agent": "MTG-Card-Analyzer/0.2 (+https://github.com/dills122/MTG-Card-Analyzer)",
-    Accept: "application/json"
-};
 
 function parsePositiveInteger(value, label, maximum) {
     const number = Number(value);
@@ -40,7 +37,16 @@ function normalizeSetCodes(values = []) {
 
 function validateDate(value, label) {
     if (value === undefined) return undefined;
-    if (!DATE_PATTERN.test(value) || Number.isNaN(Date.parse(`${value}T00:00:00Z`))) {
+    if (!DATE_PATTERN.test(value)) {
+        throw new Error(`${label} must use YYYY-MM-DD`);
+    }
+    const [year, month, day] = value.split("-").map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (
+        date.getUTCFullYear() !== year ||
+        date.getUTCMonth() !== month - 1 ||
+        date.getUTCDate() !== day
+    ) {
         throw new Error(`${label} must use YYYY-MM-DD`);
     }
     return value;
@@ -75,148 +81,6 @@ function normalizeImportOptions(options) {
     };
 }
 
-function buildCardSearchUrl(options) {
-    const filters = ["game:paper", "lang:en"];
-    if (options.setCodes.length > 0) {
-        filters.push(`(${options.setCodes.map((setCode) => `e:${setCode}`).join(" OR ")})`);
-    } else {
-        if (options.releasedAfter) filters.push(`date>=${options.releasedAfter}`);
-        if (options.releasedBefore) filters.push(`date<=${options.releasedBefore}`);
-    }
-
-    const url = new URL("/cards/search", SCRYFALL_API_ORIGIN);
-    url.searchParams.set("q", filters.join(" "));
-    url.searchParams.set("unique", "prints");
-    url.searchParams.set("order", "released");
-    url.searchParams.set("dir", "desc");
-    return url.href;
-}
-
-function trustedUrl(value, expectedOrigin, label) {
-    let url;
-    try {
-        url = new URL(value);
-    } catch {
-        throw new Error(`Invalid ${label} URL`);
-    }
-    if (url.protocol !== "https:" || url.origin !== expectedOrigin) {
-        throw new Error(`Untrusted ${label} URL: ${url.origin}`);
-    }
-    return url;
-}
-
-async function readBoundedBody(response, maximumBytes, label) {
-    const contentLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(contentLength) && contentLength > maximumBytes) {
-        throw new Error(`${label} exceeds ${maximumBytes} bytes`);
-    }
-    if (!response.body) throw new Error(`${label} response body is empty`);
-
-    const chunks = [];
-    let total = 0;
-    const reader = response.body.getReader();
-    try {
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            total += value.byteLength;
-            if (total > maximumBytes) {
-                await reader.cancel();
-                throw new Error(`${label} exceeds ${maximumBytes} bytes`);
-            }
-            chunks.push(value);
-        }
-    } finally {
-        reader.releaseLock();
-    }
-
-    const bytes = new Uint8Array(total);
-    let offset = 0;
-    for (const chunk of chunks) {
-        bytes.set(chunk, offset);
-        offset += chunk.byteLength;
-    }
-    return bytes;
-}
-
-async function request(url, options = {}) {
-    const fetchImpl = options.fetchImpl || globalThis.fetch;
-    const response = await fetchImpl(url, {
-        headers: options.headers,
-        redirect: "error",
-        signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
-    });
-    if (!response.ok) {
-        throw new Error(`Scryfall request failed with HTTP ${response.status}`);
-    }
-    return response;
-}
-
-async function fetchCardPages(searchUrl, options = {}) {
-    const maxPages = parsePositiveInteger(
-        options.maxPages ?? DEFAULT_MAX_PAGES,
-        "max-pages",
-        MAX_PAGES
-    );
-    const wait =
-        options.wait ||
-        ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
-    const cards = [];
-    let nextUrl = trustedUrl(searchUrl, SCRYFALL_API_ORIGIN, "Scryfall API").href;
-
-    for (let page = 0; page < maxPages && nextUrl; page += 1) {
-        if (page > 0) await wait(REQUEST_DELAY_MS);
-        const response = await request(nextUrl, {
-            fetchImpl: options.fetchImpl,
-            headers: REQUEST_HEADERS
-        });
-        const contentType = response.headers.get("content-type") || "";
-        if (!contentType.toLowerCase().includes("application/json")) {
-            throw new Error("Expected JSON response from Scryfall API");
-        }
-        const bytes = await readBoundedBody(
-            response,
-            MAX_API_RESPONSE_BYTES,
-            "Scryfall API response"
-        );
-        let pageData;
-        try {
-            pageData = JSON.parse(new TextDecoder().decode(bytes));
-        } catch (error) {
-            throw new Error("Scryfall API returned invalid JSON", { cause: error });
-        }
-        if (pageData?.object !== "list" || !Array.isArray(pageData.data)) {
-            throw new Error("Scryfall API response is not a card list");
-        }
-        cards.push(...pageData.data);
-        nextUrl = pageData.has_more
-            ? trustedUrl(pageData.next_page, SCRYFALL_API_ORIGIN, "Scryfall API").href
-            : undefined;
-    }
-    return cards;
-}
-
-async function downloadImage(imageUrl, destination, options = {}) {
-    const trustedImage = imageUrlForCard({ image_uris: { normal: imageUrl } });
-    if (!trustedImage) throw new Error("Untrusted Scryfall image URL");
-    const response = await request(trustedImage, {
-        fetchImpl: options.fetchImpl,
-        headers: {
-            ...REQUEST_HEADERS,
-            Accept: "image/jpeg"
-        }
-    });
-    const contentType = response.headers.get("content-type") || "";
-    if (!contentType.toLowerCase().startsWith("image/jpeg")) {
-        throw new Error("Expected JPEG image from Scryfall");
-    }
-    const bytes = await readBoundedBody(response, MAX_IMAGE_BYTES, "Scryfall image");
-    if (bytes.length < 3 || bytes[0] !== 0xff || bytes[1] !== 0xd8 || bytes[2] !== 0xff) {
-        throw new Error("Scryfall download is not a valid JPEG image");
-    }
-    await writeFile(destination, bytes, { flag: "wx" });
-}
-
 async function readManifestJson(manifestPath) {
     let manifest;
     try {
@@ -248,6 +112,23 @@ function manifestPrintIdentities(manifest) {
     return new Set(manifest.catalog.flatMap(printIdentities));
 }
 
+function hasEnoughNewPrintableCards(cards, existing, count) {
+    const selected = new Set();
+    let total = 0;
+    for (const rawCard of cards) {
+        const card = normalizeCard(rawCard);
+        if (!card) continue;
+        const identities = printIdentities(card);
+        if (identities.some((identity) => existing.has(identity) || selected.has(identity))) {
+            continue;
+        }
+        for (const identity of identities) selected.add(identity);
+        total += 1;
+        if (total === count) return true;
+    }
+    return false;
+}
+
 function slugify(value) {
     const slug = String(value)
         .normalize("NFKD")
@@ -258,29 +139,19 @@ function slugify(value) {
     return slug || "card";
 }
 
-function imageUrlForCard(card) {
-    const imageUrl = card?.image_uris?.normal;
-    if (typeof imageUrl !== "string") return undefined;
-    const parsed = new URL(imageUrl);
-    if (
-        parsed.protocol !== "https:" ||
-        (parsed.hostname !== "img.scryfall.com" && !parsed.hostname.endsWith(".scryfall.io"))
-    ) {
-        return undefined;
-    }
-    return parsed.href;
-}
-
 function normalizeCard(card) {
+    const requiredStrings = [
+        card?.id,
+        card?.name,
+        card?.set,
+        card?.set_name,
+        card?.collector_number
+    ];
     if (
         !card ||
-        typeof card.id !== "string" ||
-        typeof card.name !== "string" ||
-        typeof card.set !== "string" ||
-        typeof card.set_name !== "string" ||
-        typeof card.collector_number !== "string" ||
+        requiredStrings.some((value) => typeof value !== "string" || value.trim().length === 0) ||
         card.lang !== "en" ||
-        card.digital === true
+        card.digital !== false
     ) {
         return undefined;
     }
@@ -303,12 +174,11 @@ function toManifestPath(manifestPath, filePath) {
     return path.relative(path.dirname(manifestPath), filePath).split(path.sep).join("/");
 }
 
-function fixtureEntries(card, manifestPath, imagePath, activate) {
+function fixtureEntries(card, manifestPath, imagePath) {
     const relativeImage = toManifestPath(manifestPath, imagePath);
-    const enabled = Boolean(activate);
     return {
         catalog: {
-            enabled,
+            enabled: false,
             scryfallId: card.id,
             name: card.name,
             set: card.set,
@@ -320,13 +190,11 @@ function fixtureEntries(card, manifestPath, imagePath, activate) {
             apiUrl: card.apiUrl
         },
         fixture: {
-            enabled,
+            enabled: false,
             id: `${slugify(card.set)}-${slugify(card.collectorNumber)}-${slugify(card.name)}-${slugify(card.id.slice(0, 8))}-scryfall`,
             image: relativeImage,
             quality: "clean-scan",
-            notes: enabled
-                ? "Imported from Scryfall as an active clean-scan fixture"
-                : "Imported from Scryfall; review OCR output and thresholds before enabling",
+            notes: "Imported from Scryfall; review OCR output and thresholds before enabling",
             expected: {
                 name: card.name,
                 set: card.set,
@@ -379,7 +247,9 @@ async function importScryfallFixtures(options, overrides = {}) {
 
     const fetchCardPages = overrides.fetchCardPages || defaultDependencies.fetchCardPages;
     const cards = await fetchCardPages(buildCardSearchUrl(selection), {
-        maxPages: selection.maxPages
+        maxPages: selection.maxPages,
+        shouldStop: (collectedCards) =>
+            hasEnoughNewPrintableCards(collectedCards, existing, selection.count)
     });
     const selected = [];
     const selectedIdentities = new Set();
@@ -446,12 +316,7 @@ async function importScryfallFixtures(options, overrides = {}) {
         for (const item of prepared) {
             await rename(item.temporaryImage, item.finalImage);
             movedImages.push(item.finalImage);
-            const entries = fixtureEntries(
-                item.card,
-                manifestPath,
-                item.finalImage,
-                options.activate
-            );
+            const entries = fixtureEntries(item.card, manifestPath, item.finalImage);
             manifest.catalog.push(entries.catalog);
             manifest.cases.push(entries.fixture);
         }
@@ -472,9 +337,6 @@ const defaultDependencies = {
 };
 
 export {
-    buildCardSearchUrl,
-    downloadImage,
-    fetchCardPages,
     importScryfallFixtures,
     manifestPrintIdentities,
     normalizeCard,

--- a/src/scryfall-api/regression-fixtures.mjs
+++ b/src/scryfall-api/regression-fixtures.mjs
@@ -1,0 +1,180 @@
+import { writeFile } from "node:fs/promises";
+
+const SCRYFALL_API_ORIGIN = "https://api.scryfall.com";
+const DEFAULT_MAX_PAGES = 20;
+const MAX_PAGES = 100;
+const REQUEST_DELAY_MS = 125;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_API_RESPONSE_BYTES = 12 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 6 * 1024 * 1024;
+const REQUEST_HEADERS = {
+    "User-Agent": "MTG-Card-Analyzer/0.2 (+https://github.com/dills122/MTG-Card-Analyzer)",
+    Accept: "application/json"
+};
+
+function parseMaxPages(value) {
+    const number = Number(value);
+    if (!Number.isSafeInteger(number) || number < 1 || number > MAX_PAGES) {
+        throw new Error(`max-pages must be an integer from 1 to ${MAX_PAGES}`);
+    }
+    return number;
+}
+
+function buildCardSearchUrl(options) {
+    const filters = ["game:paper", "lang:en"];
+    if (options.setCodes.length > 0) {
+        filters.push(`(${options.setCodes.map((setCode) => `e:${setCode}`).join(" OR ")})`);
+    } else {
+        if (options.releasedAfter) filters.push(`date>=${options.releasedAfter}`);
+        if (options.releasedBefore) filters.push(`date<=${options.releasedBefore}`);
+    }
+
+    const url = new URL("/cards/search", SCRYFALL_API_ORIGIN);
+    url.searchParams.set("q", filters.join(" "));
+    url.searchParams.set("unique", "prints");
+    url.searchParams.set("order", "released");
+    url.searchParams.set("dir", "desc");
+    return url.href;
+}
+
+function trustedUrl(value, expectedOrigin, label) {
+    let url;
+    try {
+        url = new URL(value);
+    } catch {
+        throw new Error(`Invalid ${label} URL`);
+    }
+    if (url.protocol !== "https:" || url.origin !== expectedOrigin) {
+        throw new Error(`Untrusted ${label} URL: ${url.origin}`);
+    }
+    return url;
+}
+
+function imageUrlForCard(card) {
+    const imageUrl = card?.image_uris?.normal;
+    if (typeof imageUrl !== "string") return undefined;
+    let parsed;
+    try {
+        parsed = new URL(imageUrl);
+    } catch {
+        return undefined;
+    }
+    if (
+        parsed.protocol !== "https:" ||
+        (parsed.hostname !== "img.scryfall.com" && !parsed.hostname.endsWith(".scryfall.io"))
+    ) {
+        return undefined;
+    }
+    return parsed.href;
+}
+
+async function readBoundedBody(response, maximumBytes, label) {
+    const contentLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > maximumBytes) {
+        throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+    }
+    if (!response.body) throw new Error(`${label} response body is empty`);
+
+    const chunks = [];
+    let total = 0;
+    const reader = response.body.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            total += value.byteLength;
+            if (total > maximumBytes) {
+                await reader.cancel();
+                throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+            }
+            chunks.push(value);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return bytes;
+}
+
+async function request(url, options = {}) {
+    const fetchImpl = options.fetchImpl || globalThis.fetch;
+    const response = await fetchImpl(url, {
+        headers: options.headers,
+        redirect: "error",
+        signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
+    });
+    if (!response.ok) {
+        throw new Error(`Scryfall request failed with HTTP ${response.status}`);
+    }
+    return response;
+}
+
+async function fetchCardPages(searchUrl, options = {}) {
+    const maxPages = parseMaxPages(options.maxPages ?? DEFAULT_MAX_PAGES);
+    const wait =
+        options.wait ||
+        ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    const cards = [];
+    let nextUrl = trustedUrl(searchUrl, SCRYFALL_API_ORIGIN, "Scryfall API").href;
+
+    for (let page = 0; page < maxPages && nextUrl; page += 1) {
+        if (page > 0) await wait(REQUEST_DELAY_MS);
+        const response = await request(nextUrl, {
+            fetchImpl: options.fetchImpl,
+            headers: REQUEST_HEADERS
+        });
+        const contentType = response.headers.get("content-type") || "";
+        if (!contentType.toLowerCase().includes("application/json")) {
+            throw new Error("Expected JSON response from Scryfall API");
+        }
+        const bytes = await readBoundedBody(
+            response,
+            MAX_API_RESPONSE_BYTES,
+            "Scryfall API response"
+        );
+        let pageData;
+        try {
+            pageData = JSON.parse(new TextDecoder().decode(bytes));
+        } catch (error) {
+            throw new Error("Scryfall API returned invalid JSON", { cause: error });
+        }
+        if (pageData?.object !== "list" || !Array.isArray(pageData.data)) {
+            throw new Error("Scryfall API response is not a card list");
+        }
+        cards.push(...pageData.data);
+        if (options.shouldStop?.(cards)) break;
+        nextUrl = pageData.has_more
+            ? trustedUrl(pageData.next_page, SCRYFALL_API_ORIGIN, "Scryfall API").href
+            : undefined;
+    }
+    return cards;
+}
+
+async function downloadImage(imageUrl, destination, options = {}) {
+    const trustedImage = imageUrlForCard({ image_uris: { normal: imageUrl } });
+    if (!trustedImage) throw new Error("Untrusted Scryfall image URL");
+    const response = await request(trustedImage, {
+        fetchImpl: options.fetchImpl,
+        headers: {
+            ...REQUEST_HEADERS,
+            Accept: "image/jpeg"
+        }
+    });
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.toLowerCase().startsWith("image/jpeg")) {
+        throw new Error("Expected JPEG image from Scryfall");
+    }
+    const bytes = await readBoundedBody(response, MAX_IMAGE_BYTES, "Scryfall image");
+    if (bytes.length < 3 || bytes[0] !== 0xff || bytes[1] !== 0xd8 || bytes[2] !== 0xff) {
+        throw new Error("Scryfall download is not a valid JPEG image");
+    }
+    await writeFile(destination, bytes, { flag: "wx" });
+}
+
+export { buildCardSearchUrl, downloadImage, fetchCardPages, imageUrlForCard };

--- a/test/regression/scryfall-fixture-importer.spec.mjs
+++ b/test/regression/scryfall-fixture-importer.spec.mjs
@@ -3,12 +3,15 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
-    buildCardSearchUrl,
-    downloadImage,
-    fetchCardPages,
     importScryfallFixtures,
+    normalizeCard,
     normalizeImportOptions
 } from "../../src/regression/scryfall-fixture-importer.mjs";
+import {
+    buildCardSearchUrl,
+    downloadImage,
+    fetchCardPages
+} from "../../src/scryfall-api/regression-fixtures.mjs";
 
 describe("Scryfall regression fixture importer", () => {
     describe("normalizeImportOptions", () => {
@@ -59,6 +62,18 @@ describe("Scryfall regression fixture importer", () => {
                         count: 2
                     }),
                 "released-after must be on or before released-before"
+            );
+        });
+
+        it("rejects a calendar date that does not exist", () => {
+            assert.throws(
+                () =>
+                    normalizeImportOptions({
+                        sets: [],
+                        releasedAfter: "2025-02-30",
+                        count: 2
+                    }),
+                "released-after must use YYYY-MM-DD"
             );
         });
     });
@@ -112,6 +127,27 @@ describe("Scryfall regression fixture importer", () => {
             assert.equal(requests[0].options.headers.Accept, "application/json");
             assert.match(requests[0].options.headers["User-Agent"], /MTG-Card-Analyzer/);
             assert.deepEqual(waits, [125]);
+        });
+
+        it("stops pagination when enough usable cards have been collected", async () => {
+            let requests = 0;
+            const cards = await fetchCardPages("https://api.scryfall.com/cards/search?q=test", {
+                maxPages: 5,
+                fetchImpl: async () => {
+                    requests += 1;
+                    return jsonResponse({
+                        object: "list",
+                        data: [{ id: "enough" }],
+                        has_more: true,
+                        next_page: "https://api.scryfall.com/cards/search?page=2&q=test"
+                    });
+                },
+                shouldStop: (collected) => collected.length >= 1,
+                wait: async () => {}
+            });
+
+            assert.deepEqual(cards, [{ id: "enough" }]);
+            assert.equal(requests, 1);
         });
 
         it("rejects an untrusted pagination URL", async () => {
@@ -179,6 +215,24 @@ describe("Scryfall regression fixture importer", () => {
             assert.instanceOf(error, Error);
             assert.include(error.message, "Expected JPEG image from Scryfall");
         });
+    });
+
+    it("skips malformed Scryfall card image URLs", () => {
+        const malformed = card({
+            id: "malformed",
+            name: "Malformed",
+            set: "fin",
+            collector: "9"
+        });
+        malformed.image_uris.normal = "not a URL";
+
+        assert.isUndefined(normalizeCard(malformed));
+    });
+
+    it("skips Scryfall cards with empty required metadata", () => {
+        const malformed = card({ id: "malformed", name: "", set: "fin", collector: "9" });
+
+        assert.isUndefined(normalizeCard(malformed));
     });
 
     describe("importScryfallFixtures", () => {

--- a/test/regression/scryfall-fixture-importer.spec.mjs
+++ b/test/regression/scryfall-fixture-importer.spec.mjs
@@ -1,0 +1,296 @@
+import { assert } from "chai";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+    buildCardSearchUrl,
+    importScryfallFixtures,
+    normalizeImportOptions
+} from "../../src/regression/scryfall-fixture-importer.mjs";
+
+describe("Scryfall regression fixture importer", () => {
+    describe("normalizeImportOptions", () => {
+        it("normalizes repeated and comma-separated set codes", () => {
+            assert.deepEqual(normalizeImportOptions({ sets: ["fin, dsk", "FIN"], count: "4" }), {
+                setCodes: ["dsk", "fin"],
+                releasedAfter: undefined,
+                releasedBefore: undefined,
+                count: 4,
+                maxPages: 20
+            });
+        });
+
+        it("accepts a bounded release-date range", () => {
+            assert.deepInclude(
+                normalizeImportOptions({
+                    sets: [],
+                    releasedAfter: "2025-01-01",
+                    releasedBefore: "2025-06-30",
+                    count: 2
+                }),
+                {
+                    releasedAfter: "2025-01-01",
+                    releasedBefore: "2025-06-30"
+                }
+            );
+        });
+
+        it("rejects mixed set and release-date selection", () => {
+            assert.throws(
+                () =>
+                    normalizeImportOptions({
+                        sets: ["fin"],
+                        releasedAfter: "2025-01-01",
+                        count: 2
+                    }),
+                "Choose set codes or a release-date range, not both"
+            );
+        });
+
+        it("rejects an inverted release-date range", () => {
+            assert.throws(
+                () =>
+                    normalizeImportOptions({
+                        sets: [],
+                        releasedAfter: "2025-06-30",
+                        releasedBefore: "2025-01-01",
+                        count: 2
+                    }),
+                "released-after must be on or before released-before"
+            );
+        });
+    });
+
+    it("builds a newest-first unique-print search URL", () => {
+        const url = new URL(
+            buildCardSearchUrl({
+                setCodes: ["dsk", "fin"],
+                count: 2,
+                maxPages: 20
+            })
+        );
+
+        assert.equal(url.origin, "https://api.scryfall.com");
+        assert.equal(url.pathname, "/cards/search");
+        assert.equal(url.searchParams.get("q"), "game:paper lang:en (e:dsk OR e:fin)");
+        assert.equal(url.searchParams.get("unique"), "prints");
+        assert.equal(url.searchParams.get("order"), "released");
+        assert.equal(url.searchParams.get("dir"), "desc");
+    });
+
+    describe("importScryfallFixtures", () => {
+        let directory;
+
+        beforeEach(async () => {
+            directory = await mkdtemp(path.join(os.tmpdir(), "mtg-scryfall-import-"));
+        });
+
+        afterEach(async () => {
+            await rm(directory, { recursive: true, force: true });
+        });
+
+        it("downloads new prints and appends disabled catalog and case entries", async () => {
+            const manifestPath = path.join(directory, "fixtures", "manifest.json");
+            const imageDirectory = path.join(directory, "test-images", "scryfall");
+            await writeManifest(manifestPath, {
+                version: 1,
+                catalog: [existingCatalogEntry()],
+                cases: [existingCaseEntry()]
+            });
+
+            const cards = [
+                card({ id: "existing-id", name: "Existing", set: "old", collector: "1" }),
+                card({ id: "new-id", name: "Fresh Card", set: "fin", collector: "42" })
+            ];
+            const downloads = [];
+
+            const result = await importScryfallFixtures(
+                {
+                    manifestPath,
+                    imageDirectory,
+                    sets: ["fin"],
+                    count: 1
+                },
+                {
+                    fetchCardPages: async () => cards,
+                    downloadImage: async (url, destination) => {
+                        downloads.push({ url, destination });
+                        await writeFile(destination, "image bytes");
+                    }
+                }
+            );
+
+            const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+            assert.equal(result.added.length, 1);
+            assert.equal(result.excludedExisting, 1);
+            assert.lengthOf(downloads, 1);
+            assert.equal(downloads[0].url, "https://cards.scryfall.io/normal/new-id.jpg");
+            assert.include(downloads[0].destination, "fin-42-fresh-card-new-id.jpg");
+            assert.deepInclude(manifest.catalog[1], {
+                enabled: false,
+                scryfallId: "new-id",
+                name: "Fresh Card",
+                set: "FIN",
+                setName: "Final Fantasy",
+                collectorNumber: "42",
+                referenceImage: "../test-images/scryfall/fin-42-fresh-card-new-id.jpg"
+            });
+            assert.deepInclude(manifest.cases[1], {
+                enabled: false,
+                id: "fin-42-fresh-card-new-id-scryfall",
+                image: "../test-images/scryfall/fin-42-fresh-card-new-id.jpg",
+                quality: "clean-scan"
+            });
+            assert.deepInclude(manifest.cases[1].expected, {
+                name: "Fresh Card",
+                set: "FIN",
+                collectorNumber: "42"
+            });
+        });
+
+        it("excludes prints listed in extra existing manifests", async () => {
+            const manifestPath = path.join(directory, "manifest.json");
+            const existingManifestPath = path.join(directory, "already-covered.json");
+            await writeManifest(manifestPath, emptyManifest());
+            await writeManifest(existingManifestPath, {
+                version: 1,
+                catalog: [
+                    cardCatalogEntry({ id: "known-id", name: "Known", set: "fin", collector: "7" })
+                ],
+                cases: [existingCaseEntry()]
+            });
+
+            const result = await importScryfallFixtures(
+                {
+                    manifestPath,
+                    imageDirectory: path.join(directory, "images"),
+                    existingManifestPaths: [existingManifestPath],
+                    sets: ["fin"],
+                    count: 1,
+                    dryRun: true
+                },
+                {
+                    fetchCardPages: async () => [
+                        card({ id: "known-id", name: "Known", set: "fin", collector: "7" }),
+                        card({ id: "other-id", name: "Other", set: "fin", collector: "8" })
+                    ]
+                }
+            );
+
+            assert.deepEqual(
+                result.added.map((entry) => entry.scryfallId),
+                ["other-id"]
+            );
+            assert.equal(result.excludedExisting, 1);
+            assert.deepEqual(JSON.parse(await readFile(manifestPath, "utf8")), emptyManifest());
+        });
+
+        it("fails without changing the manifest when too few new printable cards are found", async () => {
+            const manifestPath = path.join(directory, "manifest.json");
+            const originalManifest = {
+                version: 1,
+                catalog: [existingCatalogEntry()],
+                cases: [existingCaseEntry()]
+            };
+            await writeManifest(manifestPath, originalManifest);
+
+            let error;
+            try {
+                await importScryfallFixtures(
+                    {
+                        manifestPath,
+                        imageDirectory: path.join(directory, "images"),
+                        sets: ["fin"],
+                        count: 2
+                    },
+                    {
+                        fetchCardPages: async () => [
+                            card({
+                                id: "existing-id",
+                                name: "Existing",
+                                set: "old",
+                                collector: "1"
+                            })
+                        ]
+                    }
+                );
+            } catch (caught) {
+                error = caught;
+            }
+            assert.instanceOf(error, Error);
+            assert.include(error.message, "Found 0 new printable cards; requested 2");
+            assert.deepEqual(JSON.parse(await readFile(manifestPath, "utf8")), originalManifest);
+        });
+    });
+});
+
+function card({ id, name, set, collector }) {
+    return {
+        id,
+        name,
+        lang: "en",
+        digital: false,
+        set,
+        set_name: set === "fin" ? "Final Fantasy" : "Old Set",
+        collector_number: collector,
+        type_line: "Creature — Test",
+        rarity: "common",
+        scryfall_uri: `https://scryfall.com/card/${set}/${collector}`,
+        image_uris: {
+            normal: `https://cards.scryfall.io/normal/${id}.jpg`
+        }
+    };
+}
+
+function cardCatalogEntry({ id, name, set, collector }) {
+    return {
+        enabled: false,
+        scryfallId: id,
+        name,
+        set: set.toUpperCase(),
+        setName: "Set",
+        collectorNumber: collector,
+        typeLine: "Creature — Test",
+        rarity: "common",
+        referenceImage: "./existing.jpg"
+    };
+}
+
+function existingCatalogEntry() {
+    const entry = cardCatalogEntry({
+        id: "existing-id",
+        name: "Existing",
+        set: "old",
+        collector: "1"
+    });
+    delete entry.scryfallId;
+    return entry;
+}
+
+function existingCaseEntry() {
+    return {
+        enabled: false,
+        id: "existing-case",
+        image: "./existing.jpg",
+        quality: "clean-scan",
+        expected: {
+            name: "Existing",
+            set: "OLD",
+            collectorNumber: "1"
+        }
+    };
+}
+
+function emptyManifest() {
+    return {
+        version: 1,
+        catalog: [],
+        cases: []
+    };
+}
+
+async function writeManifest(manifestPath, manifest) {
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 4)}\n`);
+}

--- a/test/regression/scryfall-fixture-importer.spec.mjs
+++ b/test/regression/scryfall-fixture-importer.spec.mjs
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import {
     buildCardSearchUrl,
+    downloadImage,
+    fetchCardPages,
     importScryfallFixtures,
     normalizeImportOptions
 } from "../../src/regression/scryfall-fixture-importer.mjs";
@@ -76,6 +78,107 @@ describe("Scryfall regression fixture importer", () => {
         assert.equal(url.searchParams.get("unique"), "prints");
         assert.equal(url.searchParams.get("order"), "released");
         assert.equal(url.searchParams.get("dir"), "desc");
+    });
+
+    describe("Scryfall HTTP boundary", () => {
+        it("follows trusted pagination with request pacing", async () => {
+            const requests = [];
+            const waits = [];
+            const responses = [
+                jsonResponse({
+                    object: "list",
+                    data: [{ id: "one" }],
+                    has_more: true,
+                    next_page: "https://api.scryfall.com/cards/search?page=2&q=test"
+                }),
+                jsonResponse({
+                    object: "list",
+                    data: [{ id: "two" }],
+                    has_more: false
+                })
+            ];
+
+            const cards = await fetchCardPages("https://api.scryfall.com/cards/search?q=test", {
+                maxPages: 5,
+                fetchImpl: async (url, options) => {
+                    requests.push({ url, options });
+                    return responses.shift();
+                },
+                wait: async (milliseconds) => waits.push(milliseconds)
+            });
+
+            assert.deepEqual(cards, [{ id: "one" }, { id: "two" }]);
+            assert.lengthOf(requests, 2);
+            assert.equal(requests[0].options.headers.Accept, "application/json");
+            assert.match(requests[0].options.headers["User-Agent"], /MTG-Card-Analyzer/);
+            assert.deepEqual(waits, [125]);
+        });
+
+        it("rejects an untrusted pagination URL", async () => {
+            let error;
+            try {
+                await fetchCardPages("https://api.scryfall.com/cards/search?q=test", {
+                    maxPages: 2,
+                    fetchImpl: async () =>
+                        jsonResponse({
+                            object: "list",
+                            data: [],
+                            has_more: true,
+                            next_page: "https://example.com/cards/search?page=2"
+                        }),
+                    wait: async () => {}
+                });
+            } catch (caught) {
+                error = caught;
+            }
+
+            assert.instanceOf(error, Error);
+            assert.include(error.message, "Untrusted Scryfall API URL");
+        });
+
+        it("downloads a bounded JPEG image", async () => {
+            const destination = path.join(
+                await mkdtemp(path.join(os.tmpdir(), "mtg-scryfall-download-")),
+                "card.jpg"
+            );
+            try {
+                await downloadImage("https://cards.scryfall.io/normal/card.jpg", destination, {
+                    fetchImpl: async () =>
+                        new Response(new Uint8Array([0xff, 0xd8, 0xff, 0xd9]), {
+                            status: 200,
+                            headers: { "Content-Type": "image/jpeg" }
+                        })
+                });
+                assert.deepEqual(
+                    [...new Uint8Array(await readFile(destination))],
+                    [0xff, 0xd8, 0xff, 0xd9]
+                );
+            } finally {
+                await rm(path.dirname(destination), { recursive: true, force: true });
+            }
+        });
+
+        it("rejects a non-image download", async () => {
+            let error;
+            try {
+                await downloadImage(
+                    "https://cards.scryfall.io/normal/card.jpg",
+                    path.join(os.tmpdir(), "must-not-write.jpg"),
+                    {
+                        fetchImpl: async () =>
+                            new Response("not an image", {
+                                status: 200,
+                                headers: { "Content-Type": "text/plain" }
+                            })
+                    }
+                );
+            } catch (caught) {
+                error = caught;
+            }
+
+            assert.instanceOf(error, Error);
+            assert.include(error.message, "Expected JPEG image from Scryfall");
+        });
     });
 
     describe("importScryfallFixtures", () => {
@@ -293,4 +396,11 @@ async function writeManifest(manifestPath, manifest) {
     const { mkdir } = await import("node:fs/promises");
     await mkdir(path.dirname(manifestPath), { recursive: true });
     await writeFile(manifestPath, `${JSON.stringify(manifest, null, 4)}\n`);
+}
+
+function jsonResponse(value) {
+    return new Response(JSON.stringify(value), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+    });
 }

--- a/test/scripts/import-scryfall-fixtures.spec.mjs
+++ b/test/scripts/import-scryfall-fixtures.spec.mjs
@@ -1,0 +1,85 @@
+import { assert } from "chai";
+import { buildProgram, main } from "../../scripts/import-scryfall-fixtures.mjs";
+
+describe("import-scryfall-fixtures CLI", () => {
+    it("parses repeated set and existing-manifest options", () => {
+        const options = buildProgram()
+            .exitOverride()
+            .parse([
+                "node",
+                "import-scryfall-fixtures.mjs",
+                "--set",
+                "fin,dsk",
+                "--set",
+                "tdm",
+                "--count",
+                "6",
+                "--existing-manifest",
+                "first.json",
+                "--existing-manifest",
+                "second.json",
+                "--dry-run"
+            ])
+            .opts();
+
+        assert.deepEqual(options.set, ["fin,dsk", "tdm"]);
+        assert.equal(options.count, "6");
+        assert.deepEqual(options.existingManifest, ["first.json", "second.json"]);
+        assert.isTrue(options.dryRun);
+    });
+
+    it("maps CLI options to the importer and reports selected cards", async () => {
+        let received;
+        const output = [];
+
+        const result = await main(
+            [
+                "node",
+                "import-scryfall-fixtures.mjs",
+                "--released-after",
+                "2025-01-01",
+                "--released-before",
+                "2025-06-30",
+                "--count",
+                "2"
+            ],
+            {
+                importer: async (options) => {
+                    received = options;
+                    return {
+                        added: [
+                            {
+                                name: "Card One",
+                                set: "ONE",
+                                collectorNumber: "1",
+                                scryfallId: "one"
+                            },
+                            {
+                                name: "Card Two",
+                                set: "TWO",
+                                collectorNumber: "2",
+                                scryfallId: "two"
+                            }
+                        ],
+                        excludedExisting: 3,
+                        skippedUnprintable: 1,
+                        dryRun: false
+                    };
+                },
+                writeLine: (line) => output.push(line)
+            }
+        );
+
+        assert.deepInclude(received, {
+            sets: [],
+            releasedAfter: "2025-01-01",
+            releasedBefore: "2025-06-30",
+            count: "2",
+            dryRun: false
+        });
+        assert.strictEqual(result.added.length, 2);
+        assert.include(output[0], "Imported 2 fixture(s)");
+        assert.include(output.join("\n"), "ONE/1 Card One");
+        assert.include(output.join("\n"), "Excluded existing prints: 3");
+    });
+});


### PR DESCRIPTION
## Summary

- add `pnpm fixtures:import` for selecting Scryfall prints by repeated set codes or release-date bounds
- exclude prints already present in the target manifest or repeatable `--existing-manifest` catalogs
- download bounded front JPEGs and atomically append disabled catalog/case entries for review
- pace and bound Scryfall API pagination, validate trusted origins, and clean up failed imports
- document the fixture review workflow and add focused CLI, importer, and HTTP-boundary tests

## Why

Growing OCR regression coverage currently requires manual Scryfall lookup, image download, metadata transcription, and manifest editing. This CLI makes that workflow repeatable while preserving the repository's offline, deterministic, and review-first fixture policy.

## Developer impact

Preview candidates without changing files:

```bash
pnpm fixtures:import --set fin --set dsk --count 6 --dry-run
```

Import candidates from a release-date range:

```bash
pnpm fixtures:import \
  --released-after 2025-01-01 \
  --released-before 2025-06-30 \
  --count 10
```

Imported fixtures remain disabled until their image, metadata, OCR result, and thresholds are reviewed.

## Validation

- `pnpm check` — passed; 185 tests
- `pnpm fixtures:import --help` — passed
- live Scryfall multi-set dry-run — passed
- live Scryfall release-date dry-run — passed
- `pnpm coverage:check` — repo-wide gate remains below c8's default 90% threshold at 77.9%; new importer and Scryfall adapter measured 89.33% and 86.66%

`pnpm test:regression` was not run because this change does not alter OCR, hashing, matching, fixture expectations, or enabled regression inputs.
