### PR TITLE
Add balanced Scryfall regression fixture selection

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -216,6 +216,9 @@ Import new clean-scan candidates from Scryfall by set code or release-date range
 # Preview six unused prints from two sets
 pnpm fixtures:import --set fin --set dsk --count 6 --dry-run
 
+# Preview a deterministic coverage mix across sets, colors, types, rarities, and treatments
+pnpm fixtures:import --set m12 --set m13 --set m20 --count 12 --balanced --dry-run
+
 # Download ten unused prints and append disabled review entries
 pnpm fixtures:import \
     --released-after 2025-01-01 \
@@ -226,7 +229,7 @@ pnpm fixtures:import \
 The target manifest is automatically used to exclude existing printings. Add repeatable
 `--existing-manifest <path>` options to exclude catalogs from other checkouts or suites. See the
 [regression fixture import workflow](docs/regression-testing.md#import-clean-scans-from-scryfall)
-for review, activation, and safety details.
+for balanced-selection behavior, review, activation, and safety details.
 
 ### Quality Commands
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -175,6 +175,13 @@ matching catalog and clean-scan case entries:
 # Preview newest prints from several sets without writing files
 pnpm fixtures:import --set fin --set dsk --count 6 --dry-run
 
+# Preview a deterministic coverage mix instead of collector-number ordering
+pnpm fixtures:import \
+    --set m12 --set m13 --set m20 \
+    --count 12 \
+    --balanced \
+    --dry-run
+
 # Import prints whose sets were released in a date range
 pnpm fixtures:import \
     --released-after 2025-01-01 \
@@ -189,10 +196,18 @@ pnpm fixtures:import \
 ```
 
 Choose either one or more `--set` values or release-date bounds. Set values may be repeated or
-comma-separated. Results use unique printings, newest first. The target manifest's catalog is
-always used as the existing-card list; each repeatable `--existing-manifest` adds another catalog
-to that exclusion set. Prints match by Scryfall ID when available and by set plus collector number,
-so older manifest entries without an ID are still excluded.
+comma-separated. Results use unique printings and default to newest-first order. Add `--balanced`
+to fetch the bounded candidate pool and greedily favor underrepresented sets, color categories,
+primary card types, rarities, layouts, and treatments. Balanced selection is deterministic for the
+same Scryfall response, prefers non-basic cards, and selects at most one basic land. Its dry-run
+output lists the coverage categories for every card and summarizes the number of distinct values.
+It also prefers a new card name over another printing of a name already selected in that run.
+
+The target manifest's catalog is always used as the existing-card list; each repeatable
+`--existing-manifest` adds another catalog to that exclusion set. Prints match by Scryfall ID when
+available and by set plus collector number, so older manifest entries without an ID are still
+excluded. New catalog and expected-metadata entries retain the selected card's colors, layout, and
+derived treatment style so the coverage intent remains visible after import.
 
 The command writes images under `test-images/regression/scryfall/` and atomically updates
 `test/regression/fixtures/manifest.json`. Imported catalog and case entries are disabled to preserve
@@ -205,11 +220,12 @@ the review-first fixture policy. To finish an import:
 4. Run the new case by ID and inspect both benchmark reports.
 5. Adjust thresholds from repeated evidence, then run the full unit and regression gates.
 
-The importer accepts at most 100 cards per run, follows at most 20 result pages by default, stops
-as soon as enough unused printable cards are found, spaces API page requests by 125 ms, and rejects
-oversized or non-JPEG downloads. Use `--max-pages` only when a selection contains many already
-tracked or multi-face prints. Scryfall asks API clients to stay below 10 requests per second and to
-send identifying request headers; see their
+The importer accepts at most 100 cards per run, follows at most 20 result pages by default, spaces
+API page requests by 125 ms, and rejects oversized or non-JPEG downloads. Newest-first mode stops
+as soon as enough unused printable cards are found; balanced mode reads the bounded result pool
+before choosing. Use `--max-pages` only when a selection contains many already tracked or
+multi-face prints. Scryfall asks API clients to stay below 10 requests per second and to send
+identifying request headers; see their
 [API access guidance](https://scryfall.com/docs/faqs/i-m-having-trouble-accessing-the-scryfall-api-or-i-m-blocked-17).
 
 ### Add a captured image manually

--- a/scripts/import-scryfall-fixtures.mjs
+++ b/scripts/import-scryfall-fixtures.mjs
@@ -40,6 +40,7 @@ function buildProgram() {
             []
         )
         .option("--max-pages <number>", "maximum Scryfall result pages", "20")
+        .option("--balanced", "diversify selected prints across coverage categories", false)
         .option("--dry-run", "show selected prints without writing images or manifest", false);
 }
 
@@ -56,12 +57,24 @@ async function main(argv = process.argv, overrides = {}) {
         releasedBefore: options.releasedBefore,
         count: options.count,
         maxPages: options.maxPages,
+        balanced: options.balanced,
         dryRun: options.dryRun
     });
 
     writeLine(`${result.dryRun ? "Would import" : "Imported"} ${result.added.length} fixture(s):`);
     for (const card of result.added) {
-        writeLine(`- ${card.set}/${card.collectorNumber} ${card.name}`);
+        const coverage = options.balanced
+            ? ` [${card.colorCategory}; ${card.primaryType}; ${card.layout}; ${card.style}; ${card.rarity}]`
+            : "";
+        writeLine(`- ${card.set}/${card.collectorNumber} ${card.name}${coverage}`);
+    }
+    if (options.balanced) {
+        const uniqueCount = (key) => new Set(result.added.map((card) => card[key])).size;
+        writeLine(
+            `Coverage: sets=${uniqueCount("set")}, color categories=${uniqueCount("colorCategory")}, ` +
+                `types=${uniqueCount("primaryType")}, layouts=${uniqueCount("layout")}, ` +
+                `styles=${uniqueCount("style")}, rarities=${uniqueCount("rarity")}`
+        );
     }
     writeLine(`Excluded existing prints: ${result.excludedExisting}`);
     writeLine(`Skipped cards without usable front JPEGs: ${result.skippedUnprintable}`);

--- a/src/regression/balanced-card-selector.mjs
+++ b/src/regression/balanced-card-selector.mjs
@@ -1,0 +1,111 @@
+const COLOR_ORDER = ["W", "U", "B", "R", "G"];
+const TYPE_ORDER = [
+    "Land",
+    "Creature",
+    "Artifact",
+    "Enchantment",
+    "Planeswalker",
+    "Instant",
+    "Sorcery",
+    "Battle"
+];
+const COVERAGE_WEIGHTS = {
+    set: 8,
+    colorCategory: 5,
+    primaryType: 4,
+    style: 3,
+    rarity: 2,
+    layout: 1
+};
+const DEPRIORITIZE_SCORE = 100;
+
+function coverageStyle(card) {
+    const frameEffects = Array.isArray(card.frame_effects) ? card.frame_effects : [];
+    if (card.textless === true) return "textless";
+    if (frameEffects.includes("showcase")) return "showcase";
+    if (frameEffects.includes("extendedart")) return "extended-art";
+    if (card.full_art === true) return "full-art";
+    if (card.border_color === "borderless") return "borderless";
+    return "normal";
+}
+
+function primaryType(typeLine) {
+    return TYPE_ORDER.find((type) => typeLine.includes(type)) || "Other";
+}
+
+function colorCategory(colors, cardType) {
+    if (cardType === "Land") return "land";
+    if (colors.length === 0) return "colorless";
+    if (colors.length > 1) return "multicolor";
+    return colors[0];
+}
+
+function cardCoverage(card) {
+    const colors = Array.isArray(card.colors)
+        ? COLOR_ORDER.filter((color) => card.colors.includes(color))
+        : [];
+    const typeLine = typeof card.type_line === "string" ? card.type_line : "Unknown";
+    const cardType = primaryType(typeLine);
+    return {
+        typeLine,
+        colors,
+        layout: typeof card.layout === "string" ? card.layout : "unknown",
+        style: coverageStyle(card),
+        primaryType: cardType,
+        colorCategory: colorCategory(colors, cardType),
+        isBasicLand: /\bBasic Land\b/.test(typeLine)
+    };
+}
+
+function coverageScore(card, counts, selectedNames) {
+    let score = 0;
+    if (card.isBasicLand) score -= DEPRIORITIZE_SCORE;
+    if (selectedNames.has(card.name)) score -= DEPRIORITIZE_SCORE;
+    for (const [key, weight] of Object.entries(COVERAGE_WEIGHTS)) {
+        score += weight / ((counts[key].get(card[key]) || 0) + 1);
+    }
+    return score;
+}
+
+function selectBalancedCards(cards, count) {
+    const remaining = cards.map((card, index) => ({ card, index }));
+    const selected = [];
+    const counts = Object.fromEntries(
+        Object.keys(COVERAGE_WEIGHTS).map((category) => [category, new Map()])
+    );
+    let hasBasicLand = false;
+    const selectedNames = new Set();
+
+    while (selected.length < count) {
+        let best;
+        for (const candidate of remaining) {
+            if (candidate.card.isBasicLand && hasBasicLand) continue;
+            const score = coverageScore(candidate.card, counts, selectedNames);
+            if (
+                !best ||
+                score > best.score ||
+                (score === best.score && candidate.index < best.index)
+            ) {
+                best = { ...candidate, score };
+            }
+        }
+        if (!best) break;
+
+        selected.push(best.card);
+        hasBasicLand ||= best.card.isBasicLand;
+        selectedNames.add(best.card.name);
+        for (const key of Object.keys(COVERAGE_WEIGHTS)) {
+            const categoryCounts = counts[key];
+            const value = best.card[key];
+            categoryCounts.set(value, (categoryCounts.get(value) || 0) + 1);
+        }
+        remaining.splice(
+            remaining.findIndex((candidate) => candidate.index === best.index),
+            1
+        );
+    }
+
+    return selected;
+}
+
+export { cardCoverage, selectBalancedCards };

--- a/src/regression/scryfall-fixture-importer.mjs
+++ b/src/regression/scryfall-fixture-importer.mjs
@@ -6,6 +6,7 @@ import {
     fetchCardPages,
     imageUrlForCard
 } from "../scryfall-api/regression-fixtures.mjs";
+import { cardCoverage, selectBalancedCards } from "./balanced-card-selector.mjs";
 
 const DEFAULT_MAX_PAGES = 20;
 const MAX_COUNT = 100;
@@ -77,7 +78,8 @@ function normalizeImportOptions(options) {
             options.maxPages ?? DEFAULT_MAX_PAGES,
             "max-pages",
             MAX_PAGES
-        )
+        ),
+        balanced: options.balanced === true
     };
 }
 
@@ -157,13 +159,14 @@ function normalizeCard(card) {
     }
     const imageUrl = imageUrlForCard(card);
     if (!imageUrl) return undefined;
+    const coverage = cardCoverage(card);
     return {
         id: card.id,
         name: card.name,
         set: card.set.toUpperCase(),
         setName: card.set_name,
         collectorNumber: card.collector_number,
-        typeLine: typeof card.type_line === "string" ? card.type_line : "Unknown",
+        ...coverage,
         rarity: typeof card.rarity === "string" ? card.rarity : "unknown",
         apiUrl: typeof card.scryfall_uri === "string" ? card.scryfall_uri : card.uri,
         imageUrl
@@ -186,6 +189,9 @@ function fixtureEntries(card, manifestPath, imagePath) {
             collectorNumber: card.collectorNumber,
             typeLine: card.typeLine,
             rarity: card.rarity,
+            colors: card.colors,
+            layout: card.layout,
+            style: card.style,
             referenceImage: relativeImage,
             apiUrl: card.apiUrl
         },
@@ -201,7 +207,10 @@ function fixtureEntries(card, manifestPath, imagePath) {
                 collectorNumber: card.collectorNumber,
                 metadata: {
                     typeLine: card.typeLine,
-                    rarity: card.rarity
+                    rarity: card.rarity,
+                    colors: card.colors,
+                    layout: card.layout,
+                    style: card.style
                 },
                 minNameScore: 0.7,
                 maxPrintCandidates: 1,
@@ -246,13 +255,14 @@ async function importScryfallFixtures(options, overrides = {}) {
     }
 
     const fetchCardPages = overrides.fetchCardPages || defaultDependencies.fetchCardPages;
-    const cards = await fetchCardPages(buildCardSearchUrl(selection), {
-        maxPages: selection.maxPages,
-        shouldStop: (collectedCards) =>
-            hasEnoughNewPrintableCards(collectedCards, existing, selection.count)
-    });
-    const selected = [];
-    const selectedIdentities = new Set();
+    const fetchOptions = { maxPages: selection.maxPages };
+    if (!selection.balanced) {
+        fetchOptions.shouldStop = (collectedCards) =>
+            hasEnoughNewPrintableCards(collectedCards, existing, selection.count);
+    }
+    const cards = await fetchCardPages(buildCardSearchUrl(selection), fetchOptions);
+    const candidates = [];
+    const candidateIdentities = new Set();
     let excludedExisting = 0;
     let skippedUnprintable = 0;
 
@@ -265,16 +275,20 @@ async function importScryfallFixtures(options, overrides = {}) {
         const identities = printIdentities(card);
         if (
             identities.some(
-                (identity) => existing.has(identity) || selectedIdentities.has(identity)
+                (identity) => existing.has(identity) || candidateIdentities.has(identity)
             )
         ) {
             excludedExisting += 1;
             continue;
         }
-        selected.push(card);
-        for (const identity of identities) selectedIdentities.add(identity);
-        if (selected.length === selection.count) break;
+        candidates.push(card);
+        for (const identity of identities) candidateIdentities.add(identity);
+        if (!selection.balanced && candidates.length === selection.count) break;
     }
+
+    const selected = selection.balanced
+        ? selectBalancedCards(candidates, selection.count)
+        : candidates.slice(0, selection.count);
 
     if (selected.length < selection.count) {
         throw new Error(
@@ -287,7 +301,13 @@ async function importScryfallFixtures(options, overrides = {}) {
         scryfallId: card.id,
         name: card.name,
         set: card.set,
-        collectorNumber: card.collectorNumber
+        collectorNumber: card.collectorNumber,
+        colors: card.colors,
+        colorCategory: card.colorCategory,
+        primaryType: card.primaryType,
+        layout: card.layout,
+        style: card.style,
+        rarity: card.rarity
     }));
     if (options.dryRun) {
         return { added, excludedExisting, skippedUnprintable, dryRun: true };

--- a/test/regression/scryfall-fixture-importer.spec.mjs
+++ b/test/regression/scryfall-fixture-importer.spec.mjs
@@ -7,6 +7,7 @@ import {
     normalizeCard,
     normalizeImportOptions
 } from "../../src/regression/scryfall-fixture-importer.mjs";
+import { selectBalancedCards } from "../../src/regression/balanced-card-selector.mjs";
 import {
     buildCardSearchUrl,
     downloadImage,
@@ -21,8 +22,15 @@ describe("Scryfall regression fixture importer", () => {
                 releasedAfter: undefined,
                 releasedBefore: undefined,
                 count: 4,
-                maxPages: 20
+                maxPages: 20,
+                balanced: false
             });
+        });
+
+        it("enables balanced selection explicitly", () => {
+            assert.isTrue(
+                normalizeImportOptions({ sets: ["fin"], count: 4, balanced: true }).balanced
+            );
         });
 
         it("accepts a bounded release-date range", () => {
@@ -235,6 +243,118 @@ describe("Scryfall regression fixture importer", () => {
         assert.isUndefined(normalizeCard(malformed));
     });
 
+    describe("selectBalancedCards", () => {
+        it("deterministically spreads selections across coverage categories", () => {
+            const candidates = [
+                card({
+                    id: "basic-land",
+                    name: "Forest",
+                    set: "m20",
+                    collector: "280",
+                    typeLine: "Basic Land — Forest"
+                }),
+                card({ id: "white", name: "White", set: "m20", collector: "1", colors: ["W"] }),
+                card({
+                    id: "blue",
+                    name: "Blue",
+                    set: "m20",
+                    collector: "2",
+                    colors: ["U"],
+                    typeLine: "Instant",
+                    rarity: "uncommon"
+                }),
+                card({
+                    id: "black-showcase",
+                    name: "Black",
+                    set: "spm",
+                    collector: "3",
+                    colors: ["B"],
+                    frameEffects: ["showcase"],
+                    rarity: "rare"
+                }),
+                card({
+                    id: "red-borderless",
+                    name: "Red",
+                    set: "spm",
+                    collector: "4",
+                    colors: ["R"],
+                    typeLine: "Sorcery",
+                    borderColor: "borderless"
+                }),
+                card({
+                    id: "green-full-art",
+                    name: "Green",
+                    set: "m12",
+                    collector: "5",
+                    colors: ["G"],
+                    typeLine: "Enchantment",
+                    fullArt: true,
+                    rarity: "mythic"
+                }),
+                card({
+                    id: "colorless",
+                    name: "Colorless",
+                    set: "m12",
+                    collector: "6",
+                    typeLine: "Artifact",
+                    rarity: "rare"
+                })
+            ].map(normalizeCard);
+
+            const first = selectBalancedCards(candidates, 6);
+            const second = selectBalancedCards(candidates, 6);
+
+            assert.deepEqual(
+                first.map((entry) => entry.id),
+                second.map((entry) => entry.id)
+            );
+            assert.isAtLeast(new Set(first.map((entry) => entry.set)).size, 3);
+            assert.isAtLeast(new Set(first.map((entry) => entry.colorCategory)).size, 5);
+            assert.isAtLeast(new Set(first.map((entry) => entry.primaryType)).size, 4);
+            assert.isAtLeast(new Set(first.map((entry) => entry.style)).size, 3);
+            assert.isAtMost(first.filter((entry) => entry.isBasicLand).length, 1);
+        });
+
+        it("never selects more than one basic land", () => {
+            const candidates = [
+                card({
+                    id: "forest",
+                    name: "Forest",
+                    set: "m20",
+                    collector: "280",
+                    typeLine: "Basic Land — Forest"
+                }),
+                card({
+                    id: "island",
+                    name: "Island",
+                    set: "m20",
+                    collector: "281",
+                    typeLine: "Basic Land — Island"
+                }),
+                card({ id: "spell", name: "Spell", set: "m20", collector: "1" })
+            ].map(normalizeCard);
+
+            assert.lengthOf(selectBalancedCards(candidates, 3), 2);
+            assert.lengthOf(
+                selectBalancedCards(candidates, 3).filter((entry) => entry.isBasicLand),
+                1
+            );
+        });
+
+        it("prefers a new card name over another printing of a selected name", () => {
+            const candidates = [
+                card({ id: "first-print", name: "Shared Name", set: "m20", collector: "1" }),
+                card({ id: "second-print", name: "Shared Name", set: "m13", collector: "2" }),
+                card({ id: "unique", name: "Unique Name", set: "m13", collector: "3" })
+            ].map(normalizeCard);
+
+            assert.deepEqual(
+                selectBalancedCards(candidates, 2).map((entry) => entry.id),
+                ["first-print", "unique"]
+            );
+        });
+    });
+
     describe("importScryfallFixtures", () => {
         let directory;
 
@@ -269,7 +389,10 @@ describe("Scryfall regression fixture importer", () => {
                     count: 1
                 },
                 {
-                    fetchCardPages: async () => cards,
+                    fetchCardPages: async (_url, options) => {
+                        assert.isFunction(options.shouldStop);
+                        return cards;
+                    },
                     downloadImage: async (url, destination) => {
                         downloads.push({ url, destination });
                         await writeFile(destination, "image bytes");
@@ -290,6 +413,9 @@ describe("Scryfall regression fixture importer", () => {
                 set: "FIN",
                 setName: "Final Fantasy",
                 collectorNumber: "42",
+                colors: ["U"],
+                layout: "normal",
+                style: "normal",
                 referenceImage: "../test-images/scryfall/fin-42-fresh-card-new-id.jpg"
             });
             assert.deepInclude(manifest.cases[1], {
@@ -303,6 +429,59 @@ describe("Scryfall regression fixture importer", () => {
                 set: "FIN",
                 collectorNumber: "42"
             });
+            assert.deepEqual(manifest.cases[1].expected.metadata, {
+                typeLine: "Creature — Test",
+                rarity: "common",
+                colors: ["U"],
+                layout: "normal",
+                style: "normal"
+            });
+        });
+
+        it("fetches the bounded candidate pool before balanced selection", async () => {
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeManifest(manifestPath, emptyManifest());
+            let fetchOptions;
+
+            const result = await importScryfallFixtures(
+                {
+                    manifestPath,
+                    imageDirectory: path.join(directory, "images"),
+                    sets: ["m20", "spm"],
+                    count: 2,
+                    balanced: true,
+                    dryRun: true
+                },
+                {
+                    fetchCardPages: async (_url, options) => {
+                        fetchOptions = options;
+                        return [
+                            card({
+                                id: "forest",
+                                name: "Forest",
+                                set: "m20",
+                                collector: "280",
+                                typeLine: "Basic Land — Forest"
+                            }),
+                            card({ id: "white", name: "White", set: "m20", collector: "1" }),
+                            card({
+                                id: "showcase",
+                                name: "Showcase",
+                                set: "spm",
+                                collector: "2",
+                                colors: ["B"],
+                                frameEffects: ["showcase"]
+                            })
+                        ];
+                    }
+                }
+            );
+
+            assert.notProperty(fetchOptions, "shouldStop");
+            assert.sameMembers(
+                result.added.map((entry) => entry.scryfallId),
+                ["white", "showcase"]
+            );
         });
 
         it("excludes prints listed in extra existing manifests", async () => {
@@ -381,7 +560,19 @@ describe("Scryfall regression fixture importer", () => {
     });
 });
 
-function card({ id, name, set, collector }) {
+function card({
+    id,
+    name,
+    set,
+    collector,
+    colors = ["U"],
+    typeLine = "Creature — Test",
+    rarity = "common",
+    layout = "normal",
+    frameEffects = [],
+    borderColor = "black",
+    fullArt = false
+}) {
     return {
         id,
         name,
@@ -390,8 +581,13 @@ function card({ id, name, set, collector }) {
         set,
         set_name: set === "fin" ? "Final Fantasy" : "Old Set",
         collector_number: collector,
-        type_line: "Creature — Test",
-        rarity: "common",
+        colors,
+        type_line: typeLine,
+        rarity,
+        layout,
+        frame_effects: frameEffects,
+        border_color: borderColor,
+        full_art: fullArt,
         scryfall_uri: `https://scryfall.com/card/${set}/${collector}`,
         image_uris: {
             normal: `https://cards.scryfall.io/normal/${id}.jpg`

--- a/test/scripts/import-scryfall-fixtures.spec.mjs
+++ b/test/scripts/import-scryfall-fixtures.spec.mjs
@@ -18,6 +18,7 @@ describe("import-scryfall-fixtures CLI", () => {
                 "first.json",
                 "--existing-manifest",
                 "second.json",
+                "--balanced",
                 "--dry-run"
             ])
             .opts();
@@ -25,6 +26,7 @@ describe("import-scryfall-fixtures CLI", () => {
         assert.deepEqual(options.set, ["fin,dsk", "tdm"]);
         assert.equal(options.count, "6");
         assert.deepEqual(options.existingManifest, ["first.json", "second.json"]);
+        assert.isTrue(options.balanced);
         assert.isTrue(options.dryRun);
     });
 
@@ -41,7 +43,8 @@ describe("import-scryfall-fixtures CLI", () => {
                 "--released-before",
                 "2025-06-30",
                 "--count",
-                "2"
+                "2",
+                "--balanced"
             ],
             {
                 importer: async (options) => {
@@ -52,13 +55,23 @@ describe("import-scryfall-fixtures CLI", () => {
                                 name: "Card One",
                                 set: "ONE",
                                 collectorNumber: "1",
-                                scryfallId: "one"
+                                scryfallId: "one",
+                                colorCategory: "W",
+                                primaryType: "Creature",
+                                layout: "normal",
+                                style: "normal",
+                                rarity: "common"
                             },
                             {
                                 name: "Card Two",
                                 set: "TWO",
                                 collectorNumber: "2",
-                                scryfallId: "two"
+                                scryfallId: "two",
+                                colorCategory: "U",
+                                primaryType: "Instant",
+                                layout: "transform",
+                                style: "showcase",
+                                rarity: "rare"
                             }
                         ],
                         excludedExisting: 3,
@@ -75,11 +88,16 @@ describe("import-scryfall-fixtures CLI", () => {
             releasedAfter: "2025-01-01",
             releasedBefore: "2025-06-30",
             count: "2",
+            balanced: true,
             dryRun: false
         });
         assert.strictEqual(result.added.length, 2);
         assert.include(output[0], "Imported 2 fixture(s)");
-        assert.include(output.join("\n"), "ONE/1 Card One");
+        assert.include(output.join("\n"), "ONE/1 Card One [W; Creature; normal; normal; common]");
+        assert.include(
+            output.join("\n"),
+            "Coverage: sets=2, color categories=2, types=2, layouts=2, styles=2, rarities=2"
+        );
         assert.include(output.join("\n"), "Excluded existing prints: 3");
     });
 });


### PR DESCRIPTION
## Summary

- add an opt-in `--balanced` mode for deterministic Scryfall fixture selection
- diversify picks across sets, color categories, primary types, layouts, treatments, and rarities
- prefer unique names and non-basic cards while capping basic lands at one
- retain coverage metadata in imported catalog and expected entries
- show per-card coverage and a compact coverage summary during balanced dry runs
- preserve newest-first selection as the default

## Live dry-run evidence

- core cohort (`M12`, `M13`, `M20`): 3 sets, 8 color categories, 7 types, 4 rarities
- early Modern cohort (`8ED` through `SOM`): 9 sets, 8 color categories, 6 types, 2 styles, 4 rarities
- pop-culture cohort (`SPM`, `TLA`, `TMT`, `MSH`): 4 sets, 8 color categories, 6 types, 6 styles, 4 rarities

The dry runs wrote no images or manifest entries. Vintage sets remain excluded from the planned cohorts.

## Verification

- ESLint passed
- Prettier check passed
- TypeScript check passed
- 204 unit tests passed
- repository pre-commit lint-staged hook passed
- three live Scryfall cohort dry runs passed