### PR TITLE
feat: improve console output and local cache reliability

### DIFF
--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -45,6 +45,9 @@ Deliberately dependency-free (only core Node modules) so it runs before `pnpm in
 
 Flags compose: `node scripts/setup.mjs --with-mysql --skip-seed` skips seeding but still sets up MySQL.
 
+Name seeding prints one start summary and one completion summary. Inserts run with bounded
+concurrency, so large Scryfall catalogs do not create an unbounded burst of database work.
+
 With `--with-mysql`, the generated `secure.config.cjs` matches `docker-compose.yml`'s actual defaults (host/port/user/password/database) so `pnpm setup-db` works immediately — it does **not** just copy the generic template (which has placeholder values and would fail to connect).
 
 ## Persistence architecture (what you're setting up)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -50,6 +50,27 @@ node index.mjs ./path/to/card.jpg
 needs-attention records only when both resolve to `true`. Without both, the full identification
 pipeline still runs and prints its results.
 
+Pretty logging is enabled by default. It keeps pipeline detail visible with compact, aligned level
+labels, emits one OCR progress heartbeat per crop, and prints final card/set candidates without
+internal verification objects:
+
+```text
+INFO  Reading card name
+INFO  OCR name-core: 50%
+INFO  OCR name-core: 87% confidence; "Pacifism" -> "PACIFISM"
+INFO  Name candidates (1): 1. Pacifism (100%)
+
+Scan results
+
+1. Pacifism
+   Sets: Core Set 2020
+```
+
+Interactive terminals receive colored level labels; redirected output remains color-free. Use
+`--no-pretty` when another tool needs unadorned log messages. Full match verification details stay
+available through the local operations log and `--debug` instead of being dumped into routine scan
+output.
+
 ## Inspect scan activity
 
 Every scan records an operations-log entry while the local cache is enabled. Entries include the

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "dependencies": {
         "@dills1220/nedb": "^1.9.1",
         "async": "^3.2.6",
-        "bunyan": "^1.8.15",
         "clean-text-utils": "^1.3.0",
         "commander": "^15.0.0",
         "fuzzyset.js": "1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       async:
         specifier: ^3.2.6
         version: 3.2.6
-      bunyan:
-        specifier: ^1.8.15
-        version: 1.8.15
       clean-text-utils:
         specifier: ^1.3.0
         version: 1.3.0
@@ -559,9 +556,6 @@ packages:
   bmp-js@0.1.0:
     resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
-
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
@@ -581,11 +575,6 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
-  bunyan@1.8.15:
-    resolution: {integrity: sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==}
-    engines: {'0': node >=0.10.0}
-    hasBin: true
 
   c8@12.0.0:
     resolution: {integrity: sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==}
@@ -646,9 +635,6 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -697,10 +683,6 @@ packages:
 
   dom-walk@0.1.2:
     resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
-
-  dtrace-provider@0.8.8:
-    resolution: {integrity: sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==}
-    engines: {node: '>=0.10'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -896,10 +878,6 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  glob@6.0.4:
-    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   global@4.4.0:
     resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
 
@@ -969,10 +947,6 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1218,23 +1192,13 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   mocha@11.8.0:
     resolution: {integrity: sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==}
@@ -1244,15 +1208,8 @@ packages:
   module-not-found-error@1.0.1:
     resolution: {integrity: sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==}
 
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mv@2.1.1:
-    resolution: {integrity: sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==}
-    engines: {node: '>=0.8.0'}
 
   mysql2@3.16.0:
     resolution: {integrity: sha512-AEGW7QLLSuSnjCS4pk3EIqOmogegmze9h8EyrndavUQnIUcfkVal/sK7QznE+a3bc6rzPbAiui9Jcb+96tPwYA==}
@@ -1262,15 +1219,8 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
-  nan@2.22.2:
-    resolution: {integrity: sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==}
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  ncp@2.0.0:
-    resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
-    hasBin: true
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -1286,9 +1236,6 @@ packages:
 
   omggif@1.0.10:
     resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   opencollective-postinstall@2.0.3:
     resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
@@ -1327,10 +1274,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1461,11 +1404,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rimraf@2.4.5:
-    resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -1473,9 +1411,6 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safe-json-stringify@1.2.0:
-    resolution: {integrity: sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1704,9 +1639,6 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
@@ -2253,12 +2185,6 @@ snapshots:
 
   bmp-js@0.1.0: {}
 
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-    optional: true
-
   brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
@@ -2280,13 +2206,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  bunyan@1.8.15:
-    optionalDependencies:
-      dtrace-provider: 0.8.8
-      moment: 2.30.1
-      mv: 2.1.1
-      safe-json-stringify: 1.2.0
 
   c8@12.0.0:
     dependencies:
@@ -2351,9 +2270,6 @@ snapshots:
 
   commander@15.0.0: {}
 
-  concat-map@0.0.1:
-    optional: true
-
   convert-source-map@2.0.0: {}
 
   core-util-is@1.0.2: {}
@@ -2387,11 +2303,6 @@ snapshots:
   diff@8.0.4: {}
 
   dom-walk@0.1.2: {}
-
-  dtrace-provider@0.8.8:
-    dependencies:
-      nan: 2.22.2
-    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -2591,15 +2502,6 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  glob@6.0.4:
-    dependencies:
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    optional: true
-
   global@4.4.0:
     dependencies:
       min-document: 2.19.0
@@ -2666,12 +2568,6 @@ snapshots:
   immediate@3.0.6: {}
 
   imurmurhash@0.1.4: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    optional: true
 
   inherits@2.0.4: {}
 
@@ -2906,24 +2802,11 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.7
 
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.15
-    optional: true
-
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.1
 
-  minimist@1.2.8:
-    optional: true
-
   minipass@7.1.3: {}
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-    optional: true
 
   mocha@11.8.0:
     dependencies:
@@ -2951,17 +2834,7 @@ snapshots:
 
   module-not-found-error@1.0.1: {}
 
-  moment@2.30.1:
-    optional: true
-
   ms@2.1.3: {}
-
-  mv@2.1.1:
-    dependencies:
-      mkdirp: 0.5.6
-      ncp: 2.0.0
-      rimraf: 2.4.5
-    optional: true
 
   mysql2@3.16.0:
     dependencies:
@@ -2979,13 +2852,7 @@ snapshots:
     dependencies:
       lru.min: 1.1.3
 
-  nan@2.22.2:
-    optional: true
-
   natural-compare@1.4.0: {}
-
-  ncp@2.0.0:
-    optional: true
 
   node-fetch@2.7.0:
     dependencies:
@@ -2994,11 +2861,6 @@ snapshots:
   oauth-sign@0.9.0: {}
 
   omggif@1.0.10: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-    optional: true
 
   opencollective-postinstall@2.0.3: {}
 
@@ -3035,9 +2897,6 @@ snapshots:
   parse-headers@2.0.6: {}
 
   path-exists@4.0.0: {}
-
-  path-is-absolute@1.0.1:
-    optional: true
 
   path-key@3.1.1: {}
 
@@ -3166,20 +3025,12 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rimraf@2.4.5:
-    dependencies:
-      glob: 6.0.4
-    optional: true
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
   safe-buffer@5.2.1: {}
-
-  safe-json-stringify@1.2.0:
-    optional: true
 
   safer-buffer@2.1.2: {}
 
@@ -3416,9 +3267,6 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
-
-  wrappy@1.0.2:
-    optional: true
 
   xhr@2.6.0:
     dependencies:

--- a/src/back-filler.mjs
+++ b/src/back-filler.mjs
@@ -2,10 +2,12 @@ import _ from "lodash";
 import storage from "./storage/index.mjs";
 import scryfall from "./scryfall-api/index.mjs";
 import imageHashing from "./image-hashing/index.mjs";
+import log from "./logger/log.mjs";
 
 const { names: NamesStore, hashes: HashesStore } = storage;
 const { Search } = scryfall;
 const { Hash } = imageHashing;
+const logger = log.create({ isPretty: true });
 
 async function backFillCardHashes(cardName) {
     try {
@@ -36,7 +38,7 @@ async function backFillCardHashes(cardName) {
         }
         return true;
     } catch (err) {
-        console.log(err);
+        logger.error(`Unable to backfill hashes for "${cardName}": ${err?.message || String(err)}`);
         return false;
     }
 }

--- a/src/console/format-scan-results.mjs
+++ b/src/console/format-scan-results.mjs
@@ -1,0 +1,20 @@
+function formatScanResults(results = []) {
+    if (!results.length) {
+        return "No scan results.";
+    }
+
+    const rows = results.map((result, index) => {
+        const name = result?.name || "Unknown card";
+        const sets =
+            Array.isArray(result?.sets) && result.sets.length
+                ? result.sets.join(", ")
+                : "No set match";
+        return `${index + 1}. ${name}\n   Sets: ${sets}`;
+    });
+
+    return `Scan results\n\n${rows.join("\n\n")}`;
+}
+
+export { formatScanResults };
+
+export default formatScanResults;

--- a/src/db-local/bulk-insert.mjs
+++ b/src/db-local/bulk-insert.mjs
@@ -1,29 +1,48 @@
 import { db } from "./db.mjs";
 import scryfallApi from "../scryfall-api/index.mjs";
+import { pathToFileURL } from "node:url";
+import { seedCardNames } from "./seed-card-names.mjs";
 
 const { GetCardNames } = scryfallApi;
 
-async function ExecuteBulkInsert() {
-    const names = await GetCardNames();
-    names.forEach((name) => {
-        db.insert(
-            {
-                name
-            },
-            (err) => {
-                if (!err) {
-                    console.log("local inserted");
+const dependencies = {
+    GetCardNames,
+    insertName(name) {
+        return new Promise((resolve, reject) => {
+            db.insert(
+                {
+                    name
+                },
+                (error) => {
+                    if (error) {
+                        reject(error);
+                        return;
+                    }
+                    resolve();
                 }
-            }
-        );
+            );
+        });
+    }
+};
+
+async function ExecuteBulkInsert(options = {}) {
+    return seedCardNames({
+        getCardNames: options.getCardNames || dependencies.GetCardNames,
+        insertName: options.insertName || dependencies.insertName,
+        logger: options.logger || console,
+        concurrency: options.concurrency
     });
 }
 
-(async () => {
-    await ExecuteBulkInsert();
-})();
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+    ExecuteBulkInsert().catch((error) => {
+        console.error(`Card-name seed failed: ${error?.message || String(error)}`);
+        process.exitCode = 1;
+    });
+}
 
-export { ExecuteBulkInsert };
+export { dependencies, ExecuteBulkInsert };
 
 export default {
     ExecuteBulkInsert

--- a/src/db-local/card-hash-cache.mjs
+++ b/src/db-local/card-hash-cache.mjs
@@ -63,17 +63,21 @@ function normalizeRecord(record = {}) {
     return normalized;
 }
 
-function InsertEntity(record) {
+function InsertEntity(record, callback = () => {}) {
     const normalized = normalizeRecord(record);
     if (!normalized.cardName || !normalized.setName || !normalized.cardHash) {
+        callback(null, 0);
         return;
     }
-    db.update(
-        { lookupKey: normalized.lookupKey },
-        { $set: normalized, $setOnInsert: { createdAt: new Date() } },
-        { upsert: true },
-        () => {}
-    );
+    const query = { lookupKey: normalized.lookupKey };
+    db.findOne(query, (findError, existing) => {
+        if (findError) {
+            callback(findError);
+            return;
+        }
+        const fields = existing ? normalized : { ...normalized, createdAt: new Date() };
+        db.update(query, { $set: fields }, { upsert: true }, callback);
+    });
 }
 
 function GetHashes(name, cb) {

--- a/src/db-local/grab-names.mjs
+++ b/src/db-local/grab-names.mjs
@@ -1,7 +1,7 @@
 import { db } from "./db.mjs";
 
-function GetBulkNames(cb) {
-    db.find({}, (err, docs) => {
+function GetBulkNames(cb, store = db) {
+    store.find({}, (err, docs) => {
         if (err) {
             return cb(err);
         }

--- a/src/db-local/seed-card-names.mjs
+++ b/src/db-local/seed-card-names.mjs
@@ -1,0 +1,47 @@
+const DEFAULT_CONCURRENCY = 8;
+const MAX_CONCURRENCY = 32;
+
+async function seedCardNames({
+    getCardNames,
+    insertName,
+    logger = console,
+    concurrency = DEFAULT_CONCURRENCY
+}) {
+    const names = await getCardNames();
+    if (!Array.isArray(names)) {
+        throw new Error("Scryfall card-name response must be an array");
+    }
+    if (names.some((name) => typeof name !== "string" || !name.trim())) {
+        throw new Error("Scryfall card names must be non-empty strings");
+    }
+    if (names.length === 0) {
+        logger.log("No card names returned; nothing to seed.");
+        return { inserted: 0 };
+    }
+
+    logger.log(`Seeding ${names.length} card names...`);
+    const workerCount = Math.min(names.length, normalizeConcurrency(concurrency));
+    let nextIndex = 0;
+    const workers = Array.from({ length: workerCount }, async () => {
+        while (nextIndex < names.length) {
+            const index = nextIndex;
+            nextIndex += 1;
+            await insertName(names[index]);
+        }
+    });
+    await Promise.all(workers);
+    logger.log(`Seeded ${names.length} card names.`);
+    return { inserted: names.length };
+}
+
+function normalizeConcurrency(value) {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        return DEFAULT_CONCURRENCY;
+    }
+    return Math.min(parsed, MAX_CONCURRENCY);
+}
+
+export { seedCardNames };
+
+export default seedCardNames;

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -59,7 +59,7 @@ class ProcessHashes {
     }
 
     async compareDbHashes() {
-        this.logger.info(`process-hashes::db-compare start name="${this.name}"`);
+        this.logger.info(`Checking local hash cache for "${this.name}"`);
         const hashes = await this.dependencies.CardHashes.getByCardName(this.name);
         const matches = [];
         hashes.forEach((dbHash) => {
@@ -79,9 +79,8 @@ class ProcessHashes {
                 );
             }
         });
-        this.logger.info(`process-hashes::db-compare matches=${matches.length}`);
+        this.logger.info(`Local hash cache matches for "${this.name}": ${matches.length}`);
         if (matches.length === 0) {
-            this.logger.info(`process-hashes::db-compare none name="${this.name}"`);
             if (this.ignoreNoDbMatch) {
                 return [];
             }
@@ -93,8 +92,9 @@ class ProcessHashes {
     }
 
     async compareRemoteImages() {
+        const imageLabel = this.cards.length === 1 ? "image" : "images";
         this.logger.info(
-            `process-hashes::remote-compare start name="${this.name}" mode=${this.hashMode} cards=${this.cards.length}`
+            `Comparing ${this.cards.length} Scryfall ${imageLabel} for "${this.name}" (${this.hashMode})`
         );
         const cards = _.map(this.cards, function (card) {
             const images = card.image_uris || {};
@@ -171,10 +171,10 @@ class ProcessHashes {
                 .slice(0, config.remoteBestGuess.maxCandidates)
                 .map((match) => _.omit(match, ["confidenceScore"]));
             this.logger.info(
-                `process-hashes::remote-compare using-best-guess name="${this.name}" candidates=${bestMatches.map((match) => match.setName).join(",")}`
+                `Using closest image matches for "${this.name}": ${bestMatches.map((match) => match.setName).join(", ")}`
             );
         }
-        this.logger.info(`process-hashes::remote-compare complete matches=${bestMatches.length}`);
+        this.logger.info(`Scryfall image matches for "${this.name}": ${bestMatches.length}`);
         return bestMatches;
     }
 
@@ -209,7 +209,7 @@ class ProcessHashes {
             return await this._hashRemoteSetSymbol(url, tempDirectory);
         } catch {
             this.logger.error(
-                `Remote set symbol crop/hash failed for ${url}; falling back to full image hash`
+                `Remote set-symbol hash failed for "${this.name}"; using full card image`
             );
             return new Promise((resolve, reject) => {
                 this.dependencies.Hash.HashImage(url, (hashErr, hash) => {

--- a/src/image-analysis/extract-text.mjs
+++ b/src/image-analysis/extract-text.mjs
@@ -16,8 +16,10 @@ const logger = log.create({
 function ScanImage(imgBuffer, type, cb, options = {}) {
     const scanLogger = options.logger || logger;
     const candidates = normalizeCandidates(imgBuffer, type);
+    const regionLabel = candidates.map((candidate) => candidate.region).join(", ");
+    const regionWord = candidates.length === 1 ? "region" : "regions";
     scanLogger.info(
-        `extract-text::ScanImage:: type=${type || "unknown"} source=${describeImageSource(imgBuffer)} candidates=${summarizeCandidates(candidates)}`
+        `OCR ${type || "unknown"}: ${candidates.length} ${regionWord} (${regionLabel})`
     );
     runCandidatesSequentially(candidates, type, scanLogger, options)
         .then((results) => {
@@ -86,7 +88,7 @@ async function runCandidate(candidate, type, scanLogger, options = {}) {
     const cleanedString = normalizeOcrText(extractedText, type);
     const confidence = (result && result.data && result.data.confidence) || 0;
     scanLogger.info(
-        `extract-text::result region=${candidate.region} confidence=${Math.round(confidence)} raw="${previewText(extractedText)}" normalized="${cleanedString}"`
+        `OCR ${candidate.region}: ${Math.round(confidence)}% confidence; "${previewText(extractedText)}" -> "${cleanedString}"`
     );
     return {
         region: candidate.region,
@@ -258,35 +260,15 @@ function scoreNameLine(line) {
     return score;
 }
 
-function describeImageSource(input) {
-    if (Array.isArray(input)) {
-        return "variant-list";
-    }
-    if (Buffer.isBuffer(input)) {
-        return "buffer";
-    }
-    if (typeof input === "string") {
-        return input;
-    }
-    return typeof input;
-}
-
-function summarizeCandidates(candidates = []) {
-    return candidates.map((candidate) => `${candidate.region}:${candidate.psm}`).join(",");
-}
-
 function buildProgressLogger(region, progressLogger = logger) {
-    let lastBucket = -1;
+    let halfwayLogged = false;
     return (progress = 0) => {
-        const bucket = Math.min(100, Math.max(0, Math.floor(Number(progress) * 100)));
-        if (bucket < 100 && bucket % 10 !== 0) {
+        const value = Number(progress);
+        if (halfwayLogged || value < 0.5 || value >= 1) {
             return;
         }
-        if (bucket === lastBucket) {
-            return;
-        }
-        lastBucket = bucket;
-        progressLogger.info(`extract-text::progress region=${region} progress=${bucket}%`);
+        halfwayLogged = true;
+        progressLogger.info(`OCR ${region}: 50%`);
     };
 }
 

--- a/src/image-hashing/base64-img.mjs
+++ b/src/image-hashing/base64-img.mjs
@@ -21,7 +21,7 @@ async function StringfyImagesNDAtn(imagePaths) {
             typeImage,
             nameImage
         };
-        logger.info(`base64-img::StringfyImagesNDAtn : ${Object.keys(base64Images)}`);
+        logger.info(`Encoding image snippets: ${Object.keys(base64Images).join(", ")}`);
         return base64Images;
     } catch (error) {
         logger.error(error);

--- a/src/image-hashing/hash-image.mjs
+++ b/src/image-hashing/hash-image.mjs
@@ -12,7 +12,7 @@ const logger = log.create({
 });
 
 function HashImage(imgUrl, cb) {
-    logger.info(`hash-image::hash start source="${imgUrl}"`);
+    logger.info(`Hashing image: ${formatImageSource(imgUrl)}`);
     dependencies.imageHash(imgUrl, 16, true, (error, data) => {
         if (error) {
             return cb(error);
@@ -22,9 +22,6 @@ function HashImage(imgUrl, cb) {
 }
 
 function CompareHash(hashOne, hashTwo) {
-    logger.info(
-        `hash-image::compare start left=${previewHash(hashOne)} right=${previewHash(hashTwo)}`
-    );
     const HashLength = hashOne.length;
     let twoBitMatches = 0;
     let fourBitMatches = 0;
@@ -45,18 +42,31 @@ function CompareHash(hashOne, hashTwo) {
         fourBitMatches: _.round(fourBitMatches / (HashLength / 4), 2),
         stringCompare: _.round(stringSimilarity.compareTwoStrings(hashOne, hashTwo), 2)
     };
-    logger.info("hash-image::compare result", comparisonResults);
+    logger.info(
+        `Hash similarity: 2-bit ${toPercent(comparisonResults.twoBitMatches)}, 4-bit ${toPercent(comparisonResults.fourBitMatches)}, text ${toPercent(comparisonResults.stringCompare)}`
+    );
     return comparisonResults;
 }
 
-function previewHash(hash = "") {
-    if (!hash) {
-        return "empty";
+function formatImageSource(source) {
+    const value = String(source || "");
+    if (!value) {
+        return "unknown source";
     }
-    if (hash.length <= 16) {
-        return hash;
+    if (/^https?:\/\//i.test(value)) {
+        try {
+            const url = new URL(value);
+            const filename = url.pathname.split("/").filter(Boolean).pop() || "image";
+            return `${url.hostname}/${filename}`;
+        } catch {
+            return "invalid URL";
+        }
     }
-    return `${hash.slice(0, 8)}...${hash.slice(-8)}(len=${hash.length})`;
+    return value.split(/[\\/]/).filter(Boolean).pop() || "unknown source";
+}
+
+function toPercent(score) {
+    return `${Math.round(Number(score) * 100)}%`;
 }
 
 export { CompareHash, HashImage };

--- a/src/logger/log.mjs
+++ b/src/logger/log.mjs
@@ -1,58 +1,66 @@
-import _ from "lodash";
-import bunyan from "bunyan";
+import { inspect } from "node:util";
+
+const LEVEL_COLORS = {
+    info: "\u001b[36m",
+    warn: "\u001b[33m",
+    error: "\u001b[31m"
+};
+const COLOR_RESET = "\u001b[0m";
 
 class Logger {
     constructor(params = {}) {
-        _.bindAll(this, Object.keys(Logger.prototype));
         this.isPretty = params.isPretty ?? true;
-        if (this.isPretty) {
-            this.bunyan = bunyan.createLogger({
-                level: 4,
-                name: "MTG-Processor"
-            });
-        }
+        this.sink = params.sink || console;
+        this.colors =
+            params.colors ??
+            (this.isPretty &&
+                this.sink === console &&
+                Boolean(process.stdout.isTTY) &&
+                process.env.NO_COLOR === undefined);
     }
 
     info(message, object) {
-        if (this.bunyan) {
-            this.bunyan.info(`${message}`);
-            if (object) {
-                this.bunyan.info(object);
-            }
-            return;
-        }
-        console.log(message);
-        if (object) {
-            console.log(JSON.stringify(object, null, 4));
-        }
+        this.#write("info", "log", message, object);
     }
 
     warn(message, object) {
-        if (this.bunyan) {
-            this.bunyan.warn(`${message}`);
-            if (object) {
-                this.bunyan.warn(object);
-            }
-            return;
-        }
-        console.warn(message);
-        if (object) {
-            console.warn(JSON.stringify(object, null, 4));
-        }
+        this.#write("warn", "warn", message, object);
     }
 
     error(message, object) {
-        if (this.bunyan) {
-            this.bunyan.error(`${message}`);
-            if (object) {
-                this.bunyan.error(object);
+        this.#write("error", "error", message, object);
+    }
+
+    output(message) {
+        this.sink.log(message);
+    }
+
+    #write(level, method, message, object) {
+        if (!this.isPretty) {
+            this.sink[method](message);
+            if (object !== undefined) {
+                this.sink[method](JSON.stringify(object, null, 4));
             }
             return;
         }
-        console.error(message);
-        if (object) {
-            console.error(JSON.stringify(object, null, 4));
+
+        const label = level.toUpperCase().padEnd(5);
+        const renderedLabel = this.colors ? `${LEVEL_COLORS[level]}${label}${COLOR_RESET}` : label;
+        const renderedMessage = message instanceof Error ? message.message : String(message);
+        let output = `${renderedLabel} ${renderedMessage}`;
+        if (object !== undefined) {
+            const details = inspect(object, {
+                colors: this.colors,
+                depth: 5,
+                breakLength: 100,
+                compact: false
+            })
+                .split("\n")
+                .map((line) => `      ${line}`)
+                .join("\n");
+            output += `\n${details}`;
         }
+        this.sink[method](output);
     }
 }
 

--- a/src/matcher/matching-processor.mjs
+++ b/src/matcher/matching-processor.mjs
@@ -44,7 +44,7 @@ class MatcherProcessor {
     }
 
     _search(callback) {
-        this.logger.info(`matcher::search start name="${this.name}"`);
+        this.logger.info(`Searching Scryfall for "${this.name}"`);
         dependencies.Searcher(this.name, (err, results) => {
             if (err) {
                 return callback(err);
@@ -55,20 +55,19 @@ class MatcherProcessor {
     }
 
     _processResults(callback) {
-        const numCards = _.isArray(this.cards) ? this.cards.length : "invalid";
-        this.logger.info(`matcher::search results name="${this.name}" count=${numCards}`);
         if (!_.isArray(this.cards)) {
+            this.logger.error(`Scryfall response for "${this.name}" was not a printing list`);
             return callback(new Error("Error gathering results"));
         }
         const totalCards = this.cards.length;
+        const printingLabel = totalCards === 1 ? "printing" : "printings";
+        this.logger.info(`Scryfall returned ${totalCards} ${printingLabel} for "${this.name}"`);
 
         if (totalCards === 0) {
-            this.logger.info(`matcher::search no-results name="${this.name}"`);
             return callback(null, 0);
         }
 
         if (totalCards === 1) {
-            this.logger.info(`matcher::search single-result name="${this.name}"`);
             const single = this.cards[0] || {};
             const setName = _.get(single, "set_name", "");
             this.matchResultDetails = [
@@ -80,7 +79,6 @@ class MatcherProcessor {
             return callback(null, setName ? [setName] : []);
         }
 
-        this.logger.info(`matcher::search multi-results name="${this.name}" count=${totalCards}`);
         async.waterfall(
             [(next) => this._hashLocalCard(next), (next) => this._processMultiSetMatches(next)],
             callback
@@ -88,7 +86,6 @@ class MatcherProcessor {
     }
 
     _hashLocalCard(callback) {
-        this.logger.info(`matcher::hash local-image name="${this.name}" path="${this.filePath}"`);
         dependencies
             .CreateDirectory()
             .then((directory) => {
@@ -96,7 +93,7 @@ class MatcherProcessor {
                 this._hashFromSetSymbol(directory, (hashErr) => {
                     if (hashErr) {
                         this.logger.error(
-                            `Set symbol crop/hash failed for ${this.filePath}; falling back to full card hash`
+                            `Set-symbol hash failed for "${this.name}"; using full card image`
                         );
                         return this._hashFromPath(this.filePath, callback);
                     }
@@ -109,7 +106,7 @@ class MatcherProcessor {
     }
 
     _hashFromSetSymbol(directory, callback) {
-        this.logger.info(`matcher::hash set-symbol name="${this.name}" path="${this.filePath}"`);
+        this.logger.info(`Hashing set symbol for "${this.name}"`);
         dependencies
             .GetSetSymbolSnippetTmpFile(this.filePath, directory, "set-symbol")
             .then((setSymbolPath) => {
@@ -167,7 +164,7 @@ class MatcherProcessor {
             allowRemoteBestGuess: true
         });
         this.logger.info(
-            `matcher::hash compare-start name="${this.name}" mode=${this.hashMode || "full-card"} cardCount=${this.cards.length}`
+            `Comparing ${this.cards.length} printings for "${this.name}" using ${this.hashMode || "full-card"} hashes`
         );
         const shouldQueryCache = true;
         const dbPromise = shouldQueryCache
@@ -188,9 +185,7 @@ class MatcherProcessor {
         const mergedResults = _.uniq((db || []).concat(remote || []));
         this.matchResults = mergedResults;
         this.matchResultDetails = this._buildMatchDetails(mergedResults);
-        this.logger.info(
-            `matcher::hash compare-complete name="${this.name}" mergedSets=${mergedResults.join(",") || "none"}`
-        );
+        this.logger.info(`Print matches for "${this.name}": ${mergedResults.join(", ") || "none"}`);
         return mergedResults;
     }
 

--- a/src/processor/processor.mjs
+++ b/src/processor/processor.mjs
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { callbackify, inspect } from "node:util";
+import { callbackify } from "node:util";
 import joi from "joi";
 import logger from "../logger/log.mjs";
 import imageProcessing from "../image-processing/index.mjs";
@@ -12,6 +12,7 @@ import scryfallApi from "../scryfall-api/index.mjs";
 import storage from "../storage/index.mjs";
 import imageToBase64 from "image-to-base64";
 import { resolveCardName } from "./name-resolver.mjs";
+import { formatScanResults } from "../console/format-scan-results.mjs";
 
 const dependencies = {
     ImageProcessor: imageProcessing.ImageProcessor,
@@ -39,15 +40,18 @@ const schema = joi.object().keys({
 
 class ProcessorClass {
     constructor(params) {
-        const validatedSchema = joi.attempt(params, schema);
+        const { logger: injectedLogger, ...processorParams } = params;
+        const validatedSchema = joi.attempt(processorParams, schema);
         _.assign(this, validatedSchema);
         this.imagePaths = {};
         this.extractedText = {};
         this.matcherResults = [];
         this.decision = "unknown";
-        this.logger = logger.create({
-            isPretty: this.isPretty
-        });
+        this.logger =
+            injectedLogger ||
+            logger.create({
+                isPretty: this.isPretty
+            });
     }
 
     execute(callback) {
@@ -122,7 +126,7 @@ class ProcessorClass {
     }
 
     async createDirectoryAsync() {
-        this.logger.info("Creating Directory");
+        this.logger.info("Preparing temporary files");
         const directory = await dependencies.FileIO.CreateDirectory();
         this.directory = directory;
     }
@@ -137,7 +141,7 @@ class ProcessorClass {
     }
 
     async extractNameAsync() {
-        this.logger.info("Extracting Name");
+        this.logger.info("Reading card name");
         const extractor = dependencies.ImageProcessor.create({
             path: this.filePath,
             type: "name",
@@ -165,7 +169,7 @@ class ProcessorClass {
     }
 
     async processExtractionResultsAsync() {
-        this.logger.info("Matching Name");
+        this.logger.info("Matching card name");
         const resolution = await resolveCardName({
             filePath: this.filePath,
             directory: this.directory,
@@ -190,7 +194,10 @@ class ProcessorClass {
     }
 
     async attemptMatchingAsync() {
-        this.logger.info(`Attempting Matching with ${this.nameMatches.length} candidate names`);
+        const candidateLabel = this.nameMatches.length === 1 ? "candidate" : "candidates";
+        this.logger.info(
+            `Checking printings for ${this.nameMatches.length} name ${candidateLabel}`
+        );
         const matchResults = await Promise.all(
             this.nameMatches.map((match) => this._attemptMatch(match))
         );
@@ -201,14 +208,13 @@ class ProcessorClass {
         }
         if (!this.queryingEnabled) {
             this.decision = "dry-run";
-            this.logger.info("Final results:");
             this.printResults();
             return;
         }
         if (!this.collectionEnabled) {
             this.decision = "module-disabled";
             this.logger.info(
-                "Collection tracking module is disabled -- nothing persisted. Enable with --enable-collection, COLLECTION_ENABLED=true, or collectionEnabled in the config file. Final results:"
+                "Collection tracking disabled; scan results were not saved. Enable with --enable-collection."
             );
             this.printResults();
             return;
@@ -226,16 +232,9 @@ class ProcessorClass {
         );
     }
 
-    // Prints user-facing results in a readable object format -- used whenever the pipeline
-    // stops short of persisting (dry-run, or the collection module being disabled).
+    // Prints user-facing results without internal matching and verification fields.
     printResults() {
-        console.log(
-            inspect(this.matcherResults, {
-                depth: null,
-                colors: false,
-                compact: false
-            })
-        );
+        this.logger.output(formatScanResults(this.matcherResults));
     }
 
     _attemptMatch(match) {
@@ -338,7 +337,7 @@ class ProcessorClass {
 
 function formatMatchSummary(matches = []) {
     if (!matches.length) {
-        return "Matches returned (0): none";
+        return "Name candidates (0): none";
     }
 
     const summarized = matches.map((match, index) => {
@@ -348,7 +347,7 @@ function formatMatchSummary(matches = []) {
         return `${index + 1}. ${name} (${displayPercent}%)`;
     });
 
-    return `Matches returned (${matches.length}): ${summarized.join(" | ")}`;
+    return `Name candidates (${matches.length}): ${summarized.join(" | ")}`;
 }
 
 export const create = (params) => new ProcessorClass(params);

--- a/src/processor/processor.mjs
+++ b/src/processor/processor.mjs
@@ -268,7 +268,7 @@ class ProcessorClass {
     }
 
     async CreateNeedsAttentionRecordAsync(record) {
-        this.logger.info("Creating Needs Attention Record");
+        this.logger.info(`Saving "${record.name}" for manual review`);
         const name64Image = await new Promise((resolve, reject) => {
             dependencies.Base64(this.nameExtractionImagePath, (err, encodedImage) => {
                 if (err) {
@@ -297,7 +297,7 @@ class ProcessorClass {
     }
 
     async CreateCollectionsRecordAsync(record) {
-        this.logger.info("Creating Collections Record");
+        this.logger.info(`Saving "${record.name}" to collection`);
         const set = record.sets[0];
         let additionalInfo;
         try {
@@ -330,7 +330,6 @@ class ProcessorClass {
             priceUsd: Number(additionalInfo.prices.usd) || 0,
             cardType: additionalInfo.type_line
         });
-        this.logger.info("Preparing to insert record");
         await collectionsModel.Insert();
     }
 }

--- a/test/back-filler.spec.mjs
+++ b/test/back-filler.spec.mjs
@@ -1,0 +1,81 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import { backFillCardHashes, backFillMatchingCards } from "../src/back-filler.mjs";
+import storage from "../src/storage/index.mjs";
+import scryfall from "../src/scryfall-api/index.mjs";
+import imageHashing from "../src/image-hashing/index.mjs";
+
+describe("back-filler", () => {
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("hashes each printing and stores its card metadata", async () => {
+        sandbox.stub(scryfall.Search, "SearchByNameExact").resolves({
+            data: [
+                {
+                    name: "Pacifism",
+                    set_name: "Core Set 2020",
+                    foil: true,
+                    promo: false,
+                    image_uris: { normal: "https://example.test/pacifism.jpg" }
+                }
+            ]
+        });
+        sandbox.stub(imageHashing.Hash, "HashImage").callsArgWith(1, null, "fake-hash");
+        const upsert = sandbox.stub(storage.hashes, "upsert");
+
+        const success = await backFillCardHashes("Pacifism");
+
+        assert.isTrue(success);
+        assert.isTrue(
+            upsert.calledOnceWithExactly({
+                cardName: "Pacifism",
+                setName: "Core Set 2020",
+                isFoil: true,
+                isPromo: false,
+                cardHash: "fake-hash"
+            })
+        );
+    });
+
+    it("reports a concise error when Scryfall lookup fails", async () => {
+        sandbox
+            .stub(scryfall.Search, "SearchByNameExact")
+            .rejects(new Error("network unavailable"));
+        const consoleError = sandbox.stub(console, "error");
+
+        const success = await backFillCardHashes("Pacifism");
+
+        assert.isFalse(success);
+        assert.isTrue(
+            consoleError.calledOnceWithExactly(
+                'ERROR Unable to backfill hashes for "Pacifism": network unavailable'
+            )
+        );
+    });
+
+    it("backfills every stored card name", async () => {
+        sandbox
+            .stub(storage.names, "getAll")
+            .resolves([{ name: "Pacifism" }, { name: "Fireball" }]);
+        const search = sandbox.stub(scryfall.Search, "SearchByNameExact").resolves({ data: [] });
+        sandbox.stub(storage.hashes, "upsert");
+
+        await backFillMatchingCards();
+
+        assert.deepEqual(
+            search.getCalls().map((call) => call.args.slice(0, 2)),
+            [
+                ["Pacifism", "Pacifism"],
+                ["Fireball", "Fireball"]
+            ]
+        );
+    });
+});

--- a/test/console/format-scan-results.spec.mjs
+++ b/test/console/format-scan-results.spec.mjs
@@ -1,0 +1,39 @@
+import { assert } from "chai";
+import { formatScanResults } from "../../src/console/format-scan-results.mjs";
+
+describe("formatScanResults", () => {
+    it("shows card and set candidates without internal verification data", () => {
+        const output = formatScanResults([
+            {
+                name: "Pacifism",
+                sets: ["Core Set 2020", "Magic 2010"],
+                setVerificationLinks: [
+                    { setName: "Core Set 2020", scryfallUri: "https://example.test/card" }
+                ]
+            },
+            {
+                name: "Unknown Card",
+                sets: []
+            }
+        ]);
+
+        assert.equal(
+            output,
+            [
+                "Scan results",
+                "",
+                "1. Pacifism",
+                "   Sets: Core Set 2020, Magic 2010",
+                "",
+                "2. Unknown Card",
+                "   Sets: No set match"
+            ].join("\n")
+        );
+        assert.notInclude(output, "scryfallUri");
+        assert.notInclude(output, "example.test");
+    });
+
+    it("handles an empty result list", () => {
+        assert.equal(formatScanResults([]), "No scan results.");
+    });
+});

--- a/test/db-local/bulk-insert.spec.mjs
+++ b/test/db-local/bulk-insert.spec.mjs
@@ -1,0 +1,30 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import { ExecuteBulkInsert } from "../../src/db-local/bulk-insert.mjs";
+import dbLocal from "../../src/db-local/index.mjs";
+
+describe("db-local::bulk-insert", () => {
+    it("seeds names through injected boundaries", async () => {
+        const insertName = sinon.stub().resolves();
+        const logger = { log: sinon.stub() };
+
+        const result = await ExecuteBulkInsert({
+            getCardNames: async () => ["Pacifism", "Fireball"],
+            insertName,
+            logger,
+            concurrency: 1
+        });
+
+        assert.deepEqual(result, { inserted: 2 });
+        assert.deepEqual(
+            insertName.getCalls().map((call) => call.args[0]),
+            ["Pacifism", "Fireball"]
+        );
+    });
+
+    it("keeps db-local public exports wired", () => {
+        assert.isObject(dbLocal.LocalCardDb);
+        assert.isFunction(dbLocal.GetBulkNames);
+        assert.isObject(dbLocal.CardHashes);
+    });
+});

--- a/test/db-local/card-hash-cache.spec.mjs
+++ b/test/db-local/card-hash-cache.spec.mjs
@@ -1,0 +1,92 @@
+import { assert } from "chai";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("db-local::card-hash-cache", () => {
+    const temporaryDirectories = [];
+    const savedNamesPath = process.env.CARD_NAMES_DB_PATH;
+    const savedHashPath = process.env.CARD_HASH_DB_PATH;
+
+    async function freshCache() {
+        const directory = fs.mkdtempSync(path.join(os.tmpdir(), "mtg-card-hash-cache-test-"));
+        temporaryDirectories.push(directory);
+        process.env.CARD_HASH_DB_PATH = directory;
+        return import(`../../src/db-local/card-hash-cache.mjs?t=${Date.now()}-${Math.random()}`);
+    }
+
+    function insert(cache, record) {
+        return new Promise((resolve, reject) => {
+            cache.InsertEntity(record, (error) => (error ? reject(error) : resolve()));
+        });
+    }
+
+    afterEach(() => {
+        temporaryDirectories.splice(0).forEach((directory) => {
+            fs.rmSync(directory, { recursive: true, force: true });
+        });
+        if (savedNamesPath === undefined) delete process.env.CARD_NAMES_DB_PATH;
+        else process.env.CARD_NAMES_DB_PATH = savedNamesPath;
+        if (savedHashPath === undefined) delete process.env.CARD_HASH_DB_PATH;
+        else process.env.CARD_HASH_DB_PATH = savedHashPath;
+    });
+
+    it("normalizes legacy field names and retrieves hashes by card name", async () => {
+        const cache = await freshCache();
+
+        await insert(cache, {
+            Name: "  Pacifism  ",
+            SetName: "  Core Set 2020  ",
+            CardHash: "  abc123  ",
+            IsFoil: true,
+            CardUrl: " https://example.test/card.jpg "
+        });
+        const hashes = await new Promise((resolve, reject) => {
+            cache.GetHashes("Pacifism", (error, docs) => (error ? reject(error) : resolve(docs)));
+        });
+
+        assert.lengthOf(hashes, 1);
+        assert.include(hashes[0], {
+            cardName: "Pacifism",
+            setName: "Core Set 2020",
+            cardHash: "abc123",
+            isFoil: true,
+            isPromo: false,
+            cardUrl: "https://example.test/card.jpg"
+        });
+        assert.equal(hashes[0].lookupKey, "Pacifism::Core Set 2020::1::0::abc123");
+        assert.instanceOf(hashes[0].createdAt, Date);
+        assert.instanceOf(hashes[0].updatedAt, Date);
+    });
+
+    it("upserts the same printing/hash instead of duplicating it", async () => {
+        const cache = await freshCache();
+        const record = { cardName: "Pacifism", setName: "M20", cardHash: "abc123" };
+
+        await insert(cache, record);
+        const firstInsert = await new Promise((resolve, reject) => {
+            cache.GetHashes("Pacifism", (error, docs) =>
+                error ? reject(error) : resolve(docs[0])
+            );
+        });
+        await insert(cache, { ...record, cardUrl: "https://example.test/new.jpg" });
+        const hashes = await new Promise((resolve, reject) => {
+            cache.GetHashes("Pacifism", (error, docs) => (error ? reject(error) : resolve(docs)));
+        });
+
+        assert.lengthOf(hashes, 1);
+        assert.equal(hashes[0].cardUrl, "https://example.test/new.jpg");
+        assert.equal(hashes[0].createdAt.getTime(), firstInsert.createdAt.getTime());
+    });
+
+    it("ignores incomplete cache records", async () => {
+        const cache = await freshCache();
+
+        cache.InsertEntity({ cardName: "Pacifism", setName: "M20" });
+        const hashes = await new Promise((resolve, reject) => {
+            cache.GetHashes("Pacifism", (error, docs) => (error ? reject(error) : resolve(docs)));
+        });
+
+        assert.deepEqual(hashes, []);
+    });
+});

--- a/test/db-local/grab-names.spec.mjs
+++ b/test/db-local/grab-names.spec.mjs
@@ -1,0 +1,37 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import { GetBulkNames } from "../../src/db-local/grab-names.mjs";
+
+describe("db-local::grab-names", () => {
+    it("returns stored names", (done) => {
+        const store = {
+            find: sinon.stub().callsArgWith(1, null, [{ name: "Pacifism" }])
+        };
+
+        GetBulkNames((error, names) => {
+            assert.isNull(error);
+            assert.deepEqual(names, [{ name: "Pacifism" }]);
+            done();
+        }, store);
+    });
+
+    it("returns an empty array when the store has no documents", (done) => {
+        const store = { find: sinon.stub().callsArgWith(1, null, null) };
+
+        GetBulkNames((error, names) => {
+            assert.isNull(error);
+            assert.deepEqual(names, []);
+            done();
+        }, store);
+    });
+
+    it("forwards storage errors", (done) => {
+        const expectedError = new Error("names DB unavailable");
+        const store = { find: sinon.stub().callsArgWith(1, expectedError) };
+
+        GetBulkNames((error) => {
+            assert.equal(error, expectedError);
+            done();
+        }, store);
+    });
+});

--- a/test/db-local/seed-card-names.spec.mjs
+++ b/test/db-local/seed-card-names.spec.mjs
@@ -1,0 +1,84 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import { seedCardNames } from "../../src/db-local/seed-card-names.mjs";
+
+describe("db-local::seed-card-names", () => {
+    it("inserts every name with bounded concurrency and summary output", async () => {
+        let active = 0;
+        let maxActive = 0;
+        const inserted = [];
+        const logger = { log: sinon.stub() };
+        const insertName = async (name) => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            await new Promise((resolve) => setImmediate(resolve));
+            inserted.push(name);
+            active -= 1;
+        };
+
+        const result = await seedCardNames({
+            getCardNames: async () => ["Pacifism", "Fireball", "Unsummon", "Shivan Dragon"],
+            insertName,
+            logger,
+            concurrency: 2
+        });
+
+        assert.sameMembers(inserted, ["Pacifism", "Fireball", "Unsummon", "Shivan Dragon"]);
+        assert.equal(maxActive, 2);
+        assert.deepEqual(result, { inserted: 4 });
+        assert.deepEqual(
+            logger.log.getCalls().map((call) => call.args[0]),
+            ["Seeding 4 card names...", "Seeded 4 card names."]
+        );
+    });
+
+    it("handles an empty Scryfall response without starting inserts", async () => {
+        const insertName = sinon.stub();
+        const logger = { log: sinon.stub() };
+
+        const result = await seedCardNames({
+            getCardNames: async () => [],
+            insertName,
+            logger
+        });
+
+        assert.deepEqual(result, { inserted: 0 });
+        assert.isFalse(insertName.called);
+        assert.isTrue(logger.log.calledOnceWithExactly("No card names returned; nothing to seed."));
+    });
+
+    it("rejects a malformed Scryfall response", async () => {
+        let caughtError;
+
+        try {
+            await seedCardNames({
+                getCardNames: async () => null,
+                insertName: sinon.stub(),
+                logger: { log: sinon.stub() }
+            });
+        } catch (error) {
+            caughtError = error;
+        }
+
+        assert.instanceOf(caughtError, Error);
+        assert.equal(caughtError.message, "Scryfall card-name response must be an array");
+    });
+
+    it("rejects malformed card names before writing", async () => {
+        const insertName = sinon.stub();
+        let caughtError;
+
+        try {
+            await seedCardNames({
+                getCardNames: async () => ["Pacifism", ""],
+                insertName,
+                logger: { log: sinon.stub() }
+            });
+        } catch (error) {
+            caughtError = error;
+        }
+
+        assert.equal(caughtError.message, "Scryfall card names must be non-empty strings");
+        assert.isFalse(insertName.called);
+    });
+});

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -53,16 +53,22 @@ describe("Integration::", () => {
         });
 
         it("Should execute happy path for compareDbHashes", async () => {
+            const info = sandbox.stub();
             let hasher = ProcessHashes.create({
                 cards: [{}, {}],
                 localHash: CLOSE_DIFF_HASH,
-                name: "Test"
+                name: "Test",
+                logger: { info, error: sandbox.stub() }
             });
 
             const matches = await hasher.compareDbHashes();
             let match = matches[0] || {};
             assert.isTrue(stubs.getHashesStub.calledOnce);
             assert.deepEqual(match.setName, FAKE_SET);
+            assert.deepEqual(
+                info.getCalls().map((call) => call.args[0]),
+                ['Checking local hash cache for "Test"', 'Local hash cache matches for "Test": 1']
+            );
         });
 
         it("Should fail with no match found error", async () => {
@@ -141,6 +147,7 @@ describe("Integration::", () => {
             stubs.insertHashStub.restore();
             stubs.hashImageStub = sandbox.stub(Hash, "HashImage").callsArgWith(1, null, FAKE_HASH);
             stubs.insertEntityStub = sandbox.stub(CardHashes, "upsert").returns();
+            const info = sandbox.stub();
 
             let hasher = ProcessHashes.create({
                 cards: [
@@ -153,7 +160,8 @@ describe("Integration::", () => {
                 ],
                 localHash: CLOSE_DIFF_HASH,
                 name: "Test",
-                queryingEnabled: true
+                queryingEnabled: true,
+                logger: { info, error: sandbox.stub() }
             });
 
             await hasher.compareRemoteImages();
@@ -163,6 +171,10 @@ describe("Integration::", () => {
                 SetName: "SET_A",
                 CardHash: FAKE_HASH
             });
+            assert.equal(
+                info.firstCall.args[0],
+                'Comparing 1 Scryfall image for "Test" (full-card)'
+            );
         });
 
         it("Should fall back to full remote hash when remote set-symbol hashing fails", async () => {

--- a/test/hashing/hashing.spec.mjs
+++ b/test/hashing/hashing.spec.mjs
@@ -16,10 +16,16 @@ describe("Hashing::", () => {
             sinon.restore();
         });
         it("Should return a hash of the image", (done) => {
+            const consoleLogStub = sinon.stub(console, "log");
             Hashing.HashImage(url, (error, hash) => {
                 assert.isNull(error);
                 assert.isString(hash);
                 assert.isTrue(stubs.imageHashStub.calledOnce, "Image Hash called");
+                assert.isTrue(
+                    consoleLogStub.calledOnceWithExactly(
+                        "INFO  Hashing image: img.scryfall.com/53.jpg"
+                    )
+                );
                 done();
             });
         });
@@ -36,16 +42,38 @@ describe("Hashing::", () => {
                 done();
             });
         });
+
+        it("does not let a malformed remote URL break hashing", (done) => {
+            const consoleLogStub = sinon.stub(console, "log");
+
+            Hashing.HashImage("http://%", (error, hash) => {
+                assert.isNull(error);
+                assert.equal(hash, fakeHash);
+                assert.isTrue(
+                    consoleLogStub.calledOnceWithExactly("INFO  Hashing image: invalid URL")
+                );
+                done();
+            });
+        });
     });
     describe("HashComparison::", () => {
         const hashOne = "0773063f063f36070e070a070f378e7f1f000fff0fff020103f00ffb0f810ff0";
         const hashTwo = "0773063f063f36070e070a070f378e7f1f000fff0fff020103f00ffb0f810ff0";
+        afterEach(() => {
+            sinon.restore();
+        });
         it("Should return a hash comparison result", (done) => {
+            const consoleLogStub = sinon.stub(console, "log");
             let hashComparisonResults = Hashing.CompareHash(hashOne, hashTwo);
             assert.isObject(hashComparisonResults);
             assert.equal(hashComparisonResults.twoBitMatches, 1);
             assert.equal(hashComparisonResults.fourBitMatches, 1);
             assert.equal(hashComparisonResults.stringCompare, 1);
+            assert.isTrue(
+                consoleLogStub.calledOnceWithExactly(
+                    "INFO  Hash similarity: 2-bit 100%, 4-bit 100%, text 100%"
+                )
+            );
             done();
         });
     });

--- a/test/image-analysis/extract-text.spec.mjs
+++ b/test/image-analysis/extract-text.spec.mjs
@@ -187,4 +187,34 @@ describe("TextExtraction::", () => {
         await extraction;
         assert.isTrue(recognizeStub.calledTwice);
     });
+
+    it("logs one useful OCR progress heartbeat instead of every ten percent", async () => {
+        const info = sandbox.stub();
+        sandbox
+            .stub(textExtraction.dependencies.Tesseract, "recognize")
+            .callsFake(async (_buffer, _language, options) => {
+                options.logger({ status: "recognizing text", progress: 0.1 });
+                options.logger({ status: "recognizing text", progress: 0.5 });
+                options.logger({ status: "recognizing text", progress: 1 });
+                return { data: { text: "Pacifism\n", confidence: 82 } };
+            });
+
+        await new Promise((resolve, reject) => {
+            textExtraction.ScanImage(
+                [{ buffer: Buffer.from("card"), region: "name-core", psm: "line" }],
+                "name",
+                (err, result) => (err ? reject(err) : resolve(result)),
+                { logger: { info, error: sandbox.stub() } }
+            );
+        });
+
+        assert.deepEqual(
+            info.getCalls().map((call) => call.args[0]),
+            [
+                "OCR name: 1 region (name-core)",
+                "OCR name-core: 50%",
+                'OCR name-core: 82% confidence; "Pacifism" -> "PACIFISM"'
+            ]
+        );
+    });
 });

--- a/test/logger/log.spec.mjs
+++ b/test/logger/log.spec.mjs
@@ -1,0 +1,64 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import { Logger } from "../../src/logger/log.mjs";
+
+describe("Logger", () => {
+    let sink;
+
+    beforeEach(() => {
+        sink = {
+            log: sinon.stub(),
+            warn: sinon.stub(),
+            error: sinon.stub()
+        };
+    });
+
+    it("renders pretty info messages without Bunyan process metadata", () => {
+        const logger = new Logger({ isPretty: true, colors: false, sink });
+
+        logger.info("Creating work directory");
+
+        assert.isTrue(sink.log.calledOnceWithExactly("INFO  Creating work directory"));
+    });
+
+    it("renders structured details beneath their message", () => {
+        const logger = new Logger({ isPretty: true, colors: false, sink });
+
+        logger.info("Hash comparison complete", {
+            setName: "Core Set 2020",
+            score: 0.98
+        });
+
+        assert.isTrue(sink.log.calledOnce);
+        const output = sink.log.firstCall.args[0];
+        assert.include(output, "INFO  Hash comparison complete");
+        assert.include(output, "setName: 'Core Set 2020'");
+        assert.notInclude(output, '"hostname"');
+        assert.notInclude(output, '"pid"');
+    });
+
+    it("prints concise Error messages without stack noise", () => {
+        const logger = new Logger({ isPretty: true, colors: false, sink });
+
+        logger.error(new Error("OCR failed"));
+
+        assert.isTrue(sink.error.calledOnceWithExactly("ERROR OCR failed"));
+    });
+
+    it("keeps plain mode output unadorned", () => {
+        const logger = new Logger({ isPretty: false, sink });
+
+        logger.warn("Cache unavailable", { retry: false });
+
+        assert.isTrue(sink.warn.firstCall.calledWithExactly("Cache unavailable"));
+        assert.isTrue(sink.warn.secondCall.calledWithExactly('{\n    "retry": false\n}'));
+    });
+
+    it("prints user-facing output without a log-level prefix", () => {
+        const logger = new Logger({ isPretty: true, colors: false, sink });
+
+        logger.output("Scan results\n\n1. Pacifism");
+
+        assert.isTrue(sink.log.calledOnceWithExactly("Scan results\n\n1. Pacifism"));
+    });
+});

--- a/test/matcher/matching-processor.spec.mjs
+++ b/test/matcher/matching-processor.spec.mjs
@@ -16,6 +16,7 @@ describe("MatcherProcessor::", () => {
     });
 
     it("returns normalized set details when only one search result exists", (done) => {
+        const info = sandbox.stub();
         const expectedCard = {
             set_name: "M20",
             scryfall_uri: "https://scryfall.com/card/m20/1/example"
@@ -26,7 +27,8 @@ describe("MatcherProcessor::", () => {
         const hashStub = sandbox.stub(dependencies, "Hash");
         const processor = create({
             name: "Pacifism",
-            filePath: "/tmp/pacifism.jpg"
+            filePath: "/tmp/pacifism.jpg",
+            logger: { info, error: sandbox.stub() }
         });
 
         processor.execute((err, result) => {
@@ -40,21 +42,32 @@ describe("MatcherProcessor::", () => {
                     scryfallUri: "https://scryfall.com/card/m20/1/example"
                 }
             ]);
+            assert.deepEqual(
+                info.getCalls().map((call) => call.args[0]),
+                ['Searching Scryfall for "Pacifism"', 'Scryfall returned 1 printing for "Pacifism"']
+            );
             done();
         });
     });
 
     it("errors when search results are not an array", (done) => {
         const searchStub = sandbox.stub(dependencies, "Searcher").callsArgWith(1, null, {});
+        const logger = { info: sandbox.stub(), error: sandbox.stub() };
         const processor = create({
             name: "Pacifism",
-            filePath: "/tmp/pacifism.jpg"
+            filePath: "/tmp/pacifism.jpg",
+            logger
         });
 
         processor.execute((err) => {
             assert.isTrue(searchStub.calledOnce);
             assert.instanceOf(err, Error);
             assert.equal(err.message, "Error gathering results");
+            assert.isTrue(
+                logger.error.calledOnceWithExactly(
+                    'Scryfall response for "Pacifism" was not a printing list'
+                )
+            );
             done();
         });
     });

--- a/test/processing/processor.spec.mjs
+++ b/test/processing/processor.spec.mjs
@@ -304,6 +304,27 @@ describe("Integration::", () => {
             assert.isTrue(consoleLogStub.called, "still prints results, same as dry-run");
         });
 
+        it("prints concise scan results through the injected logger", async () => {
+            const output = sandbox.stub();
+            const injectedLogger = {
+                info: sandbox.stub(),
+                warn: sandbox.stub(),
+                error: sandbox.stub(),
+                output
+            };
+            const processorInstance = Processor.create({
+                filePath: FAKE_PATH,
+                queryingEnabled: false,
+                logger: injectedLogger
+            });
+
+            await processorInstance.execute();
+
+            assert.isTrue(
+                output.calledOnceWithExactly("Scan results\n\n1. Pacifism\n   Sets: SPA")
+            );
+        });
+
         it("Should reject promise execution on matching errors", async () => {
             stubs.MatchProcessorExecuteStub.restore();
             const expectedError = new Error("failed to match");


### PR DESCRIPTION
## Summary

- replace Bunyan JSON/process metadata and internal trace tokens with concise, human-readable runtime output
- reduce OCR progress noise while keeping useful pipeline detail and clean scan-result summaries
- bound card-name seeding concurrency and replace per-record chatter with start/completion summaries
- restore NeDB hash-cache writes by replacing unsupported setOnInsert behavior
- add focused tests and raise statement/line coverage from 82.49% to 84.98%

## Verification

- pnpm check — passed: lint, formatting, typecheck, 292 tests
- pnpm coverage — passed: 84.98% statements/lines, 76.32% branches, 82.28% functions
- git diff --check origin/master...HEAD — passed
- pnpm audit --audit-level high — reports 23 existing transitive advisories: 1 critical, 12 high; this branch only removes Bunyan and its obsolete dependency subtree

## Scope notes

- The repository 90% global coverage gate remains unmet, but coverage improves by 2.49 percentage points without lowering thresholds.
- OCR regression fixtures were not run because matching/OCR decision behavior is unchanged.