### PR TITLE
fix: silence obsolete Tesseract model warnings

### DIFF
--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -12,8 +12,8 @@ The existing scan path already had strong reusable pieces:
 - `src/image-processing/ocr-preprocessing.mjs` crops three likely name regions and applies
   grayscale, normalization, scaling, thresholding, inversion, and sharpening.
 - `src/image-analysis/extract-text.mjs` runs Tesseract on those variants and selects the
-  highest-confidence OCR result. The audit also found that Tesseract v3's default cache mode
-  could race while rewriting the bundled `eng.traineddata`; OCR now opens that cache read-only.
+  highest-confidence OCR result. One bounded Tesseract worker loads the reviewed English model;
+  its obsolete `enable_new_segsearch` and `save_raw_choices` directives are disabled in place.
 - `src/fuzzy-matching/match-name.mjs` applies the production fuzzy-name thresholds.
 - `src/image-hashing/hash-image.mjs` provides the production perceptual hash and comparison
   metrics.
@@ -31,11 +31,11 @@ the same OCR, fuzzy matcher, and hash implementation while keeping the input cor
 Every regression case is evaluated with cold application state. Image hashes are recomputed for
 both the fixture and every candidate reference image; the runner has no in-memory or persistent
 hash cache. Fixture names are injected before the fuzzy matcher can initialize NeDB. Tesseract
-runs with `cacheMethod: none` and reads the repository's bundled `eng.traineddata` directly, so it
-neither reads nor writes an OCR cache. One initialized Tesseract worker is shared sequentially by
-all selected cases and terminated after the run. This avoids loading the OCR engine and language
-model for every crop. The worker's adaptive recognition state is reset before each crop. OCR
-results remain independent of earlier fixtures, and the persistent language-data cache stays off.
+runs with `cacheMethod: none` and reads the bundled `eng.traineddata`, so it neither reads nor writes
+an OCR cache. One initialized Tesseract worker is shared sequentially by all selected cases and
+terminated after the run. This avoids loading the OCR engine and language model for every crop. The
+worker's adaptive recognition state is reset before each crop. OCR results remain independent of
+earlier fixtures, and the persistent language-data cache stays off.
 Unnecessary OCR previews are disabled. Synthetic transformations use a per-case temporary
 directory only when needed, and that directory is deleted after the case. The Markdown and JSON
 benchmark reports are the only durable files written by the runner.

--- a/index.mjs
+++ b/index.mjs
@@ -12,6 +12,7 @@ import {
 import storage from "./src/storage/index.mjs";
 import migrate from "./src/migrate/nedb-to-rds.mjs";
 import diagnostics from "./src/diagnostics/index.mjs";
+import { textExtraction } from "./src/image-analysis/index.mjs";
 
 const { Processor } = processorModule;
 const KNOWN_COMMANDS = ["scan", "log", "migrate", "collection", "diagnostics", "config"];
@@ -474,6 +475,7 @@ export async function run(options = {}) {
         commanderFactory = buildCli,
         fsAccess = access,
         processorFactory = Processor.create,
+        ocrShutdown = textExtraction.ShutDown,
         migrateFn = migrate.migrateNedbToRds,
         diagnosticsFn = diagnostics.gatherDiagnostics,
         exit = process.exit,
@@ -567,13 +569,21 @@ export async function run(options = {}) {
         isPretty: config.prettyLogging
     });
 
+    let exitCode;
     try {
         await executeProcessor(processor);
-        exit(0);
+        exitCode = 0;
     } catch (err) {
         logger.log(err);
-        exit(1);
+        exitCode = 1;
     }
+    try {
+        await ocrShutdown();
+    } catch (err) {
+        logger.log(err);
+        exitCode = 1;
+    }
+    exit(exitCode);
 }
 
 export { buildCli };

--- a/src/diagnostics/env-check.mjs
+++ b/src/diagnostics/env-check.mjs
@@ -2,9 +2,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { DEFAULT_OCR_MODEL_PATH } from "../image-analysis/ocr-model.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.join(__dirname, "../..");
+const unsupportedOcrParameters = ["enable_new_segsearch", "save_raw_choices"];
+
+function findUnsupportedOcrParameters(model) {
+    return unsupportedOcrParameters.filter((parameter) => model.includes(Buffer.from(parameter)));
+}
 
 // Sanity-checks the environment is actually usable, not just "file exists". Shared by
 // scripts/verify-env.mjs (dev setup) and `node index.mjs diagnostics` (support bundle) --
@@ -36,14 +42,21 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
         record(`Node ${process.versions.node} -- this project targets Node >=20`, "fail");
     }
 
-    const traineddataPath = path.join(repoRoot, "eng.traineddata");
-    if (fs.existsSync(traineddataPath)) {
-        record("eng.traineddata present at repo root", "pass");
+    if (fs.existsSync(DEFAULT_OCR_MODEL_PATH)) {
+        const model = fs.readFileSync(DEFAULT_OCR_MODEL_PATH);
+        const unsupportedParameters = findUnsupportedOcrParameters(model);
+        if (unsupportedParameters.length === 0) {
+            record("English OCR model available (patched eng.traineddata)", "pass");
+        } else {
+            record(
+                `English OCR model contains unsupported parameters: ${unsupportedParameters.join(
+                    ", "
+                )}`,
+                "fail"
+            );
+        }
     } else {
-        record(
-            "eng.traineddata missing at repo root -- OCR will fail. See README prerequisites.",
-            "fail"
-        );
+        record("English OCR model missing at repo root -- restore eng.traineddata.", "fail");
     }
 
     const testImage = path.join(repoRoot, "test-images/PlatinumAngel.jpg");
@@ -113,6 +126,6 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
     return { checks, requiredFailures, warnings };
 }
 
-export { runEnvironmentCheck };
+export { findUnsupportedOcrParameters, runEnvironmentCheck };
 
 export default { runEnvironmentCheck };

--- a/src/image-analysis/extract-text.mjs
+++ b/src/image-analysis/extract-text.mjs
@@ -1,15 +1,18 @@
 import { cleanString } from "../util.mjs";
 import log from "../logger/log.mjs";
 import Tesseract from "tesseract.js";
+import { DEFAULT_OCR_LANGUAGE_PATH } from "./ocr-model.mjs";
 
 const logger = log.create({
     isPretty: true
 });
+let defaultSessionPromise;
+let defaultSessionOptionsKey;
 
 /**
- * Run OCR on one or more preprocessed regions with field-aware Tesseract config.
+ * Run OCR on one or more preprocessed regions and select the strongest normalized result.
  * @param {Buffer|string|Array} imgBuffer image buffer, path, or prepared variants
- * @param {"name"|"type"|"art"|"flavor"} type snippet type to inform PSM/whitelist
+ * @param {"name"|"type"|"art"|"flavor"} type snippet type to inform normalization
  * @param {(err: Error|null, result: {cleanText: string, dirtyText: string}|null) => void} cb callback
  * @param {{logger?: {info: Function, error: Function}, session?: {recognize: Function}, cacheMethod?: string, langPath?: string, gzip?: boolean}} options runtime options
  */
@@ -54,41 +57,23 @@ function normalizeCandidates(input, type) {
     if (Array.isArray(input)) {
         return input.map((item) => ({
             buffer: item.buffer || item,
-            region: item.region || type,
-            psm: resolvePsm(item.psm, type)
+            region: item.region || type
         }));
     }
     return [
         {
             buffer: input,
-            region: type,
-            psm: inferPsm(type)
+            region: type
         }
     ];
 }
 
 async function runCandidate(candidate, type, scanLogger, options = {}) {
-    const ocrConfig = getTesseractConfig(type, candidate.psm);
-    const onProgress = buildProgressLogger(candidate.region, scanLogger);
-    const result = options.session
-        ? await options.session.recognize(candidate.buffer, {
-              region: candidate.region,
-              logger: scanLogger
-          })
-        : await Tesseract.recognize(candidate.buffer, "eng", {
-              ...ocrConfig,
-              // Tesseract v3 otherwise rewrites ./eng.traineddata for every worker. Multiple OCR
-              // variants can race and truncate the bundled model, so treat the local cache as input.
-              cacheMethod: "readOnly",
-              ...(options.cacheMethod ? { cacheMethod: options.cacheMethod } : {}),
-              ...(options.langPath ? { langPath: options.langPath } : {}),
-              ...(typeof options.gzip === "boolean" ? { gzip: options.gzip } : {}),
-              logger: (message) => {
-                  if (message.status === "recognizing text") {
-                      onProgress(message.progress);
-                  }
-              }
-          });
+    const session = options.session || (await getDefaultOcrSession(options));
+    const result = await session.recognize(candidate.buffer, {
+        region: candidate.region,
+        logger: scanLogger
+    });
     const extractedText = (result && result.data && result.data.text) || result.text || "";
     const cleanedString = normalizeOcrText(extractedText, type);
     const confidence = (result && result.data && result.data.confidence) || 0;
@@ -104,31 +89,29 @@ async function runCandidate(candidate, type, scanLogger, options = {}) {
     };
 }
 
-function getTesseractConfig(type, psm) {
+function resolveWorkerOptions(options = {}) {
     return {
-        tessedit_char_whitelist:
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789,'- ",
-        preserve_interword_spaces: "1",
-        tessedit_pageseg_mode: resolvePsm(psm, type),
-        oem: 1
+        cacheMethod: options.cacheMethod || "none",
+        langPath: options.langPath || DEFAULT_OCR_LANGUAGE_PATH,
+        gzip: typeof options.gzip === "boolean" ? options.gzip : false
     };
 }
 
-function inferPsm(type) {
-    if (type === "name" || type === "type") {
-        return 7; // single line of text
+async function getDefaultOcrSession(options = {}) {
+    const workerOptions = resolveWorkerOptions(options);
+    const nextOptionsKey = JSON.stringify(workerOptions);
+    if (defaultSessionPromise && defaultSessionOptionsKey !== nextOptionsKey) {
+        await ShutDown();
     }
-    return 11; // sparse text as a safer fallback
-}
-
-function resolvePsm(psm, type) {
-    if (typeof psm === "number") {
-        return psm;
+    if (!defaultSessionPromise) {
+        defaultSessionOptionsKey = nextOptionsKey;
+        defaultSessionPromise = createOcrSession(workerOptions).catch((error) => {
+            defaultSessionPromise = undefined;
+            defaultSessionOptionsKey = undefined;
+            throw error;
+        });
     }
-    if (psm === "line") return 7;
-    if (psm === "block") return 6;
-    if (psm === "sparse") return 11;
-    return inferPsm(type);
+    return defaultSessionPromise;
 }
 
 function normalizeOcrText(text, type) {
@@ -288,27 +271,29 @@ function previewText(text) {
     return `${normalized.slice(0, max - 3)}...`;
 }
 
-function ShutDown() {
-    Tesseract.terminate();
+async function ShutDown() {
+    const pendingSession = defaultSessionPromise;
+    defaultSessionPromise = undefined;
+    defaultSessionOptionsKey = undefined;
+    if (pendingSession) {
+        const session = await pendingSession;
+        await session.terminate();
+    }
 }
 
 async function createOcrSession(options = {}) {
     let progressLogger = () => {};
     const worker = Tesseract.createWorker({
-        // Match ScanImage's one-shot defaults while allowing regression runs to disable caching.
-        cacheMethod: "readOnly",
-        ...(options.cacheMethod ? { cacheMethod: options.cacheMethod } : {}),
-        ...(options.langPath ? { langPath: options.langPath } : {}),
-        ...(typeof options.gzip === "boolean" ? { gzip: options.gzip } : {}),
+        ...resolveWorkerOptions(options),
         logger: (message) => progressLogger(message)
     });
     try {
         await worker.load();
         await worker.loadLanguage("eng");
         await worker.initialize("eng");
-    } catch (err) {
+    } catch (error) {
         await worker.terminate().catch(() => {});
-        throw err;
+        throw error;
     }
 
     let terminated = false;

--- a/src/image-analysis/ocr-model.mjs
+++ b/src/image-analysis/ocr-model.mjs
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The trained network preserves the reviewed OCR corpus. Its two obsolete configuration entries
+// are commented in place so modern Tesseract cores do not emit unsupported-parameter warnings.
+const DEFAULT_OCR_LANGUAGE_PATH = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../.."
+);
+const DEFAULT_OCR_MODEL_PATH = path.join(DEFAULT_OCR_LANGUAGE_PATH, "eng.traineddata");
+
+export { DEFAULT_OCR_LANGUAGE_PATH, DEFAULT_OCR_MODEL_PATH };
+
+export default {
+    DEFAULT_OCR_LANGUAGE_PATH,
+    DEFAULT_OCR_MODEL_PATH
+};

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -2,7 +2,6 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import textExtractionModule from "../image-analysis/extract-text.mjs";
 import imageProcessorModule from "../image-processing/image-processor.mjs";
@@ -11,11 +10,8 @@ import imageHashing from "../image-hashing/hash-image.mjs";
 import { materializeFixture } from "./image-fixture.mjs";
 import { resolveCardName } from "../processor/name-resolver.mjs";
 
-const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const noCacheOcrOptions = Object.freeze({
-    cacheMethod: "none",
-    langPath: repositoryRoot,
-    gzip: false
+    cacheMethod: "none"
 });
 
 const silentLogger = {
@@ -364,7 +360,7 @@ async function runRegression(manifest, options = {}) {
                 applicationPersistence: "disabled",
                 imageHashCache: "disabled",
                 ocrCache: "disabled",
-                ocrLanguageSource: "bundled eng.traineddata",
+                ocrLanguageSource: "patched bundled eng.traineddata",
                 ocrWorkerLifecycle: "shared process; adaptive state reset per crop",
                 temporaryArtifacts: "deleted after each case"
             },

--- a/test/diagnostics/env-check.spec.mjs
+++ b/test/diagnostics/env-check.spec.mjs
@@ -1,5 +1,8 @@
 import { assert } from "chai";
-import { runEnvironmentCheck } from "../../src/diagnostics/env-check.mjs";
+import {
+    findUnsupportedOcrParameters,
+    runEnvironmentCheck
+} from "../../src/diagnostics/env-check.mjs";
 
 // Exercises the real local environment (same checks scripts/verify-env.mjs runs) rather than
 // mocking every fs/DB dependency -- the point of this module is "is the environment actually
@@ -24,6 +27,26 @@ describe("diagnostics::env-check", () => {
         const nodeCheck = result.checks.find((check) => check.label.startsWith("Node "));
         assert.exists(nodeCheck);
         assert.equal(nodeCheck.status, "pass", "this test suite itself requires Node >=20");
+    });
+
+    it("checks the patched English OCR model used at runtime", async () => {
+        const result = await runEnvironmentCheck();
+        const modelCheck = result.checks.find((check) =>
+            check.label.startsWith("English OCR model")
+        );
+
+        assert.exists(modelCheck);
+        assert.equal(modelCheck.status, "pass");
+        assert.include(modelCheck.label, "patched eng.traineddata");
+    });
+
+    it("detects the obsolete parameters that cause Tesseract warning noise", () => {
+        const modelConfig = Buffer.from("enable_new_segsearch 0\nsave_raw_choices 1\n");
+
+        assert.deepEqual(findUnsupportedOcrParameters(modelConfig), [
+            "enable_new_segsearch",
+            "save_raw_choices"
+        ]);
     });
 
     it("reports the resolved config (storageAdapter/localCacheEnabled/collectionEnabled/debugLogging/queryingEnabled/prettyLogging)", async () => {

--- a/test/image-analysis/extract-text.spec.mjs
+++ b/test/image-analysis/extract-text.spec.mjs
@@ -4,34 +4,40 @@ import textExtraction from "../../src/image-analysis/extract-text.mjs";
 
 describe("TextExtraction::", () => {
     let sandbox;
+    let worker;
+    let createWorkerStub;
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
+        worker = {
+            load: sandbox.stub().resolves(),
+            loadLanguage: sandbox.stub().resolves(),
+            initialize: sandbox.stub().resolves(),
+            recognize: sandbox.stub().resolves({ data: { text: "Pacifism", confidence: 80 } }),
+            setParameters: sandbox.stub().resolves(),
+            terminate: sandbox.stub().resolves()
+        };
+        createWorkerStub = sandbox.stub(textExtraction.dependencies.Tesseract, "createWorker");
+        createWorkerStub.returns(worker);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+        await textExtraction.ShutDown();
         sandbox.restore();
     });
 
     it("reuses one worker while resetting adaptive OCR state between images", async () => {
-        const worker = {
-            load: sandbox.stub().resolves(),
-            loadLanguage: sandbox.stub().resolves(),
-            initialize: sandbox.stub().resolves(),
-            recognize: sandbox.stub().resolves({ data: { text: "Pacifism" } }),
-            terminate: sandbox.stub().resolves()
-        };
-        const createWorkerStub = sandbox
-            .stub(textExtraction.dependencies.Tesseract, "createWorker")
-            .returns(worker);
-
         const session = await textExtraction.createOcrSession({
             cacheMethod: "none",
             langPath: "/fixtures",
             gzip: false
         });
-        await session.recognize("/tmp/first.jpg", { region: "name-core" });
-        await session.recognize("/tmp/second.jpg", { region: "name-wide" });
+        await session.recognize("/tmp/first.jpg", {
+            region: "name-core"
+        });
+        await session.recognize("/tmp/second.jpg", {
+            region: "name-wide"
+        });
         await session.terminate();
 
         assert.isTrue(createWorkerStub.calledOnce);
@@ -44,6 +50,7 @@ describe("TextExtraction::", () => {
         assert.isTrue(worker.loadLanguage.calledOnceWithExactly("eng"));
         assert.equal(worker.initialize.callCount, 2);
         assert.isTrue(worker.initialize.alwaysCalledWithExactly("eng"));
+        assert.isTrue(worker.setParameters.notCalled);
         assert.deepEqual(worker.recognize.args, [["/tmp/first.jpg"], ["/tmp/second.jpg"]]);
         assert.isBelow(worker.recognize.firstCall.callId, worker.initialize.secondCall.callId);
         assert.isBelow(worker.initialize.secondCall.callId, worker.recognize.secondCall.callId);
@@ -76,17 +83,12 @@ describe("TextExtraction::", () => {
         assert.equal(session.recognize.firstCall.args[1].region, "name-core");
         assert.equal(session.recognize.secondCall.args[1].region, "name-wide");
         assert.isTrue(oneShotRecognize.notCalled);
+        assert.isTrue(createWorkerStub.notCalled);
     });
 
     it("terminates a worker when OCR session initialization fails", async () => {
         const expectedError = new Error("language initialization failed");
-        const worker = {
-            load: sandbox.stub().resolves(),
-            loadLanguage: sandbox.stub().rejects(expectedError),
-            initialize: sandbox.stub().resolves(),
-            terminate: sandbox.stub().resolves()
-        };
-        sandbox.stub(textExtraction.dependencies.Tesseract, "createWorker").returns(worker);
+        worker.loadLanguage.rejects(expectedError);
 
         let actualError;
         try {
@@ -97,22 +99,20 @@ describe("TextExtraction::", () => {
 
         assert.strictEqual(actualError, expectedError);
         assert.isTrue(worker.terminate.calledOnce);
-        assert.isTrue(worker.initialize.notCalled);
+        assert.isTrue(worker.recognize.notCalled);
     });
 
     it("returns clean and raw OCR text from tesseract recognize", (done) => {
-        const recognizeStub = sandbox
-            .stub(textExtraction.dependencies.Tesseract, "recognize")
-            .resolves({
-                data: {
-                    text: "  Pacifism!! \n"
-                }
-            });
+        const recognizeStub = worker.recognize.resolves({
+            data: {
+                text: "  Pacifism!! \n"
+            }
+        });
 
         textExtraction.ScanImage("/tmp/fake-image.jpg", "name", (err, result) => {
             assert.isNull(err);
             assert.isTrue(recognizeStub.calledOnce);
-            assert.equal(recognizeStub.firstCall.args[2].cacheMethod, "readOnly");
+            assert.equal(createWorkerStub.firstCall.args[0].cacheMethod, "none");
             assert.equal(result.cleanText, "PACIFISM");
             assert.equal(result.dirtyText, "  Pacifism!! \n");
             assert.containsAllKeys(result, ["confidence", "bestVariant", "candidates"]);
@@ -122,9 +122,7 @@ describe("TextExtraction::", () => {
 
     it("returns OCR error when tesseract recognize rejects", (done) => {
         const expectedErr = new Error("OCR failed");
-        const recognizeStub = sandbox
-            .stub(textExtraction.dependencies.Tesseract, "recognize")
-            .rejects(expectedErr);
+        const recognizeStub = worker.recognize.rejects(expectedErr);
 
         textExtraction.ScanImage("/tmp/fake-image.jpg", "name", (err, result) => {
             assert.strictEqual(err, expectedErr);
@@ -135,16 +133,14 @@ describe("TextExtraction::", () => {
     });
 
     it("allows regression runs to disable the OCR cache and use a local language model", (done) => {
-        const recognizeStub = sandbox
-            .stub(textExtraction.dependencies.Tesseract, "recognize")
-            .resolves({ data: { text: "Pacifism" } });
+        worker.recognize.resolves({ data: { text: "Pacifism" } });
 
         textExtraction.ScanImage(
             "/tmp/fake-image.jpg",
             "name",
             (err) => {
                 assert.isNull(err);
-                assert.include(recognizeStub.firstCall.args[2], {
+                assert.include(createWorkerStub.firstCall.args[0], {
                     cacheMethod: "none",
                     langPath: "/fixtures",
                     gzip: false
@@ -188,14 +184,12 @@ describe("TextExtraction::", () => {
     });
 
     it("normalizes ligatures/diacritics and drops noisy tokens for name extraction", (done) => {
-        const recognizeStub = sandbox
-            .stub(textExtraction.dependencies.Tesseract, "recognize")
-            .resolves({
-                data: {
-                    text: "m\nThought Reﬂection éggg\n‘V' t, ”I“ . . 1 \\\\K‘ 'g‘r .\n",
-                    confidence: 53
-                }
-            });
+        const recognizeStub = worker.recognize.resolves({
+            data: {
+                text: "m\nThought Reﬂection éggg\n‘V' t, ”I“ . . 1 \\\\K‘ 'g‘r .\n",
+                confidence: 53
+            }
+        });
 
         textExtraction.ScanImage("/tmp/fake-image.jpg", "name", (err, result) => {
             assert.isNull(err);
@@ -210,8 +204,7 @@ describe("TextExtraction::", () => {
     });
 
     it("prefers cleaner name candidate over noisier high-confidence band", async () => {
-        const recognizeStub = sandbox
-            .stub(textExtraction.dependencies.Tesseract, "recognize")
+        const recognizeStub = worker.recognize
             .onFirstCall()
             .resolves({
                 data: {
@@ -244,13 +237,12 @@ describe("TextExtraction::", () => {
         assert.equal(result.bestVariant.region, "name-core");
     });
 
-    it("processes OCR variants sequentially to protect the shared trained-data cache", async () => {
+    it("processes OCR variants sequentially through the shared worker", async () => {
         let resolveFirst;
         const firstResult = new Promise((resolve) => {
             resolveFirst = resolve;
         });
-        const recognizeStub = sandbox
-            .stub(textExtraction.dependencies.Tesseract, "recognize")
+        const recognizeStub = worker.recognize
             .onFirstCall()
             .returns(firstResult)
             .onSecondCall()
@@ -277,14 +269,13 @@ describe("TextExtraction::", () => {
 
     it("logs one useful OCR progress heartbeat instead of every ten percent", async () => {
         const info = sandbox.stub();
-        sandbox
-            .stub(textExtraction.dependencies.Tesseract, "recognize")
-            .callsFake(async (_buffer, _language, options) => {
-                options.logger({ status: "recognizing text", progress: 0.1 });
-                options.logger({ status: "recognizing text", progress: 0.5 });
-                options.logger({ status: "recognizing text", progress: 1 });
-                return { data: { text: "Pacifism\n", confidence: 82 } };
-            });
+        worker.recognize.callsFake(async () => {
+            const progressLogger = createWorkerStub.firstCall.args[0].logger;
+            progressLogger({ status: "recognizing text", progress: 0.1 });
+            progressLogger({ status: "recognizing text", progress: 0.5 });
+            progressLogger({ status: "recognizing text", progress: 1 });
+            return { data: { text: "Pacifism\n", confidence: 82 } };
+        });
 
         await new Promise((resolve, reject) => {
             textExtraction.ScanImage(
@@ -303,5 +294,38 @@ describe("TextExtraction::", () => {
                 'OCR name-core: 82% confidence; "Pacifism" -> "PACIFISM"'
             ]
         );
+    });
+
+    it("reuses one worker for each candidate and terminates it on shutdown", async () => {
+        worker.recognize
+            .onFirstCall()
+            .resolves({ data: { text: "Pacifism", confidence: 82 } })
+            .onSecondCall()
+            .resolves({ data: { text: "Pacifism", confidence: 80 } });
+
+        const result = await new Promise((resolve, reject) => {
+            textExtraction.ScanImage(
+                [
+                    { buffer: Buffer.from("a"), region: "name-core", psm: "line" },
+                    { buffer: Buffer.from("b"), region: "top-band", psm: "block" }
+                ],
+                "name",
+                (err, extracted) => (err ? reject(err) : resolve(extracted)),
+                { cacheMethod: "none", langPath: "/fixtures", gzip: false }
+            );
+        });
+
+        assert.equal(result.cleanText, "PACIFISM");
+        assert.isTrue(createWorkerStub.calledOnce);
+        assert.include(createWorkerStub.firstCall.args[0], {
+            cacheMethod: "none",
+            langPath: "/fixtures",
+            gzip: false
+        });
+        assert.isTrue(worker.setParameters.notCalled);
+        assert.isTrue(worker.recognize.calledTwice);
+
+        await textExtraction.ShutDown();
+        assert.isTrue(worker.terminate.calledOnce);
     });
 });

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -44,7 +44,7 @@ describe("CLI::index.mjs", () => {
         });
     });
 
-    async function runCli(cliOverrides = {}, accessImpl) {
+    async function runCli(cliOverrides = {}, accessImpl, runOverrides = {}) {
         const fakeCli = {
             filePath: "",
             flags: {},
@@ -65,7 +65,8 @@ describe("CLI::index.mjs", () => {
             fsAccess: fsAccessStub,
             processorFactory: processorCreateStub,
             exit: processExitStub,
-            logger: { log: consoleLogStub }
+            logger: { log: consoleLogStub },
+            ...runOverrides
         });
 
         return { commanderFactory, executeStub, processorCreateStub, fsAccessStub, fakeCli };
@@ -98,6 +99,24 @@ describe("CLI::index.mjs", () => {
         });
         assert.isTrue(executeStub.calledOnce);
         assert.isTrue(processExitStub.calledWith(0));
+    });
+
+    it("shuts down the OCR worker after a scan completes", async () => {
+        const ocrShutdown = sandbox.stub().resolves();
+
+        await runCli({ filePath: "./some-path.jpg", flags: {} }, undefined, { ocrShutdown });
+
+        assert.isTrue(ocrShutdown.calledOnce);
+    });
+
+    it("exits with an error when the OCR worker cannot shut down cleanly", async () => {
+        const expectedError = new Error("OCR worker shutdown failed");
+        const ocrShutdown = sandbox.stub().rejects(expectedError);
+
+        await runCli({ filePath: "./some-path.jpg", flags: {} }, undefined, { ocrShutdown });
+
+        assert.isTrue(consoleLogStub.calledWith(expectedError));
+        assert.isTrue(processExitStub.calledWith(1));
     });
 
     it("--query / --no-pretty (tri-state, explicitly passed) override the defaults", async () => {


### PR DESCRIPTION
## Summary

- disable the obsolete `enable_new_segsearch` and `save_raw_choices` directives in the reviewed bundled OCR model
- reuse one bounded Tesseract worker across OCR candidates and terminate it cleanly after CLI and regression runs
- validate the patched model through diagnostics and add focused worker lifecycle tests

## Why

The bundled `eng.traineddata` contained configuration directives that the current Tesseract core no longer supports. Tesseract printed both warnings for every OCR crop, creating repeated console noise even though recognition continued.

Engine and replacement-model upgrades were evaluated but rejected because they regressed blocking OCR fixtures. This change preserves the proven trained network while disabling only the unsupported directives.

## Impact

Application OCR remains verbose and useful, but the repeated Tesseract parameter warnings are removed. Reusing the worker also avoids loading the OCR engine and language model for every crop while preserving sequential, isolated recognition state.

The separate Node `DEP0040` `punycode` deprecation from the legacy dependency tree remains out of scope.

## Verification

- `pnpm check` — pass; 294 tests
- `pnpm test:regression` — 73/78 overall, 71/71 blocking fixtures passed
- 5/7 non-blocking vintage fixtures remain known failures
- targeted real OCR checks confirm the obsolete parameter warnings are absent
