### PR TITLE
refactor: fold OCR region crops into shared smart-crop registry

### DIFF
--- a/src/image-processing/ocr-preprocessing.mjs
+++ b/src/image-processing/ocr-preprocessing.mjs
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import jimp from "jimp";
 import { getImageDimensions } from "./util.mjs";
-import { round, clamp } from "../util.mjs";
+import smartCrop from "./smart-crop.mjs";
 import {
     computeOtsuThreshold,
     applyThreshold,
@@ -11,10 +11,10 @@ import {
     padAndScale
 } from "./binarize.mjs";
 
-// Tuned preprocessing settings to make small MTG text pop for OCR.
+// Tuned preprocessing settings to make small MTG text pop for OCR. Crop geometry (region
+// templates, percent->pixel math, min-source-size gate) lives in smart-crop.mjs -- this module
+// only owns what happens to the pixels after the crop.
 const preprocessConfig = {
-    minSourceWidth: 360,
-    minSourceHeight: 500,
     padding: 12,
     scaleFactor: 2.75,
     minOutputWidth: 900,
@@ -22,91 +22,6 @@ const preprocessConfig = {
     brightness: 0.05,
     blur: 1,
     invertPivot: 110
-};
-
-// Region templates focus on likely text bands (top name line, lower type line, and fallbacks).
-const regionTemplates = {
-    name: [
-        {
-            key: "name-core",
-            leftPercent: 0.08,
-            topPercent: 0.05,
-            widthPercent: 0.78,
-            heightPercent: 0.065,
-            psm: "line"
-        },
-        {
-            key: "name-wide",
-            leftPercent: 0.05,
-            topPercent: 0.045,
-            widthPercent: 0.9,
-            heightPercent: 0.08,
-            psm: "line"
-        },
-        {
-            key: "top-band",
-            leftPercent: 0.05,
-            topPercent: 0.03,
-            widthPercent: 0.9,
-            heightPercent: 0.12,
-            psm: "block"
-        }
-    ],
-    type: [
-        {
-            key: "type-core",
-            leftPercent: 0.08,
-            topPercent: 0.565,
-            widthPercent: 0.78,
-            heightPercent: 0.08,
-            psm: "line"
-        },
-        {
-            key: "type-wide",
-            leftPercent: 0.05,
-            topPercent: 0.54,
-            widthPercent: 0.9,
-            heightPercent: 0.1,
-            psm: "block"
-        },
-        {
-            key: "lower-band",
-            leftPercent: 0.05,
-            topPercent: 0.6,
-            widthPercent: 0.9,
-            heightPercent: 0.14,
-            psm: "sparse"
-        }
-    ],
-    "rules-name": [
-        {
-            key: "rules-name",
-            leftPercent: 0.055,
-            topPercent: 0.57,
-            widthPercent: 0.89,
-            heightPercent: 0.31,
-            psm: "block",
-            mode: "soft"
-        }
-    ],
-    default: [
-        {
-            key: "top-strip",
-            leftPercent: 0.05,
-            topPercent: 0.05,
-            widthPercent: 0.9,
-            heightPercent: 0.15,
-            psm: "block"
-        },
-        {
-            key: "bottom-strip",
-            leftPercent: 0.05,
-            topPercent: 0.75,
-            widthPercent: 0.9,
-            heightPercent: 0.2,
-            psm: "sparse"
-        }
-    ]
 };
 
 /**
@@ -119,23 +34,18 @@ const regionTemplates = {
 async function prepareOcrVariants(imgPath, type, options = {}) {
     const { directory } = options;
     const dimensions = await getImageDimensions(imgPath);
-    if (
-        dimensions.width < preprocessConfig.minSourceWidth ||
-        dimensions.height < preprocessConfig.minSourceHeight
-    ) {
-        throw new Error("Image is to small");
-    }
+    smartCrop.assertSourceSizeOk(dimensions);
 
     const baseImage = await jimp.read(imgPath);
-    const regions = buildRegions(dimensions, type);
+    const templates = smartCrop.getRegionTemplates(type);
     const variants = [];
 
-    for (const region of regions) {
-        const processed = await cropAndPreprocess(baseImage, region);
+    for (const template of templates) {
+        const processed = await cropAndPreprocess(baseImage, template);
         const buffer = await processed.getBufferAsync(jimp.MIME_PNG);
         variants.push({
-            region: region.key,
-            psm: region.psm,
+            region: template.key,
+            psm: template.psm,
             buffer,
             image: processed
         });
@@ -149,46 +59,9 @@ async function prepareOcrVariants(imgPath, type, options = {}) {
     return { variants, previewPath };
 }
 
-function buildRegions(dimensions, type) {
-    const templates = regionTemplates[type] || regionTemplates.default;
-    return templates.map((template) => ({
-        key: template.key,
-        psm: template.psm,
-        mode: template.mode,
-        ...percentToPixels(template, dimensions)
-    }));
-}
-
-function percentToPixels(region, dimensions) {
-    return {
-        width: round(dimensions.width * region.widthPercent),
-        height: round(dimensions.height * region.heightPercent),
-        left: round(dimensions.width * region.leftPercent),
-        top: round(dimensions.height * region.topPercent)
-    };
-}
-
-async function cropAndPreprocess(baseImage, region) {
-    const { left, top, width, height } = clampToImage(
-        region,
-        baseImage.bitmap.width,
-        baseImage.bitmap.height
-    );
-    const cropped = baseImage.clone().crop(left, top, width, height);
-    return region.mode === "soft" ? buildSoftOcrImage(cropped) : buildOcrImage(cropped);
-}
-
-function clampToImage(region, width, height) {
-    const left = clamp(region.left, 0, width);
-    const top = clamp(region.top, 0, height);
-    const clampedWidth = clamp(region.width, 1, width - left);
-    const clampedHeight = clamp(region.height, 1, height - top);
-    return {
-        left,
-        top,
-        width: clampedWidth,
-        height: clampedHeight
-    };
+async function cropAndPreprocess(baseImage, template) {
+    const { image: cropped } = smartCrop.cropRegion(baseImage, template);
+    return template.mode === "soft" ? buildSoftOcrImage(cropped) : buildOcrImage(cropped);
 }
 
 /**

--- a/src/image-processing/smart-crop.mjs
+++ b/src/image-processing/smart-crop.mjs
@@ -4,17 +4,104 @@ import path from "node:path";
 import { getImageDimensions } from "./util.mjs";
 import { round, clamp } from "../util.mjs";
 
-// Reusable region registry -- the "layer" other crop spots plug into. Only setSymbol is wired up
-// today (see smart-crop plan); name/type/rules-name style regions currently owned by
-// ocr-preprocessing.mjs can register here later without reshaping this module.
+// Reusable region registry -- the shared "layer" every crop spot plugs into. setSymbol feeds the
+// image-hash path; name/type/rules-name/default feed OCR (region templates, one or more crop
+// candidates per type -- ocr-preprocessing.mjs runs each through its own pixel preprocessing and
+// picks the best result after real OCR scoring, so these carry no confidence heuristic here).
 const regions = {
     setSymbol: {
         leftPercent: 0.78,
         topPercent: 0.535,
         widthPercent: 0.13,
         heightPercent: 0.1
-    }
+    },
+    name: [
+        {
+            key: "name-core",
+            leftPercent: 0.08,
+            topPercent: 0.05,
+            widthPercent: 0.78,
+            heightPercent: 0.065,
+            psm: "line"
+        },
+        {
+            key: "name-wide",
+            leftPercent: 0.05,
+            topPercent: 0.045,
+            widthPercent: 0.9,
+            heightPercent: 0.08,
+            psm: "line"
+        },
+        {
+            key: "top-band",
+            leftPercent: 0.05,
+            topPercent: 0.03,
+            widthPercent: 0.9,
+            heightPercent: 0.12,
+            psm: "block"
+        }
+    ],
+    type: [
+        {
+            key: "type-core",
+            leftPercent: 0.08,
+            topPercent: 0.565,
+            widthPercent: 0.78,
+            heightPercent: 0.08,
+            psm: "line"
+        },
+        {
+            key: "type-wide",
+            leftPercent: 0.05,
+            topPercent: 0.54,
+            widthPercent: 0.9,
+            heightPercent: 0.1,
+            psm: "block"
+        },
+        {
+            key: "lower-band",
+            leftPercent: 0.05,
+            topPercent: 0.6,
+            widthPercent: 0.9,
+            heightPercent: 0.14,
+            psm: "sparse"
+        }
+    ],
+    "rules-name": [
+        {
+            key: "rules-name",
+            leftPercent: 0.055,
+            topPercent: 0.57,
+            widthPercent: 0.89,
+            heightPercent: 0.31,
+            psm: "block",
+            mode: "soft"
+        }
+    ],
+    default: [
+        {
+            key: "top-strip",
+            leftPercent: 0.05,
+            topPercent: 0.05,
+            widthPercent: 0.9,
+            heightPercent: 0.15,
+            psm: "block"
+        },
+        {
+            key: "bottom-strip",
+            leftPercent: 0.05,
+            topPercent: 0.75,
+            widthPercent: 0.9,
+            heightPercent: 0.2,
+            psm: "sparse"
+        }
+    ]
 };
+
+// OCR types without a dedicated table (or unrecognized types) fall back to the default bands.
+function getRegionTemplates(type) {
+    return regions[type] || regions.default;
+}
 
 const config = {
     minSourceWidth: 360,
@@ -23,6 +110,12 @@ const config = {
     // card border/background instead of a real set-symbol icon).
     lowConfidenceStdDevThreshold: 10
 };
+
+function assertSourceSizeOk(dimensions) {
+    if (dimensions.width < config.minSourceWidth || dimensions.height < config.minSourceHeight) {
+        throw new Error("Image is to small");
+    }
+}
 
 /**
  * Crop a jimp image to a named region's percent-based geometry. Pure -- clones rather than
@@ -89,9 +182,7 @@ function cropSetSymbolFromImage(img) {
  */
 async function writeSetSymbolSnippet(imgPath, directory) {
     const dimensions = await getImageDimensions(imgPath);
-    if (dimensions.width < config.minSourceWidth || dimensions.height < config.minSourceHeight) {
-        throw new Error("Image is to small");
-    }
+    assertSourceSizeOk(dimensions);
     const img = await jimp.read(imgPath);
     const result = cropSetSymbolFromImage(img);
     if (result.lowConfidence) {
@@ -105,18 +196,22 @@ async function writeSetSymbolSnippet(imgPath, directory) {
 
 export {
     regions,
+    getRegionTemplates,
     cropRegion,
     computeGreyscaleStdDev,
     assessConfidence,
+    assertSourceSizeOk,
     cropSetSymbolFromImage,
     writeSetSymbolSnippet
 };
 
 export default {
     regions,
+    getRegionTemplates,
     cropRegion,
     computeGreyscaleStdDev,
     assessConfidence,
+    assertSourceSizeOk,
     cropSetSymbolFromImage,
     writeSetSymbolSnippet
 };

--- a/test/image-processing/smart-crop.spec.mjs
+++ b/test/image-processing/smart-crop.spec.mjs
@@ -6,6 +6,7 @@ import jimp from "jimp";
 import { assert } from "chai";
 import {
     regions,
+    getRegionTemplates,
     cropRegion,
     computeGreyscaleStdDev,
     assessConfidence,
@@ -109,6 +110,40 @@ describe("Smart crop::", () => {
 
             assert.approximately(region.width / width, regions.setSymbol.widthPercent, 0.01);
             assert.approximately(region.height / height, regions.setSymbol.heightPercent, 0.01);
+            assert.equal(image.bitmap.width, region.width);
+            assert.equal(image.bitmap.height, region.height);
+        });
+    });
+
+    describe("getRegionTemplates::", () => {
+        it("returns the name templates for type 'name'", () => {
+            assert.equal(getRegionTemplates("name"), regions.name);
+        });
+
+        it("returns the type templates for type 'type'", () => {
+            assert.equal(getRegionTemplates("type"), regions.type);
+        });
+
+        it("returns the rules-name templates for type 'rules-name'", () => {
+            assert.equal(getRegionTemplates("rules-name"), regions["rules-name"]);
+        });
+
+        it("falls back to default templates for an unknown type", () => {
+            assert.equal(getRegionTemplates("unknown-type"), regions.default);
+        });
+    });
+
+    describe("cropRegion with OCR-style templates::", () => {
+        it("crops using a template that also carries key/psm/mode metadata", async () => {
+            const img = await checkerboardImage(1000, 1400);
+            const template = regions.name[0];
+
+            const { image, region } = cropRegion(img, template);
+
+            assert.equal(
+                region.width,
+                clamp(round(1000 * template.widthPercent), 1, 1000 - region.left)
+            );
             assert.equal(image.bitmap.width, region.width);
             assert.equal(image.bitmap.height, region.height);
         });


### PR DESCRIPTION
## Summary

Checkpoint 2 of the smart-crop consolidation (checkpoint 1: #183). OCR crop *geometry*
(name/type/rules-name/default region percent tables, percent→pixel math, bounds clamping,
min-source-size gate) moves from `ocr-preprocessing.mjs` into `smart-crop.mjs`'s `regions`
registry — one canonical source of crop coordinates for the whole repo now. Percents are
byte-identical to what was there before; this is a pure relocation, not a retune.

OCR-specific *pixel* preprocessing (Otsu threshold, binarize, sharpen, pad/scale) stays in
`ocr-preprocessing.mjs`, untouched — it now crops via `smartCrop.cropRegion`/
`smartCrop.getRegionTemplates` and does exactly what it already did to the resulting pixels.

## Scope note: no confidence flagging on OCR crops

Checkpoint 1 added a low-confidence (blank/flat-region) signal to the set-symbol crop path,
since it's the only pre-hash quality check available there. Investigated whether OCR crops
should get the same treatment and found they already have something stronger:
`src/image-analysis/extract-text.mjs` runs every OCR variant through real Tesseract recognition
and scores each on actual output quality (`scoreOcrCandidate`/`selectBestResult`) — better ground
truth than a pre-crop pixel-variance guess, which could also false-positive on a legitimately
short/plain crop (e.g. a one-word type line). So: geometry moves, no new heuristic on the OCR
path. The confidence primitive remains available in `smart-crop.mjs` if a real need shows up.

## Tests

- New `test/image-processing/smart-crop.spec.mjs` coverage: `getRegionTemplates` (per-type
  lookup + default fallback) and `cropRegion` handling OCR-style templates (extra `key`/`psm`/
  `mode` fields).
- Existing `test/image-processing/ocr-preprocessing.spec.mjs` test passes unchanged — geometry is
  byte-identical, just re-sourced.

## Verification

- `pnpm test` — 307 passing
- `pnpm lint` / `pnpm typecheck` / `pnpm prettier:check` — clean
- `pnpm test:regression` — 71/71 blocking fixtures passed, **identical pass rate** to before this
  change (same 5/7 non-blocking failures, pre-existing and unrelated) — OCR/name-matching path
  unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)