### PR TITLE
fix: tag card-hash DB cache entries with hashMode, stop cross-mode compares

### DIFF
--- a/src/back-filler.mjs
+++ b/src/back-filler.mjs
@@ -29,7 +29,8 @@ async function backFillCardHashes(cardName) {
                 setName: card.set_name,
                 isFoil: card.foil ? true : false,
                 isPromo: card.promo ? true : false,
-                cardHash
+                cardHash,
+                hashMode: "full-card"
             });
         }
         cardHashes = [...new Set(cardHashes)];

--- a/src/db-local/card-hash-cache.mjs
+++ b/src/db-local/card-hash-cache.mjs
@@ -31,6 +31,10 @@ function normalizeRecord(record = {}) {
     const isFoil = Boolean(record.isFoil || record.IsFoil);
     const isPromo = Boolean(record.isPromo || record.IsPromo);
     const cardUrl = record.cardUrl || record.CardUrl || "";
+    // Defaults to "full-card" for writers/legacy rows that predate this field -- matches
+    // back-filler.mjs's real behavior (always full-card, never cropped) and process-hashes.mjs's
+    // own joi default, so an untagged on-disk row is classified correctly with no migration.
+    const hashMode = record.hashMode || record.HashMode || "full-card";
     const normalized = {
         cardName: String(cardName).trim(),
         setName: String(setName).trim(),
@@ -38,6 +42,7 @@ function normalizeRecord(record = {}) {
         isFoil,
         isPromo,
         cardUrl: String(cardUrl).trim(),
+        hashMode: String(hashMode).trim(),
         updatedAt: new Date()
     };
     normalized.lookupKey = toLookupKey(normalized);

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -62,7 +62,18 @@ class ProcessHashes {
 
     async compareDbHashes() {
         this.logger.info(`Checking local hash cache for "${this.name}"`);
-        const hashes = await this.dependencies.CardHashes.getByCardName(this.name);
+        const hashMode = this.hashMode || "full-card";
+        const allHashes = await this.dependencies.CardHashes.getByCardName(this.name);
+        // A stored hash computed in a different mode (full-card vs set-symbol) measures something
+        // different than this.localHash -- comparing across modes is apples-to-oranges, so treat
+        // a mode mismatch as "no usable cached hash," not "compare it anyway."
+        const hashes = allHashes.filter((dbHash) => (dbHash.hashMode || "full-card") === hashMode);
+        const skippedForModeMismatch = allHashes.length - hashes.length;
+        if (skippedForModeMismatch > 0) {
+            this.logger.info(
+                `Skipped ${skippedForModeMismatch} cached hash(es) for "${this.name}": hashMode mismatch (expected ${hashMode})`
+            );
+        }
         const matches = [];
         hashes.forEach((dbHash) => {
             const compareResults = this.dependencies.Hash.compareHash(
@@ -242,7 +253,8 @@ class ProcessHashes {
         this.dependencies.CardHashes.upsert({
             cardName: this.name,
             setName,
-            cardHash: hash
+            cardHash: hash,
+            hashMode: this.hashMode
         });
     }
 }

--- a/test/back-filler.spec.mjs
+++ b/test/back-filler.spec.mjs
@@ -40,7 +40,8 @@ describe("back-filler", () => {
                 setName: "Core Set 2020",
                 isFoil: true,
                 isPromo: false,
-                cardHash: "fake-hash"
+                cardHash: "fake-hash",
+                hashMode: "full-card"
             })
         );
     });

--- a/test/db-local/card-hash-cache.spec.mjs
+++ b/test/db-local/card-hash-cache.spec.mjs
@@ -44,11 +44,26 @@ describe("db-local::card-hash-cache", () => {
             cardHash: "abc123",
             isFoil: true,
             isPromo: false,
-            cardUrl: "https://example.test/card.jpg"
+            cardUrl: "https://example.test/card.jpg",
+            hashMode: "full-card"
         });
         assert.equal(hashes[0].lookupKey, "Pacifism::Core Set 2020::1::0::abc123");
         assert.instanceOf(hashes[0].createdAt, Date);
         assert.instanceOf(hashes[0].updatedAt, Date);
+    });
+
+    it("preserves an explicit hashMode instead of defaulting it", async () => {
+        const cache = await freshCache();
+
+        await cache.insertEntity({
+            cardName: "Pacifism",
+            setName: "M20",
+            cardHash: "abc123",
+            hashMode: "set-symbol"
+        });
+        const [hash] = await cache.getHashes("Pacifism");
+
+        assert.equal(hash.hashMode, "set-symbol");
     });
 
     it("upserts the same printing/hash instead of duplicating it", async () => {

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -71,6 +71,36 @@ describe("Integration::", () => {
             );
         });
 
+        it("Should ignore cached hashes from a different hashMode", async () => {
+            stubs.getHashesStub.resolves([
+                {
+                    cardHash: CLOSE_DIFF_HASH,
+                    setName: FAKE_SET,
+                    hashMode: "full-card"
+                }
+            ]);
+            const info = sandbox.stub();
+            let hasher = ProcessHashes.create({
+                cards: [{}, {}],
+                localHash: CLOSE_DIFF_HASH,
+                name: "Test",
+                hashMode: "set-symbol",
+                ignoreNoDbMatch: true,
+                logger: { info, error: sandbox.stub() }
+            });
+
+            const matches = await hasher.compareDbHashes();
+            assert.deepEqual(matches, []);
+            assert.deepEqual(
+                info.getCalls().map((call) => call.args[0]),
+                [
+                    'Checking local hash cache for "Test"',
+                    'Skipped 1 cached hash(es) for "Test": hashMode mismatch (expected set-symbol)',
+                    'Local hash cache matches for "Test": 0'
+                ]
+            );
+        });
+
         it("Should fail with no match found error", async () => {
             let hasher = ProcessHashes.create({
                 cards: [{}, {}],
@@ -161,7 +191,8 @@ describe("Integration::", () => {
             assert.deepEqual(stubs.insertEntityStub.firstCall.args[0], {
                 cardName: "Test",
                 setName: "SET_A",
-                cardHash: FAKE_HASH
+                cardHash: FAKE_HASH,
+                hashMode: "full-card"
             });
             assert.equal(
                 info.firstCall.args[0],


### PR DESCRIPTION
## Summary

The local card-hash cache (`src/db-local/card-hash-cache.mjs`) stores hashes from two writers
that compute them differently:

- `src/back-filler.mjs` — always hashes the full remote card image, no crop.
- `src/export-processor/process-hashes.mjs`'s `_insertCardHash` — hashes whatever mode is active
  for the run (`set-symbol` cropped or `full-card`).

Neither writer tagged the stored record with which mode produced the hash, and the reader
(`compareDbHashes`) fetched *every* stored hash for a card name and bit-compared all of them
against the current `localHash` with no awareness that some rows were full-card hashes and
others set-symbol hashes — apples-to-oranges, producing meaningless similarity scores (false
matches or false non-matches depending on luck of the bit pattern). This predates the smart-crop
consolidation (#183, #184) — it's been latent since set-symbol hashing was first added.

## Fix

- `card-hash-cache.mjs`'s `normalizeRecord` gains a `hashMode` field, defaulting to `"full-card"`
  for untagged/legacy rows — matches `back-filler.mjs`'s real behavior and
  `process-hashes.mjs`'s own joi default, so no DB migration is needed.
- Both writers now tag their inserts (`back-filler.mjs` explicitly `"full-card"`,
  `process-hashes.mjs` with `this.hashMode`).
- `compareDbHashes()` filters stored hashes to the current run's `hashMode` before comparing — a
  mode mismatch is treated as "no usable cached hash," same as today's no-match path, with a log
  line noting how many rows were skipped for visibility.

**Non-goal:** `back-filler.mjs` still only produces full-card hashes; teaching it to also crop via
`smart-crop.mjs` for set-symbol-mode entries is separate, later work.

## Tests

- `card-hash-cache.spec.mjs`: covers the default and an explicit `hashMode`.
- `back-filler.spec.mjs` / `process-hashes.spec.mjs`: exact-match upsert assertions updated for
  the new field.
- New `process-hashes.spec.mjs` test proves a stored hash from a different `hashMode` is excluded
  from `compareDbHashes`' match set — the actual regression test for this bug.

## Verification

- `pnpm test` — 309 passing
- `pnpm lint` / `pnpm typecheck` / `pnpm prettier:check` — clean
- `pnpm test:regression` — 71/71 blocking fixtures passed, identical to before (the regression
  harness runs with the hash cache disabled, so this path isn't exercised by it either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)