### PR TITLE
fix: randomize Scryfall fixture-import page/candidate selection

### DIFF
--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -205,15 +205,24 @@ pnpm fixtures:import \
     --set fin \
     --count 5 \
     --existing-manifest ../other-checkout/test/regression/fixtures/manifest.json
+
+# Re-run an identical selection later (debugging, or reproducing a CI failure)
+pnpm fixtures:import --set fin --set dsk --count 6 --seed 20260808 --dry-run
 ```
 
 Choose either one or more `--set` values or release-date bounds. Set values may be repeated or
-comma-separated. Results use unique printings and default to newest-first order. Add `--balanced`
-to fetch the bounded candidate pool and greedily favor underrepresented sets, color categories,
-primary card types, rarities, layouts, and treatments. Balanced selection is deterministic for the
-same Scryfall response, prefers non-basic cards, and selects at most one basic land. Its dry-run
-output lists the coverage categories for every card and summarizes the number of distinct values.
-It also prefers a new card name over another printing of a name already selected in that run.
+comma-separated. Results use unique printings ordered newest-first within each fetched result page,
+but each run lands on a random page of the full result set (wrapping back to page one if the random
+start runs off the end) and shuffles the candidate pool before selecting. This is deliberate: a wide
+`--set` list or release-date range can span thousands of prints, and always starting at page one
+would return the same newest set on every run. Pass `--seed <number>` to make the random page and
+shuffle reproducible across runs (same seed, same inputs, same selection). Add `--balanced` to fetch
+the bounded candidate pool and greedily favor underrepresented sets, color categories, primary card
+types, rarities, layouts, and treatments; it draws from the same randomized pool, so vary `--seed`
+(or omit it) to get a different balanced mix. Balanced selection prefers non-basic cards and selects
+at most one basic land. Its dry-run output lists the coverage categories for every card and
+summarizes the number of distinct values. It also prefers a new card name over another printing of a
+name already selected in that run.
 
 The target manifest's catalog is always used as the existing-card list; each repeatable
 `--existing-manifest` adds another catalog to that exclusion set. Prints match by Scryfall ID when
@@ -232,11 +241,12 @@ the review-first fixture policy. To finish an import:
 4. Run the new case by ID and inspect both benchmark reports.
 5. Adjust thresholds from repeated evidence, then run the full unit and regression gates.
 
-The importer accepts at most 100 cards per run, follows at most 20 result pages by default, spaces
-API page requests by 125 ms, and rejects oversized or non-JPEG downloads. Newest-first mode stops
-as soon as enough unused printable cards are found; balanced mode reads the bounded result pool
-before choosing. Use `--max-pages` only when a selection contains many already tracked or
-multi-face prints. Scryfall asks API clients to stay below 10 requests per second and to send
+The importer accepts at most 100 cards per run, follows at most 20 result pages by default from its
+randomly chosen start page, spaces API page requests by 125 ms, and rejects oversized or non-JPEG
+downloads. Newest-first mode stops as soon as enough unused printable cards are found; balanced mode
+reads the bounded result pool before choosing. Use `--max-pages` only when a selection contains many
+already tracked or multi-face prints, or when a small `--set` list needs a wider search window to
+wrap all the way around. Scryfall asks API clients to stay below 10 requests per second and to send
 identifying request headers; see their
 [API access guidance](https://scryfall.com/docs/faqs/i-m-having-trouble-accessing-the-scryfall-api-or-i-m-blocked-17).
 

--- a/scripts/import-scryfall-fixtures.mjs
+++ b/scripts/import-scryfall-fixtures.mjs
@@ -41,6 +41,7 @@ function buildProgram() {
         )
         .option("--max-pages <number>", "maximum Scryfall result pages", "20")
         .option("--balanced", "diversify selected prints across coverage categories", false)
+        .option("--seed <number>", "seed the random page/shuffle selection for a reproducible run")
         .option("--dry-run", "show selected prints without writing images or manifest", false);
 }
 
@@ -58,6 +59,7 @@ async function main(argv = process.argv, overrides = {}) {
         count: options.count,
         maxPages: options.maxPages,
         balanced: options.balanced,
+        seed: options.seed,
         dryRun: options.dryRun
     });
 

--- a/src/regression/scryfall-fixture-importer.mjs
+++ b/src/regression/scryfall-fixture-importer.mjs
@@ -4,6 +4,7 @@ import {
     buildCardSearchUrl,
     downloadImage,
     fetchCardPages,
+    fetchResultCount,
     imageUrlForCard
 } from "../scryfall-api/regression-fixtures.mjs";
 import { cardCoverage, selectBalancedCards } from "./balanced-card-selector.mjs";
@@ -11,8 +12,36 @@ import { cardCoverage, selectBalancedCards } from "./balanced-card-selector.mjs"
 const DEFAULT_MAX_PAGES = 20;
 const MAX_COUNT = 100;
 const MAX_PAGES = 100;
+const MAX_SEED = 2 ** 32 - 1;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const SET_CODE_PATTERN = /^[a-z0-9]{2,6}$/i;
+
+// mulberry32: small, fast, seedable PRNG. Not cryptographic; only used to pick a
+// random Scryfall result page and shuffle candidates so repeated imports over the
+// same wide query stop landing on the same set every time.
+function mulberry32(seed) {
+    let state = seed >>> 0;
+    return function random() {
+        state |= 0;
+        state = (state + 0x6d2b79f5) | 0;
+        let t = Math.imul(state ^ (state >>> 15), 1 | state);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+function createRng(seed) {
+    return seed === undefined ? Math.random : mulberry32(seed);
+}
+
+function shuffle(items, rng) {
+    const shuffled = items.slice();
+    for (let i = shuffled.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(rng() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+}
 
 function parsePositiveInteger(value, label, maximum) {
     const number = Number(value);
@@ -34,6 +63,15 @@ function normalizeSetCodes(values = []) {
         }
     }
     return [...new Set(setCodes)].sort();
+}
+
+function validateSeed(value) {
+    if (value === undefined) return undefined;
+    const number = Number(value);
+    if (!Number.isSafeInteger(number) || number < 0 || number > MAX_SEED) {
+        throw new Error(`seed must be an integer from 0 to ${MAX_SEED}`);
+    }
+    return number;
 }
 
 function validateDate(value, label) {
@@ -79,7 +117,8 @@ function normalizeImportOptions(options) {
             "max-pages",
             MAX_PAGES
         ),
-        balanced: options.balanced === true
+        balanced: options.balanced === true,
+        seed: validateSeed(options.seed)
     };
 }
 
@@ -255,12 +294,56 @@ async function importScryfallFixtures(options, overrides = {}) {
     }
 
     const fetchCardPages = overrides.fetchCardPages || defaultDependencies.fetchCardPages;
-    const fetchOptions = { maxPages: selection.maxPages };
+    const fetchResultCount = overrides.fetchResultCount || defaultDependencies.fetchResultCount;
+    const rng = overrides.random || createRng(selection.seed);
+    const searchUrl = buildCardSearchUrl(selection);
+
+    // Scryfall always returns matches newest-first. A wide query (broad set list or
+    // release-date range) has far more pages than maxPages ever walks, so starting at
+    // page 1 every run returns the same newest set every time. Land on a random page
+    // instead, then wrap back to page 1 if we run off the end before filling the budget.
+    const { totalCards, pageSize } = await fetchResultCount(searchUrl, {
+        fetchImpl: overrides.fetchImpl
+    });
+    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCards / pageSize)) : 1;
+    const startPage = totalPages > 1 ? 1 + Math.floor(rng() * totalPages) : 1;
+
+    const fetchOptions = {
+        maxPages: selection.maxPages,
+        startPage,
+        fetchImpl: overrides.fetchImpl
+    };
     if (!selection.balanced) {
         fetchOptions.shouldStop = (collectedCards) =>
             hasEnoughNewPrintableCards(collectedCards, existing, selection.count);
     }
-    const cards = await fetchCardPages(buildCardSearchUrl(selection), fetchOptions);
+    let cards = await fetchCardPages(searchUrl, fetchOptions);
+
+    const pagesUsed = pageSize > 0 ? Math.ceil(cards.length / pageSize) : cards.length > 0 ? 1 : 0;
+    const ranOffTheEnd = startPage > 1 && startPage - 1 + pagesUsed >= totalPages;
+    const budgetRemains = pagesUsed < selection.maxPages;
+    const stillWant = selection.balanced
+        ? budgetRemains
+        : !hasEnoughNewPrintableCards(cards, existing, selection.count);
+    if (ranOffTheEnd && budgetRemains && stillWant) {
+        const priorCards = cards;
+        const wrapOptions = {
+            maxPages: selection.maxPages - pagesUsed,
+            startPage: 1,
+            fetchImpl: overrides.fetchImpl
+        };
+        if (!selection.balanced) {
+            wrapOptions.shouldStop = (collectedCards) =>
+                hasEnoughNewPrintableCards(
+                    [...priorCards, ...collectedCards],
+                    existing,
+                    selection.count
+                );
+        }
+        const wrapped = await fetchCardPages(searchUrl, wrapOptions);
+        cards = priorCards.concat(wrapped);
+    }
+
     const candidates = [];
     const candidateIdentities = new Set();
     let excludedExisting = 0;
@@ -286,9 +369,10 @@ async function importScryfallFixtures(options, overrides = {}) {
         if (!selection.balanced && candidates.length === selection.count) break;
     }
 
+    const shuffledCandidates = shuffle(candidates, rng);
     const selected = selection.balanced
-        ? selectBalancedCards(candidates, selection.count)
-        : candidates.slice(0, selection.count);
+        ? selectBalancedCards(shuffledCandidates, selection.count)
+        : shuffledCandidates.slice(0, selection.count);
 
     if (selected.length < selection.count) {
         throw new Error(
@@ -353,6 +437,7 @@ async function importScryfallFixtures(options, overrides = {}) {
 
 const defaultDependencies = {
     fetchCardPages,
+    fetchResultCount,
     downloadImage
 };
 

--- a/src/scryfall-api/regression-fixtures.mjs
+++ b/src/scryfall-api/regression-fixtures.mjs
@@ -115,38 +115,48 @@ async function request(url, options = {}) {
     return response;
 }
 
+function withPageParam(url, page) {
+    const next = new URL(url);
+    if (page && page > 1) next.searchParams.set("page", String(page));
+    return next.href;
+}
+
+async function fetchPage(url, options) {
+    const response = await request(url, {
+        fetchImpl: options.fetchImpl,
+        headers: REQUEST_HEADERS
+    });
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.toLowerCase().includes("application/json")) {
+        throw new Error("Expected JSON response from Scryfall API");
+    }
+    const bytes = await readBoundedBody(response, MAX_API_RESPONSE_BYTES, "Scryfall API response");
+    let pageData;
+    try {
+        pageData = JSON.parse(new TextDecoder().decode(bytes));
+    } catch (error) {
+        throw new Error("Scryfall API returned invalid JSON", { cause: error });
+    }
+    if (pageData?.object !== "list" || !Array.isArray(pageData.data)) {
+        throw new Error("Scryfall API response is not a card list");
+    }
+    return pageData;
+}
+
 async function fetchCardPages(searchUrl, options = {}) {
     const maxPages = parseMaxPages(options.maxPages ?? DEFAULT_MAX_PAGES);
     const wait =
         options.wait ||
         ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
     const cards = [];
-    let nextUrl = trustedUrl(searchUrl, SCRYFALL_API_ORIGIN, "Scryfall API").href;
+    let nextUrl = withPageParam(
+        trustedUrl(searchUrl, SCRYFALL_API_ORIGIN, "Scryfall API").href,
+        options.startPage
+    );
 
     for (let page = 0; page < maxPages && nextUrl; page += 1) {
         if (page > 0) await wait(REQUEST_DELAY_MS);
-        const response = await request(nextUrl, {
-            fetchImpl: options.fetchImpl,
-            headers: REQUEST_HEADERS
-        });
-        const contentType = response.headers.get("content-type") || "";
-        if (!contentType.toLowerCase().includes("application/json")) {
-            throw new Error("Expected JSON response from Scryfall API");
-        }
-        const bytes = await readBoundedBody(
-            response,
-            MAX_API_RESPONSE_BYTES,
-            "Scryfall API response"
-        );
-        let pageData;
-        try {
-            pageData = JSON.parse(new TextDecoder().decode(bytes));
-        } catch (error) {
-            throw new Error("Scryfall API returned invalid JSON", { cause: error });
-        }
-        if (pageData?.object !== "list" || !Array.isArray(pageData.data)) {
-            throw new Error("Scryfall API response is not a card list");
-        }
+        const pageData = await fetchPage(nextUrl, options);
         cards.push(...pageData.data);
         if (options.shouldStop?.(cards)) break;
         nextUrl = pageData.has_more
@@ -154,6 +164,16 @@ async function fetchCardPages(searchUrl, options = {}) {
             : undefined;
     }
     return cards;
+}
+
+async function fetchResultCount(searchUrl, options = {}) {
+    const pageData = await fetchPage(
+        trustedUrl(searchUrl, SCRYFALL_API_ORIGIN, "Scryfall API").href,
+        options
+    );
+    const pageSize = pageData.data.length;
+    const totalCards = Number.isFinite(pageData.total_cards) ? pageData.total_cards : pageSize;
+    return { totalCards, pageSize };
 }
 
 async function downloadImage(imageUrl, destination, options = {}) {
@@ -177,4 +197,4 @@ async function downloadImage(imageUrl, destination, options = {}) {
     await writeFile(destination, bytes, { flag: "wx" });
 }
 
-export { buildCardSearchUrl, downloadImage, fetchCardPages, imageUrlForCard };
+export { buildCardSearchUrl, downloadImage, fetchCardPages, fetchResultCount, imageUrlForCard };

--- a/test/regression/scryfall-fixture-importer.spec.mjs
+++ b/test/regression/scryfall-fixture-importer.spec.mjs
@@ -11,7 +11,8 @@ import { selectBalancedCards } from "../../src/regression/balanced-card-selector
 import {
     buildCardSearchUrl,
     downloadImage,
-    fetchCardPages
+    fetchCardPages,
+    fetchResultCount
 } from "../../src/scryfall-api/regression-fixtures.mjs";
 
 describe("Scryfall regression fixture importer", () => {
@@ -23,13 +24,29 @@ describe("Scryfall regression fixture importer", () => {
                 releasedBefore: undefined,
                 count: 4,
                 maxPages: 20,
-                balanced: false
+                balanced: false,
+                seed: undefined
             });
         });
 
         it("enables balanced selection explicitly", () => {
             assert.isTrue(
                 normalizeImportOptions({ sets: ["fin"], count: 4, balanced: true }).balanced
+            );
+        });
+
+        it("accepts an explicit seed for reproducible selection", () => {
+            assert.equal(normalizeImportOptions({ sets: ["fin"], count: 4, seed: "7" }).seed, 7);
+        });
+
+        it("rejects a negative or non-integer seed", () => {
+            assert.throws(
+                () => normalizeImportOptions({ sets: ["fin"], count: 4, seed: "-1" }),
+                "seed must be an integer"
+            );
+            assert.throws(
+                () => normalizeImportOptions({ sets: ["fin"], count: 4, seed: "1.5" }),
+                "seed must be an integer"
             );
         });
 
@@ -156,6 +173,35 @@ describe("Scryfall regression fixture importer", () => {
 
             assert.deepEqual(cards, [{ id: "enough" }]);
             assert.equal(requests, 1);
+        });
+
+        it("starts pagination at a given page instead of always page one", async () => {
+            const requests = [];
+            const cards = await fetchCardPages("https://api.scryfall.com/cards/search?q=test", {
+                maxPages: 1,
+                startPage: 4,
+                fetchImpl: async (url) => {
+                    requests.push(url);
+                    return jsonResponse({ object: "list", data: [{ id: "page-four" }] });
+                },
+                wait: async () => {}
+            });
+
+            assert.deepEqual(cards, [{ id: "page-four" }]);
+            assert.equal(new URL(requests[0]).searchParams.get("page"), "4");
+        });
+
+        it("reports total cards and page size for a search", async () => {
+            const meta = await fetchResultCount("https://api.scryfall.com/cards/search?q=test", {
+                fetchImpl: async () =>
+                    jsonResponse({
+                        object: "list",
+                        total_cards: 351,
+                        data: [{ id: "one" }, { id: "two" }]
+                    })
+            });
+
+            assert.deepEqual(meta, { totalCards: 351, pageSize: 2 });
         });
 
         it("rejects an untrusted pagination URL", async () => {
@@ -389,6 +435,7 @@ describe("Scryfall regression fixture importer", () => {
                     count: 1
                 },
                 {
+                    fetchResultCount: singlePageMeta,
                     fetchCardPages: async (_url, options) => {
                         assert.isFunction(options.shouldStop);
                         return cards;
@@ -453,6 +500,7 @@ describe("Scryfall regression fixture importer", () => {
                     dryRun: true
                 },
                 {
+                    fetchResultCount: singlePageMeta,
                     fetchCardPages: async (_url, options) => {
                         fetchOptions = options;
                         return [
@@ -506,6 +554,7 @@ describe("Scryfall regression fixture importer", () => {
                     dryRun: true
                 },
                 {
+                    fetchResultCount: singlePageMeta,
                     fetchCardPages: async () => [
                         card({ id: "known-id", name: "Known", set: "fin", collector: "7" }),
                         card({ id: "other-id", name: "Other", set: "fin", collector: "8" })
@@ -540,6 +589,7 @@ describe("Scryfall regression fixture importer", () => {
                         count: 2
                     },
                     {
+                        fetchResultCount: singlePageMeta,
                         fetchCardPages: async () => [
                             card({
                                 id: "existing-id",
@@ -556,6 +606,149 @@ describe("Scryfall regression fixture importer", () => {
             assert.instanceOf(error, Error);
             assert.include(error.message, "Found 0 new printable cards; requested 2");
             assert.deepEqual(JSON.parse(await readFile(manifestPath, "utf8")), originalManifest);
+        });
+
+        it("starts on a random result page instead of always the newest set", async () => {
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeManifest(manifestPath, emptyManifest());
+            const requestedPages = [];
+
+            await importScryfallFixtures(
+                {
+                    manifestPath,
+                    imageDirectory: path.join(directory, "images"),
+                    releasedAfter: "2000-01-01",
+                    count: 1,
+                    dryRun: true
+                },
+                {
+                    // 20 pages of 175 results each: enough range for the random pick to
+                    // land away from page one.
+                    fetchResultCount: async () => ({ totalCards: 3500, pageSize: 175 }),
+                    fetchCardPages: async (_url, options) => {
+                        requestedPages.push(options.startPage);
+                        return [card({ id: "hit", name: "Hit", set: "fin", collector: "1" })];
+                    },
+                    random: () => 0.5 // -> page 1 + floor(0.5 * 20) = page 11
+                }
+            );
+
+            assert.deepEqual(requestedPages, [11]);
+        });
+
+        it("wraps back to page one when the random start runs off the end", async () => {
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeManifest(manifestPath, emptyManifest());
+            const requestedPages = [];
+
+            const result = await importScryfallFixtures(
+                {
+                    manifestPath,
+                    imageDirectory: path.join(directory, "images"),
+                    releasedAfter: "2000-01-01",
+                    count: 1,
+                    dryRun: true
+                },
+                {
+                    // 4 pages total; random start lands on the last page, which alone
+                    // holds no new usable card, forcing a wrap to page one.
+                    fetchResultCount: async () => ({ totalCards: 700, pageSize: 175 }),
+                    fetchCardPages: async (_url, options) => {
+                        requestedPages.push(options.startPage);
+                        if (options.startPage === 4) {
+                            return [
+                                card({
+                                    id: "unprintable",
+                                    name: "",
+                                    set: "fin",
+                                    collector: "1"
+                                })
+                            ];
+                        }
+                        return [
+                            card({ id: "wrapped", name: "Wrapped", set: "fin", collector: "2" })
+                        ];
+                    },
+                    random: () => 0.99 // -> page 1 + floor(0.99 * 4) = page 4 (last page)
+                }
+            );
+
+            assert.deepEqual(requestedPages, [4, 1]);
+            assert.deepEqual(
+                result.added.map((entry) => entry.scryfallId),
+                ["wrapped"]
+            );
+        });
+
+        it("shuffles the candidate pool so repeated imports don't return the same order", async () => {
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeManifest(manifestPath, emptyManifest());
+            const cards = [
+                card({ id: "a", name: "Card A", set: "fin", collector: "1" }),
+                card({ id: "b", name: "Card B", set: "fin", collector: "2" }),
+                card({ id: "c", name: "Card C", set: "fin", collector: "3" })
+            ];
+
+            const result = await importScryfallFixtures(
+                {
+                    manifestPath,
+                    imageDirectory: path.join(directory, "images"),
+                    sets: ["fin"],
+                    count: 3,
+                    dryRun: true
+                },
+                {
+                    fetchResultCount: singlePageMeta,
+                    fetchCardPages: async () => cards,
+                    // forces a swap of the first and last candidate so the result isn't
+                    // just the fetch order echoed back
+                    random: (() => {
+                        const values = [0.1, 0.9];
+                        let i = 0;
+                        return () => values[i++ % values.length];
+                    })()
+                }
+            );
+
+            assert.notDeepEqual(
+                result.added.map((entry) => entry.scryfallId),
+                ["a", "b", "c"]
+            );
+            assert.sameMembers(
+                result.added.map((entry) => entry.scryfallId),
+                ["a", "b", "c"]
+            );
+        });
+
+        it("reproduces the same selection for the same seed", async () => {
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeManifest(manifestPath, emptyManifest());
+            const cards = [
+                card({ id: "a", name: "Card A", set: "fin", collector: "1" }),
+                card({ id: "b", name: "Card B", set: "fin", collector: "2" }),
+                card({ id: "c", name: "Card C", set: "fin", collector: "3" })
+            ];
+
+            const runOnce = () =>
+                importScryfallFixtures(
+                    {
+                        manifestPath,
+                        imageDirectory: path.join(directory, "images"),
+                        sets: ["fin"],
+                        count: 3,
+                        seed: 42,
+                        dryRun: true
+                    },
+                    { fetchResultCount: singlePageMeta, fetchCardPages: async () => cards }
+                );
+
+            const first = await runOnce();
+            const second = await runOnce();
+
+            assert.deepEqual(
+                first.added.map((entry) => entry.scryfallId),
+                second.added.map((entry) => entry.scryfallId)
+            );
         });
     });
 });
@@ -653,4 +846,11 @@ function jsonResponse(value) {
         status: 200,
         headers: { "Content-Type": "application/json" }
     });
+}
+
+// A fetchResultCount stub reporting a single-page result set, so importer tests that
+// don't care about page randomization keep their pre-randomization deterministic
+// fetchCardPages behavior (startPage always resolves to 1).
+async function singlePageMeta() {
+    return { totalCards: 1, pageSize: 1 };
 }


### PR DESCRIPTION
## Problem

The Scryfall regression-fixture importer (`pnpm fixtures:import`) always returned cards from the same set when run repeatedly over a wide `--set` list or `--released-after`/`--released-before` range.

Root cause: `buildCardSearchUrl` always queries `order=released&dir=desc` starting at page 1. Scryfall groups a whole set's cards together by release date, so a wide query's first page(s) are always the same newest set. Non-balanced mode's `shouldStop` fires as soon as it has `count` unseen cards, so it never walked past that first set — repeated runs kept landing on the same batch until enough exclusions built up in the manifest over many runs.

## Fix

- `fetchResultCount()` (new, in `src/scryfall-api/regression-fixtures.mjs`) reads `total_cards` / page size from Scryfall so the importer knows how many pages exist.
- `importScryfallFixtures` picks a random start page across the full result set, and wraps back to page 1 if that random page runs off the end before the requested count / page budget is satisfied.
- `fetchCardPages()` accepts a `startPage` option to land on an arbitrary page (backward compatible — no-op when omitted).
- The candidate pool is shuffled (seedable mulberry32 PRNG) before final selection, in both plain and `--balanced` modes, for extra mixing within the fetched window.
- New `--seed <n>` CLI flag makes a run reproducible (debugging a flaky selection, or pinning a CI import).

## Testing

- `pnpm test` — 317 passing (7 new importer tests covering random start-page selection, end-of-results wraparound, candidate shuffling, and seed reproducibility)
- `pnpm lint`, `pnpm prettier:check`, `pnpm typecheck` — clean

## Notes for reviewers

- `src/regression/scryfall-fixture-importer.mjs` is the core change; `src/scryfall-api/regression-fixtures.mjs` just exposes the extra `fetchResultCount` request and a `startPage` param on the existing paginator — no behavior change for existing callers that don't pass it.
- Docs updated in `docs/regression-testing.md` to describe the new randomization behavior and `--seed` flag.
- No live-network calls added to tests; `fetchResultCount` is mocked/injected everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)