### PR TITLE
chore: coverage gate + logging gaps (#28, #31)

### DIFF
--- a/.github/workflows/ci.action.yml
+++ b/.github/workflows/ci.action.yml
@@ -40,8 +40,17 @@ jobs:
             - name: Lint + Format + Types
               run: pnpm check:fast
 
-            - name: Test
-              run: pnpm test
+            - name: Test + Coverage gate
+              run: pnpm coverage:check
+
+            - name: Upload coverage report
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: mtg-coverage-${{ github.run_id }}
+                  path: coverage/
+                  if-no-files-found: warn
+                  retention-days: 14
     dot_only_linter_job:
         runs-on: ubuntu-latest
         steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ workflow. A normal build does not require AI Central.
 
 ## Before Opening a PR
 
-Run the full local gate — it's what CI checks:
+Run the full local gate — it's close to what CI checks:
 
 ```bash
 pnpm check
@@ -51,7 +51,9 @@ For anything touching logic, also run coverage and take a look at what's newly u
 pnpm coverage
 ```
 
-No coverage threshold is enforced yet (see [#31](https://github.com/dills122/MTG-Card-Analyzer/issues/31)), but new code shouldn't make the picture worse.
+CI enforces a coverage floor (`pnpm coverage:check`, thresholds in the `c8` block of `package.json` —
+currently 85% lines/statements/functions, 70% branches) so coverage can't silently regress. Run
+`pnpm coverage:check` locally before pushing if your change touches lightly-covered code.
 
 ## Tests
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,11 @@
             "html",
             "lcov"
         ],
-        "reports-dir": "coverage"
+        "reports-dir": "coverage",
+        "lines": 85,
+        "statements": 85,
+        "functions": 85,
+        "branches": 70
     },
     "dependencies": {
         "@dills1220/nedb": "^1.9.1",

--- a/src/back-filler.mjs
+++ b/src/back-filler.mjs
@@ -37,6 +37,7 @@ async function backFillCardHashes(cardName) {
         if (cardHashes.length > 0) {
             cardHashes.forEach((hash) => HashesStore.upsert(hash));
         }
+        logger.info(`Backfilled ${cardHashes.length} printing hash(es) for "${cardName}"`);
         return true;
     } catch (err) {
         logger.error(`Unable to backfill hashes for "${cardName}": ${err?.message || String(err)}`);
@@ -46,9 +47,14 @@ async function backFillCardHashes(cardName) {
 
 async function backFillMatchingCards() {
     const names = await NamesStore.getAll();
+    logger.info(`Backfilling hashes for ${names.length} stored card name(s)`);
+    let succeeded = 0;
     for (const { name } of names) {
-        await backFillCardHashes(name);
+        if (await backFillCardHashes(name)) {
+            succeeded += 1;
+        }
     }
+    logger.info(`Backfill complete: ${succeeded}/${names.length} card name(s) succeeded`);
 }
 
 export { backFillCardHashes, backFillMatchingCards };

--- a/src/db-local/card-hash-cache.mjs
+++ b/src/db-local/card-hash-cache.mjs
@@ -1,6 +1,9 @@
 import { getConfig } from "../config/index.mjs";
 import { resolveDbFilename as resolvePath } from "./resolve-db-path.mjs";
 import { createNedbStore } from "./create-nedb-store.mjs";
+import log from "../logger/log.mjs";
+
+const logger = log.create({ isPretty: true });
 
 function resolveDbFilename() {
     const config = getConfig();
@@ -52,6 +55,10 @@ function normalizeRecord(record = {}) {
 async function insertEntity(record) {
     const normalized = normalizeRecord(record);
     if (!normalized.cardName || !normalized.setName || !normalized.cardHash) {
+        logger.warn("Skipping card-hash cache write: missing cardName, setName, or cardHash", {
+            cardName: normalized.cardName,
+            setName: normalized.setName
+        });
         return 0;
     }
     const query = { lookupKey: normalized.lookupKey };

--- a/src/image-processing/image-processor.mjs
+++ b/src/image-processing/image-processor.mjs
@@ -49,7 +49,8 @@ class ImageProcessor {
     cropImage() {
         return this.dependencies.ocrPreprocessor
             .prepareOcrVariants(this.path, this.type, {
-                directory: this.persistArtifacts === false ? undefined : this.directory
+                directory: this.persistArtifacts === false ? undefined : this.directory,
+                logger: this.logger
             })
             .then(({ variants, previewPath }) => {
                 this.ocrVariants = variants;

--- a/src/image-processing/ocr-preprocessing.mjs
+++ b/src/image-processing/ocr-preprocessing.mjs
@@ -10,6 +10,9 @@ import {
     sharpen,
     padAndScale
 } from "./binarize.mjs";
+import log from "../logger/log.mjs";
+
+const defaultLogger = log.create({ isPretty: true });
 
 // Tuned preprocessing settings to make small MTG text pop for OCR. Crop geometry (region
 // templates, percent->pixel math, min-source-size gate) lives in smart-crop.mjs -- this module
@@ -32,7 +35,7 @@ const preprocessConfig = {
  * @returns {Promise<{variants: Array, previewPath?: string}>}
  */
 async function prepareOcrVariants(imgPath, type, options = {}) {
-    const { directory } = options;
+    const { directory, logger = defaultLogger } = options;
     const dimensions = await getImageDimensions(imgPath);
     smartCrop.assertSourceSizeOk(dimensions);
 
@@ -54,6 +57,7 @@ async function prepareOcrVariants(imgPath, type, options = {}) {
     let previewPath;
     if (directory && variants[0]) {
         previewPath = await writePreview(variants[0].image, directory, type, variants[0].region);
+        logger.info(`Wrote OCR preview crop for "${type}": ${previewPath}`);
     }
 
     return { variants, previewPath };

--- a/src/models/card-collection.mjs
+++ b/src/models/card-collection.mjs
@@ -1,6 +1,9 @@
 import Joi from "joi";
 import storage from "../storage/index.mjs";
 import { pick } from "../util.mjs";
+import log from "../logger/log.mjs";
+
+const logger = log.create({ isPretty: true });
 
 // "I scanned another copy" semantics: delta adds to whatever quantity already exists for
 // this cardName+cardSet (default 1), it does not overwrite it. See src/storage/index.mjs
@@ -25,9 +28,16 @@ function create(params) {
     const validated = Joi.attempt(params, schema);
     return {
         ...validated,
-        insert() {
+        async insert() {
             const object = pick(this, Object.keys(schema.describe().keys));
-            return dependencies.upsert(object);
+            try {
+                return await dependencies.upsert(object);
+            } catch (err) {
+                logger.error(
+                    `Collection write failed for "${object.cardName}" (${object.cardSet}): ${err?.message || String(err)}`
+                );
+                throw err;
+            }
         }
     };
 }

--- a/src/storage/index.mjs
+++ b/src/storage/index.mjs
@@ -3,6 +3,9 @@ import { getConfig } from "../config/index.mjs";
 import { db as namesDb } from "../db-local/db.mjs";
 import cardHashCache from "../db-local/card-hash-cache.mjs";
 import opsLog from "../db-local/ops-log.mjs";
+import log from "../logger/log.mjs";
+
+const logger = log.create({ isPretty: true });
 
 // Two distinct tiers, deliberately not the same concept:
 //
@@ -52,8 +55,11 @@ function upsertHash(record) {
         return;
     }
     // Fire-and-forget, same as before -- callers don't wait on the cache write, and a
-    // failure here shouldn't ever surface as an unhandled rejection.
-    cardHashCache.insertEntity(record).catch(() => {});
+    // failure here shouldn't ever surface as an unhandled rejection. Still worth logging:
+    // a silently-dropped hash write means future scans miss a cache hit with no trace.
+    cardHashCache.insertEntity(record).catch((err) => {
+        logger.error(`Card-hash cache write failed: ${err?.message || String(err)}`);
+    });
 }
 
 function logOperation(entry) {
@@ -61,8 +67,11 @@ function logOperation(entry) {
         return;
     }
     // Fire-and-forget, same as before -- callers don't wait on the log write, and a failure
-    // here shouldn't ever surface as an unhandled rejection.
-    opsLog.logOperation(entry).catch(() => {});
+    // here shouldn't ever surface as an unhandled rejection. Still worth logging: a silently-
+    // dropped ops-log entry means diagnostics go missing with no trace.
+    opsLog.logOperation(entry).catch((err) => {
+        logger.error(`Ops-log write failed: ${err?.message || String(err)}`);
+    });
 }
 
 const storage = {


### PR DESCRIPTION
## Summary

Round-4 code quality: two backlog items from the audit issues.

**#31 — coverage baseline + CI threshold**
- Baseline run: 91.56% lines/statements, 89.58% functions, 77.29% branches.
- Set `c8` check-coverage floor in `package.json`: 85% lines/statements/functions, 70% branches.
- CI's `pr_job` now runs `pnpm coverage:check` in place of plain `pnpm test`, and uploads the lcov/html report as a build artifact.
- Updated `CONTRIBUTING.md` to describe the enforced floor instead of "no threshold yet."

**#28 — logging gaps**
Fixed the real gaps from the issue's audit (modules with logic and either zero logging or a silently-swallowed error), not just literal file-by-file coverage:
- `back-filler.mjs`: info logs for per-card and overall backfill progress.
- `models/card-collection.mjs`: log + rethrow on a failed collection write.
- `db-local/card-hash-cache.mjs`: warn when a record is skipped for missing cardName/setName/cardHash.
- `storage/index.mjs`: the two fire-and-forget cache writes (`cardHashCache.insertEntity`, `opsLog.logOperation`) used `.catch(() => {})` by design — now logs the error before continuing to swallow it, same fire-and-forget semantics.
- `image-processing/ocr-preprocessing.mjs`: accepts an optional logger (threaded from `image-processor.mjs`) and logs when it writes a debug preview crop.

Left untouched, same reasoning the issue used to exclude re-export-only files:
- `db-local/db.mjs`, `db-local/bulk-insert.mjs` — thin wrappers; the real writes are now logged at their choke points above.
- `storage/adapters/rds-adapter.mjs`, `nedb-adapter.mjs` — pure method-name dispatch to already-logged modules.
- `models/transaction.mjs` — no longer exists; superseded by `storage/index.mjs`'s ops log.

Closes #31, closes #28.

## Verification

```
pnpm check:fast   # lint + prettier:check + typecheck
pnpm test         # 317 passing
pnpm coverage:check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)