### PR TITLE
fix(ocr): handle undersized card images instead of rejecting outright (#156)

### DIFF
--- a/src/image-processing/image-processor.mjs
+++ b/src/image-processing/image-processor.mjs
@@ -52,9 +52,10 @@ class ImageProcessor {
                 directory: this.persistArtifacts === false ? undefined : this.directory,
                 logger: this.logger
             })
-            .then(({ variants, previewPath }) => {
+            .then(({ variants, previewPath, sourceSizing }) => {
                 this.ocrVariants = variants;
                 this.imagePath = previewPath;
+                this.sourceSizing = sourceSizing;
                 return variants;
             });
     }
@@ -69,6 +70,9 @@ class ImageProcessor {
                         return reject(err);
                     }
                     this.results = extractResults;
+                    if (this.sourceSizing) {
+                        this.results.sourceSizing = this.sourceSizing;
+                    }
                     try {
                         if (
                             this.persistArtifacts !== false &&

--- a/src/image-processing/ocr-preprocessing.mjs
+++ b/src/image-processing/ocr-preprocessing.mjs
@@ -32,19 +32,32 @@ const preprocessConfig = {
  * @param {string} imgPath
  * @param {"name"|"type"|"rules-name"} type
  * @param {{directory?: string}} options
- * @returns {Promise<{variants: Array, previewPath?: string}>}
+ * @returns {Promise<{variants: Array, previewPath?: string, sourceSizing: {upscaleFactor: number, upscaled: boolean}}>}
  */
 async function prepareOcrVariants(imgPath, type, options = {}) {
     const { directory, logger = defaultLogger } = options;
     const dimensions = await getImageDimensions(imgPath);
-    smartCrop.assertSourceSizeOk(dimensions);
+    const sourceSizing = smartCrop.assertOcrSourceSizeOk(dimensions);
+    if (sourceSizing.upscaled) {
+        logger.warn(
+            `OCR source image ${dimensions.width}x${dimensions.height} is below the standard minimum; ` +
+                `proceeding ${sourceSizing.upscaleFactor.toFixed(2)}x undersized (see issue #156)`
+        );
+    }
 
     const baseImage = await jimp.read(imgPath);
     const templates = smartCrop.getRegionTemplates(type);
     const variants = [];
 
     for (const template of templates) {
-        const processed = await cropAndPreprocess(baseImage, template);
+        const processed = await cropAndPreprocess(baseImage, template, {
+            // Hard Otsu thresholding + invert + sharpen (buildOcrImage) assumes real per-pixel
+            // detail to binarize; on a source that's already been stretched past its native
+            // resolution, that detail is interpolated noise, and thresholding it destroys
+            // character shapes rather than clarifying them. The soft profile (contrast only,
+            // no threshold) reads noticeably better on undersized sources -- see issue #156.
+            lowResolutionSource: sourceSizing.upscaled
+        });
         const buffer = await processed.getBufferAsync(jimp.MIME_PNG);
         variants.push({
             region: template.key,
@@ -60,12 +73,13 @@ async function prepareOcrVariants(imgPath, type, options = {}) {
         logger.info(`Wrote OCR preview crop for "${type}": ${previewPath}`);
     }
 
-    return { variants, previewPath };
+    return { variants, previewPath, sourceSizing };
 }
 
-async function cropAndPreprocess(baseImage, template) {
+async function cropAndPreprocess(baseImage, template, options = {}) {
     const { image: cropped } = smartCrop.cropRegion(baseImage, template);
-    return template.mode === "soft" ? buildSoftOcrImage(cropped) : buildOcrImage(cropped);
+    const useSoftProfile = template.mode === "soft" || options.lowResolutionSource;
+    return useSoftProfile ? buildSoftOcrImage(cropped) : buildOcrImage(cropped);
 }
 
 /**

--- a/src/image-processing/smart-crop.mjs
+++ b/src/image-processing/smart-crop.mjs
@@ -106,6 +106,10 @@ function getRegionTemplates(type) {
 const config = {
     minSourceWidth: 360,
     minSourceHeight: 500,
+    // A source below the standard minimum but within this factor of it is still treated as
+    // recoverable for OCR (see assertOcrSourceSizeOk) -- anything further out is degenerate/
+    // unreadable rather than merely low-resolution.
+    maxRecoverableUpscaleFactor: 2,
     // Greyscale luminance std-dev (0-255) below this reads as a near-uniform-color crop (solid
     // card border/background instead of a real set-symbol icon).
     lowConfidenceStdDevThreshold: 10
@@ -115,6 +119,33 @@ function assertSourceSizeOk(dimensions) {
     if (dimensions.width < config.minSourceWidth || dimensions.height < config.minSourceHeight) {
         throw new Error("Image is to small");
     }
+}
+
+function computeSourceUpscaleFactor(dimensions) {
+    return Math.max(
+        1,
+        config.minSourceWidth / dimensions.width,
+        config.minSourceHeight / dimensions.height
+    );
+}
+
+/**
+ * OCR-specific sizing gate (GitHub issue #156). Unlike assertSourceSizeOk's hard cutoff --
+ * used for set-symbol image-hash crops, where a soft/undersized crop actively hurts hash
+ * comparison -- every OCR crop is upscaled to a fixed minimum width by padAndScale
+ * (see binarize.mjs) regardless of source resolution. So a source that's merely somewhat
+ * under the standard minimum can still reach OCR instead of being rejected outright; only a
+ * source too small/degraded to trust at all (further than maxRecoverableUpscaleFactor out)
+ * is still rejected.
+ * @param {{width: number, height: number}} dimensions
+ * @returns {{upscaleFactor: number, upscaled: boolean}}
+ */
+function assertOcrSourceSizeOk(dimensions) {
+    const upscaleFactor = computeSourceUpscaleFactor(dimensions);
+    if (upscaleFactor > config.maxRecoverableUpscaleFactor) {
+        throw new Error("Image is to small");
+    }
+    return { upscaleFactor, upscaled: upscaleFactor > 1 };
 }
 
 /**
@@ -201,6 +232,7 @@ export {
     computeGreyscaleStdDev,
     assessConfidence,
     assertSourceSizeOk,
+    assertOcrSourceSizeOk,
     cropSetSymbolFromImage,
     writeSetSymbolSnippet
 };
@@ -212,6 +244,7 @@ export default {
     computeGreyscaleStdDev,
     assessConfidence,
     assertSourceSizeOk,
+    assertOcrSourceSizeOk,
     cropSetSymbolFromImage,
     writeSetSymbolSnippet
 };

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -16,6 +16,7 @@ const noCacheOcrOptions = Object.freeze({
 
 const silentLogger = {
     info: () => {},
+    warn: () => {},
     error: () => {}
 };
 
@@ -206,7 +207,11 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
                 cleanText: ocr.cleanText,
                 dirtyText: ocr.dirtyText,
                 confidence: ocr.confidence || 0,
-                variant: ocr.bestVariant?.region || ""
+                variant: ocr.bestVariant?.region || "",
+                // Whether the source image was below the standard OCR minimum and had to be
+                // processed through the undersized-input path (see GitHub issue #156).
+                upscaled: Boolean(ocr.sourceSizing?.upscaled),
+                upscaleFactor: ocr.sourceSizing?.upscaleFactor || 1
             },
             nameMatches,
             nameCandidateCount: nameMatches.length,
@@ -233,7 +238,14 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
             blocking: fixture.blocking !== false,
             sourceImage: fixture.image,
             expected: fixture.expected,
-            ocr: { cleanText: "", dirtyText: "", confidence: 0, variant: "" },
+            ocr: {
+                cleanText: "",
+                dirtyText: "",
+                confidence: 0,
+                variant: "",
+                upscaled: false,
+                upscaleFactor: 1
+            },
             nameMatches: [],
             nameCandidateCount: 0,
             printCandidateCount: 0,
@@ -270,6 +282,9 @@ function summarize(results) {
         passed,
         failed: results.length - passed,
         passRate: results.length ? Math.round((passed / results.length) * 10000) / 100 : 0,
+        // Fixtures whose source image was below the standard OCR minimum and went through the
+        // undersized-input path instead of being rejected outright (see GitHub issue #156).
+        undersizedInputs: results.filter((result) => result.ocr.upscaled).length,
         totalRuntimeMs: Math.round(runtimes.reduce((sum, runtime) => sum + runtime, 0) * 100) / 100,
         meanRuntimeMs: results.length
             ? Math.round(

--- a/src/regression/report.mjs
+++ b/src/regression/report.mjs
@@ -27,6 +27,7 @@ function formatBenchmarkReport(report) {
         `- CI gate: ${report.gate?.failed === 0 ? "PASS" : "FAIL"} (${report.gate?.passed || 0}/${report.gate?.total || 0} blocking fixtures passed)`,
         `- Non-blocking fixtures: ${report.gate?.nonBlocking || 0} (${report.gate?.nonBlockingFailed || 0} failed)`,
         `- Disabled fixtures: ${report.pending?.cases || 0}`,
+        `- Undersized-input fixtures: ${report.summary.undersizedInputs || 0}`,
         `- Fixtures containing CHANGE_ME: ${report.pending?.placeholderCases || 0}`,
         `- Total runtime: ${report.summary.totalRuntimeMs} ms`,
         `- Mean runtime: ${report.summary.meanRuntimeMs} ms`,
@@ -58,9 +59,12 @@ function formatBenchmarkReport(report) {
             : `${result.blocking === false ? "NON-BLOCKING FAIL" : "FAIL"}: ${result.failures
                   .map(markdownCell)
                   .join("; ")}`;
+        const ocrOutputLabel = result.ocr.upscaled
+            ? `${result.ocr.cleanText} (undersized source, upscaled ${result.ocr.upscaleFactor.toFixed(2)}x)`
+            : result.ocr.cleanText;
         lines.push(
             `| ${markdownCell(result.id)} | ${markdownCell(result.quality)} | ${markdownCell(
-                result.ocr.cleanText
+                ocrOutputLabel
             )} | ${markdownCell(nameMatch?.name || "—")} (${
                 nameMatch ? Math.round(nameMatch.percentage * 10000) / 100 : 0
             }%) | ${result.nameCandidateCount} | ${result.printCandidateCount} | ${markdownCell(

--- a/test/image-processing/image-processor.spec.mjs
+++ b/test/image-processing/image-processor.spec.mjs
@@ -69,6 +69,29 @@ describe("Integration::", () => {
             });
         });
 
+        it("attaches undersized-source sizing metadata to the results (issue #156)", (done) => {
+            const sourceSizing = { upscaleFactor: 1.36, upscaled: true };
+            stubs.preprocessStub = sandbox.stub().resolves({
+                variants: [{ buffer: Buffer.from("OCR"), region: TYPE, psm: "line" }],
+                previewPath: FAKE_PATH,
+                sourceSizing
+            });
+            const processor = ImageProcessor.create({
+                path: FAKE_PATH_INPUT,
+                type: TYPE,
+                directory: FAKE_DIR,
+                dependencies: {
+                    ocrPreprocessor: { prepareOcrVariants: stubs.preprocessStub },
+                    textExtraction: { scanImage: stubs.textExtractionStub }
+                }
+            });
+
+            processor.extract((err) => {
+                assert.deepEqual(processor.results.sourceSizing, sourceSizing);
+                return done(err);
+            });
+        });
+
         it("Should error out due to an incomplete schema", (done) => {
             let processor = () => ImageProcessor.create({});
             assert.throw(processor, Error);

--- a/test/image-processing/ocr-preprocessing.spec.mjs
+++ b/test/image-processing/ocr-preprocessing.spec.mjs
@@ -1,6 +1,17 @@
 import { assert } from "chai";
 import path from "node:path";
+import sinon from "sinon";
+import jimp from "jimp";
+import os from "node:os";
+import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { prepareOcrVariants } from "../../src/image-processing/ocr-preprocessing.mjs";
+
+async function makeTempDir() {
+    const dir = path.join(os.tmpdir(), `ocr-preprocessing-spec-${randomUUID()}`);
+    await fs.mkdir(dir, { recursive: true });
+    return dir;
+}
 
 describe("OCR preprocessing::", () => {
     it("builds a single soft rules-text fallback region", async () => {
@@ -8,12 +19,53 @@ describe("OCR preprocessing::", () => {
             "test-images/regression/scryfall/fin-570-vivi-ornitier-25ef2d44.jpg"
         );
 
-        const { variants, previewPath } = await prepareOcrVariants(fixturePath, "rules-name");
+        const { variants, previewPath, sourceSizing } = await prepareOcrVariants(
+            fixturePath,
+            "rules-name"
+        );
 
         assert.lengthOf(variants, 1);
         assert.equal(variants[0].region, "rules-name");
         assert.equal(variants[0].psm, "block");
         assert.isAbove(variants[0].image.bitmap.width, 900);
         assert.isUndefined(previewPath);
+        assert.deepEqual(sourceSizing, { upscaleFactor: 1, upscaled: false });
+    });
+
+    describe("undersized sources (GitHub issue #156)::", () => {
+        it("reaches OCR (instead of rejecting the image) and reports the upscale used", async () => {
+            const fixturePath = path.resolve("test-images/red-1.jpg");
+            const logger = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+
+            const { variants, sourceSizing } = await prepareOcrVariants(fixturePath, "name", {
+                logger
+            });
+
+            assert.isNotEmpty(variants);
+            assert.isTrue(sourceSizing.upscaled);
+            assert.approximately(sourceSizing.upscaleFactor, 1.36, 0.01);
+            assert.isTrue(logger.warn.calledOnce);
+            assert.match(logger.warn.firstCall.args[0], /undersized/);
+        });
+
+        it("still rejects a source too degraded to be a recoverable upscale", async () => {
+            const tempDir = await makeTempDir();
+            try {
+                const tinyImage = await new jimp(100, 100, 0xffffffff);
+                const tinyPath = path.join(tempDir, "tiny.png");
+                await tinyImage.writeAsync(tinyPath);
+
+                let caughtError;
+                try {
+                    await prepareOcrVariants(tinyPath, "name");
+                } catch (err) {
+                    caughtError = err;
+                }
+                assert.instanceOf(caughtError, Error);
+                assert.equal(caughtError.message, "Image is to small");
+            } finally {
+                await fs.rm(tempDir, { recursive: true, force: true });
+            }
+        });
     });
 });

--- a/test/image-processing/smart-crop.spec.mjs
+++ b/test/image-processing/smart-crop.spec.mjs
@@ -10,6 +10,7 @@ import {
     cropRegion,
     computeGreyscaleStdDev,
     assessConfidence,
+    assertOcrSourceSizeOk,
     cropSetSymbolFromImage,
     writeSetSymbolSnippet
 } from "../../src/image-processing/smart-crop.mjs";
@@ -197,6 +198,31 @@ describe("Smart crop::", () => {
             }
             assert.instanceOf(caughtError, Error);
             assert.match(caughtError.message, /low confidence/);
+        });
+    });
+
+    describe("assertOcrSourceSizeOk::", () => {
+        it("reports no upscaling needed when the source already meets the OCR minimum", () => {
+            const sizing = assertOcrSourceSizeOk({ width: 360, height: 500 });
+            assert.deepEqual(sizing, { upscaleFactor: 1, upscaled: false });
+        });
+
+        it("permits and reports an upscale for a source within the recoverable range", () => {
+            // 265x370 -- the real-world fixture from GitHub issue #156.
+            const sizing = assertOcrSourceSizeOk({ width: 265, height: 370 });
+            assert.isTrue(sizing.upscaled);
+            assert.approximately(sizing.upscaleFactor, 1.36, 0.01);
+        });
+
+        it("rejects a source too far below the minimum to be a recoverable upscale", () => {
+            let caughtError;
+            try {
+                assertOcrSourceSizeOk({ width: 100, height: 100 });
+            } catch (err) {
+                caughtError = err;
+            }
+            assert.instanceOf(caughtError, Error);
+            assert.equal(caughtError.message, "Image is to small");
         });
     });
 });

--- a/test/regression/fixtures/manifest.json
+++ b/test/regression/fixtures/manifest.json
@@ -278,7 +278,7 @@
             "apiUrl": "https://scryfall.com/card/mh3/208/writhing-chrysalis"
         },
         {
-            "enabled": false,
+            "enabled": true,
             "name": "Ingenious Artillerist",
             "set": "CLB",
             "setName": "Commander Legends: Battle for Baldur's Gate",
@@ -1852,11 +1852,11 @@
             }
         },
         {
-            "enabled": false,
+            "enabled": true,
             "id": "red-1-pending",
             "image": "../../../test-images/red-1.jpg",
-            "quality": "clean-scan",
-            "notes": "Disabled: 265x370 image is below the current 360x500 preprocessing minimum; tracked by GitHub issue #156",
+            "quality": "low-resolution",
+            "notes": "265x370 source is below the 360x500 OCR minimum; recovered via the undersized-input upscale path (issue #156)",
             "expected": {
                 "name": "Ingenious Artillerist",
                 "set": "CLB",


### PR DESCRIPTION
## Summary

`smartCrop.assertSourceSizeOk`'s 360x500 minimum rejected any smaller source before it ever reached OCR — even though every OCR crop is already unconditionally upscaled to >=900px wide by `padAndScale` (`binarize.mjs`) regardless of source resolution. So a merely low-resolution photo (not a corrupt/degenerate one) had no real reason to be blocked pre-crop.

- `smart-crop.mjs`: new `assertOcrSourceSizeOk`, used only by the OCR path (`assertSourceSizeOk` / `writeSetSymbolSnippet`'s hard gate is untouched — a soft/undersized set-symbol crop actively hurts image-hash comparison). A source within 2x of the minimum is treated as recoverable and upscaled; further out is still rejected with the same `"Image is to small"` error.
- `ocr-preprocessing.mjs`: on a recoverable-but-undersized source, use the existing soft preprocessing profile (contrast only) instead of hard Otsu threshold + invert + sharpen — thresholding assumes real per-pixel detail, and on an already-upscaled/interpolated crop it destroys character shapes instead of clarifying them. This is what actually got the real fixture (`red-1.jpg`, 265x370) from OCR garbage (`"mm 1"`) to a fuzzy-matchable read (`"Ingenious Artillerisl"`, 1 character off).
- `image-processor.mjs`, `regression-runner.mjs`, `report.mjs`: thread the resulting sizing info (`upscaleFactor`/`upscaled`) through to the regression benchmark so it's visible per-fixture and in the summary (`Undersized-input fixtures: N`), instead of just working silently.
- `manifest.json`: enable the `red-1-pending` case and its catalog entry (both were disabled for this exact reason), retag its quality as `low-resolution`, and update the notes.

Also fixes `regression-runner`'s `silentLogger` stub, which only implemented `info`/`error` and broke as soon as the OCR path started calling `logger.warn`.

Closes #156.

## Verification

```
pnpm check:fast   # lint + prettier:check + typecheck
pnpm test         # 323 passing
pnpm coverage:check
pnpm test:regression
```

Regression: 72/72 blocking fixtures pass (including `red-1-pending`, now enabled); 5/7 non-blocking vintage fixtures still fail, unaffected by this change and tracked separately by #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)