### PR TITLE
fix: send a User-Agent on remote Scryfall image-hash requests

### DIFF
--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -220,7 +220,13 @@ class ProcessHashes {
     }
 
     async _hashRemoteSetSymbol(url, tempDirectory) {
-        const image = await jimp.read(url);
+        // Scryfall's image CDN 400s a header-less request -- jimp's own URL loader sends none by
+        // default. Same fix/header as image-hashing/hash-image.mjs's remote imageHash() calls.
+        // Only a real http(s) URL takes jimp's {url, headers} request-object form; a local test
+        // fixture path must stay a plain string so it still takes jimp's fs-read branch.
+        const image = imageHashing.isRemoteUrl(url)
+            ? await jimp.read({ url, headers: imageHashing.REMOTE_IMAGE_REQUEST_HEADERS })
+            : await jimp.read(url);
         const cropped = this.dependencies.CropSetSymbol(image);
         if (cropped.lowConfidence) {
             throw new Error(`Set symbol crop is low confidence: ${cropped.reason}`);

--- a/src/image-hashing/hash-image.mjs
+++ b/src/image-hashing/hash-image.mjs
@@ -11,9 +11,29 @@ const logger = log.create({
     isPretty: true
 });
 
+// Scryfall's image CDN (cards.scryfall.io) returns HTTP 400 for a header-less request -- Node's
+// global fetch (what the image-hash package uses under the hood) sends no User-Agent by default,
+// so every remote hash was failing outright. Same header value as scryfall-api/http-client.mjs's
+// REQUEST_HEADERS; duplicated locally (like regression-fixtures.mjs's own copy) rather than
+// importing across the image-hashing/scryfall-api boundary for one constant.
+export const REMOTE_IMAGE_REQUEST_HEADERS = {
+    "User-Agent": "MTG-Card-Analyzer/0.2 (+https://github.com/dills122/MTG-Card-Analyzer)",
+    Accept: "image/*"
+};
+
+export function isRemoteUrl(value) {
+    return typeof value === "string" && /^https?:\/\//i.test(value);
+}
+
 function hashImage(imgUrl, cb) {
     logger.info(`Hashing image: ${formatImageSource(imgUrl)}`);
-    dependencies.imageHash(imgUrl, 16, true, (error, data) => {
+    // image-hash accepts either a plain path/URL string or a {url, ...fetchInit} request object;
+    // only remote URLs need the header -- a local file path must stay a plain string so it still
+    // takes the fs.readFile branch instead of being treated as a request object.
+    const source = isRemoteUrl(imgUrl)
+        ? { url: imgUrl, headers: REMOTE_IMAGE_REQUEST_HEADERS }
+        : imgUrl;
+    dependencies.imageHash(source, 16, true, (error, data) => {
         if (error) {
             return cb(error);
         }
@@ -74,5 +94,7 @@ export { compareHash, hashImage };
 export default {
     compareHash,
     hashImage,
-    dependencies
+    dependencies,
+    isRemoteUrl,
+    REMOTE_IMAGE_REQUEST_HEADERS
 };

--- a/src/image-hashing/index.mjs
+++ b/src/image-hashing/index.mjs
@@ -1,7 +1,10 @@
 import Hash from "./hash-image.mjs";
+import { REMOTE_IMAGE_REQUEST_HEADERS, isRemoteUrl } from "./hash-image.mjs";
 
-export { Hash };
+export { Hash, REMOTE_IMAGE_REQUEST_HEADERS, isRemoteUrl };
 
 export default {
-    Hash
+    Hash,
+    REMOTE_IMAGE_REQUEST_HEADERS,
+    isRemoteUrl
 };

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -1,5 +1,6 @@
 import os from "os";
 import path from "node:path";
+import jimp from "jimp";
 import { assert } from "chai";
 import sinon from "sinon";
 import exportProcessor from "../../src/export-processor/index.mjs";
@@ -227,6 +228,67 @@ describe("Integration::", () => {
             assert.isTrue(stubs.symbolStub.calledOnce);
             assert.isTrue(stubs.hashImageStub.calledOnce);
             assert.equal(stubs.hashImageStub.firstCall.args[0], "http://www.fake.url/img");
+        });
+
+        // Scryfall's image CDN 400s a header-less request; jimp's own URL loader sends none by
+        // default. Lock in that a remote set-symbol crop always carries a User-Agent.
+        it("passes a User-Agent header when jimp reads a remote set-symbol image", async () => {
+            const readStub = sandbox.stub(jimp, "read").resolves({
+                clone: () => ({ crop: () => ({}) })
+            });
+            let hasher = ProcessHashes.create({
+                cards: [
+                    {
+                        image_uris: {
+                            normal: "https://cards.scryfall.io/normal/front/a/b/card.jpg"
+                        },
+                        set_name: "SET_A"
+                    }
+                ],
+                localHash: CLOSE_DIFF_HASH,
+                name: "Test",
+                hashMode: "set-symbol"
+            });
+            sandbox.stub(hasher.dependencies, "CropSetSymbol").returns({
+                image: { writeAsync: sandbox.stub().resolves() },
+                lowConfidence: false
+            });
+            sandbox.stub(Hash, "hashImage").callsArgWith(1, null, FAKE_HASH);
+
+            await hasher._hashRemoteSetSymbol(
+                "https://cards.scryfall.io/normal/front/a/b/card.jpg",
+                "/tmp"
+            );
+
+            assert.isTrue(readStub.calledOnce);
+            const [source] = readStub.firstCall.args;
+            assert.equal(source.url, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
+            assert.property(source.headers, "User-Agent");
+            assert.isNotEmpty(source.headers["User-Agent"]);
+        });
+
+        it("reads a local fixture path as a plain string, not a headers request object", async () => {
+            const fixturePath = path.resolve(
+                "test-images/regression/scryfall/fin-570-vivi-ornitier-25ef2d44.jpg"
+            );
+            const readStub = sandbox.stub(jimp, "read").resolves({
+                clone: () => ({ crop: () => ({}) })
+            });
+            let hasher = ProcessHashes.create({
+                cards: [{ image_uris: { normal: fixturePath }, set_name: "SET_A" }],
+                localHash: CLOSE_DIFF_HASH,
+                name: "Test",
+                hashMode: "set-symbol"
+            });
+            sandbox.stub(hasher.dependencies, "CropSetSymbol").returns({
+                image: { writeAsync: sandbox.stub().resolves() },
+                lowConfidence: false
+            });
+            sandbox.stub(Hash, "hashImage").callsArgWith(1, null, FAKE_HASH);
+
+            await hasher._hashRemoteSetSymbol(fixturePath, "/tmp");
+
+            assert.isTrue(readStub.calledOnceWithExactly(fixturePath));
         });
 
         it("Should fall back to full remote hash when set-symbol crop is low confidence", async () => {

--- a/test/image-hashing/hash-image.spec.mjs
+++ b/test/image-hashing/hash-image.spec.mjs
@@ -1,0 +1,72 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import { hashImage, compareHash, dependencies } from "../../src/image-hashing/hash-image.mjs";
+
+describe("image-hashing::hash-image", () => {
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe("hashImage::", () => {
+        // Scryfall's image CDN 400s a header-less request (Node's global fetch, which the
+        // image-hash package uses, sends no User-Agent by default) -- every remote hash was
+        // failing outright until this was fixed. Lock in that a remote URL always carries a
+        // User-Agent through image-hash's {url, headers} request-object form.
+        it("passes a User-Agent header for a remote http(s) URL", (done) => {
+            const imageHashStub = sandbox
+                .stub(dependencies, "imageHash")
+                .callsArgWith(3, null, "hash");
+
+            hashImage("https://cards.scryfall.io/normal/front/a/b/card.jpg", (err, hash) => {
+                assert.isNull(err);
+                assert.equal(hash, "hash");
+                assert.isTrue(imageHashStub.calledOnce);
+                const [source] = imageHashStub.firstCall.args;
+                assert.equal(source.url, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
+                assert.property(source.headers, "User-Agent");
+                assert.isNotEmpty(source.headers["User-Agent"]);
+                done(err);
+            });
+        });
+
+        it("passes a local file path through unchanged (no headers wrapper)", (done) => {
+            const imageHashStub = sandbox
+                .stub(dependencies, "imageHash")
+                .callsArgWith(3, null, "hash");
+
+            hashImage("/tmp/some/local/card.png", (err) => {
+                assert.isTrue(imageHashStub.calledOnce);
+                const [source] = imageHashStub.firstCall.args;
+                assert.equal(source, "/tmp/some/local/card.png");
+                done(err);
+            });
+        });
+
+        it("forwards a hashing error to the callback", (done) => {
+            sandbox.stub(dependencies, "imageHash").callsArgWith(3, new Error("boom"));
+
+            hashImage("https://cards.scryfall.io/normal/front/a/b/card.jpg", (err, hash) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.message, "boom");
+                assert.isUndefined(hash);
+                done();
+            });
+        });
+    });
+
+    describe("compareHash::", () => {
+        it("scores an identical hash as a perfect match", () => {
+            const hash = "a".repeat(64);
+            const result = compareHash(hash, hash);
+            assert.equal(result.twoBitMatches, 1);
+            assert.equal(result.fourBitMatches, 1);
+            assert.equal(result.stringCompare, 1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Found during release-readiness testing: a clean-clone run of the exact quick-start command from the README —

```
node index.mjs scan ./test-images/PlatinumAngel.jpg
```

— crashes:

```
Error: Failed to fetch image. HTTP status: 400 Bad Request
    at .../image-hash@7.0.1/node_modules/image-hash/lib/index.js:145:23
```

**Root cause:** Scryfall's image CDN (`cards.scryfall.io`) returns HTTP 400 for any request with no `User-Agent` header. Confirmed directly:

```js
fetch('https://cards.scryfall.io/...')                              // -> 400
fetch('https://cards.scryfall.io/...', {headers:{'User-Agent':'...'}}) // -> 200
```

Node's global `fetch` (what the `image-hash` package uses) and jimp's own URL loader both send no `User-Agent` by default — so **every** remote image-hash comparison against Scryfall was broken, not flaky:

- `image-hashing/hash-image.mjs`'s `hashImage()`: every set-symbol and full-card remote hash 400'd. The set-symbol path already has a try/catch that falls back to full-card on failure, so this was invisible beyond a routine-looking `"using full card image"` log line — but the full-card fallback also 400'd with nothing left to catch it, taking the whole match down with a raw stack trace and exit code 1.
- `export-processor/process-hashes.mjs`'s `_hashRemoteSetSymbol()`: `jimp.read(url)` has the same gap independently of the above (jimp's remote loader takes its own `{url, headers}` request-object form rather than going through `image-hash`).

`image-hashing/hash-image.mjs` now exports `REMOTE_IMAGE_REQUEST_HEADERS` and `isRemoteUrl` so `process-hashes.mjs` (which already depends on the `image-hashing` package) reuses the same header/guard instead of a third copy of the User-Agent string.

## Verified against the real failure

Before this fix, a clean-clone scan of `test-images/PlatinumAngel.jpg` failed all 15 set-symbol remote hashes, then crashed on the full-card fallback (exit 1). After: 0 set-symbol failures, scan completes and prints results (exit 0) — and set-symbol matching (the more precise mode, previously *always* silently falling back to full-card) now actually works.

## Verification

```
pnpm check:fast   # lint + prettier:check + typecheck
pnpm test         # 349 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)