### PR TITLE
docs: fix stale undersized-image claim, fill module-map gaps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -105,9 +105,10 @@ Run `node index.mjs --help` for the command list or see the
   <img width="320" src="test-images/PlatinumAngel.jpg" alt="Platinum Angel card used by the example scan">
 </p>
 
-OCR quality varies with lighting, focus, rotation, framing, and card layout. Images smaller than
-360 by 500 pixels are currently rejected. Setup and printing lookup use Scryfall, so the scanner
-is local-first rather than fully offline.
+OCR quality varies with lighting, focus, rotation, framing, and card layout. The OCR minimum is
+360 by 500 pixels; a smaller source within 2x of that is still upscaled and processed, and only a
+source further below is rejected. Setup and printing lookup use Scryfall, so the scanner is
+local-first rather than fully offline.
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,13 +65,16 @@ See [Configuration and local data](configuration.md) for precedence, paths, and 
 | `src/fuzzy-matching/`   | Name and type normalization and fuzzy ranking                     |
 | `src/matcher/`          | Candidate-print matching and hash orchestration                   |
 | `src/image-hashing/`    | Perceptual image hashing and comparison                           |
+| `src/export-processor/` | Card-hash comparison against the local cache and remote Scryfall  |
 | `src/processor/`        | End-to-end scan workflow and decision orchestration               |
+| `src/models/`           | Collection and needs-attention record validation and persistence  |
 | `src/scryfall-api/`     | Scryfall requests and response translation                        |
 | `src/storage/`          | Persistence contract and backend selection                        |
 | `src/db-local/`         | NeDB name index, cache, operations log, and local persistence     |
 | `src/rds/`              | Optional legacy MySQL persistence adapter                         |
 | `src/diagnostics/`      | Sanitized environment and recent-activity reports                 |
 | `src/regression/`       | Offline OCR, matching, and print-selection benchmark framework    |
+| `src/logger/`           | Shared pretty/plain leveled logger                                |
 
 ## Tests and external services
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -44,9 +44,10 @@ benchmark reports are the only durable files written by the runner.
 
 <!-- markdownlint-enable MD013 -->
 
-Images below 360 by 500 pixels are rejected by current production preprocessing. Keep
-low-resolution fixtures above that hard boundary unless the expected result is the validation
-failure itself.
+Production preprocessing requires 360 by 500 pixels; a source within 2x of that minimum is
+upscaled and still processed (see `smartCrop.assertOcrSourceSizeOk`), and only a source further
+below is rejected. Keep low-resolution fixtures within the recoverable range unless the expected
+result is the validation failure itself.
 
 ## Run the suite
 


### PR DESCRIPTION
## Summary

Found while sweeping docs for release readiness:

- `Readme.md` and `docs/regression-testing.md` both still said images below 360x500 are hard-rejected. #156 changed that to an upscale-and-try path (a source within 2x of the minimum is upscaled and processed; only a source further below is rejected) — updated both to match current behavior.
- `docs/architecture.md`'s module map was missing `src/export-processor/`, `src/models/`, and `src/logger/`.

## Verification

```
pnpm check:fast
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)