### PR TITLE
Add review-first OCR training and model comparison workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ lib-cov/
 # Generated OCR regression reports
 artifacts/regression/
 
+# Local OCR training review crops (unreviewed and potentially rights-restricted)
+artifacts/training-review/
+
 # Build output
 build/
 dist/

--- a/Readme.md
+++ b/Readme.md
@@ -119,6 +119,7 @@ local-first rather than fully offline.
 | Change settings or understand local database files               | [Configuration and local data](docs/configuration.md) |
 | Understand the scan pipeline and module boundaries               | [Architecture](docs/architecture.md)                  |
 | Add or evaluate OCR and matching fixtures                        | [Regression testing](docs/regression-testing.md)      |
+| Build a reviewed custom OCR fine-tuning corpus                   | [OCR training data](docs/ocr-training-data.md)        |
 | Prepare a change or pull request                                 | [Contributing](CONTRIBUTING.md)                       |
 
 The default NeDB backend is the recommended path. A legacy MySQL/RDS adapter remains available for

--- a/docs/ocr-training-data.md
+++ b/docs/ocr-training-data.md
@@ -33,6 +33,28 @@ integer runtime model and is not a valid fine-tuning base according to Tesseract
 
 ## Add a reviewed pair
 
+### Stage a local review batch
+
+The staging command can crop the production `name-core` region from disabled regression candidates.
+It refuses enabled fixtures, placeholder labels, compound card names without face-specific ground
+truth, duplicate IDs, oversized batches, and an existing batch directory. Output stays under the
+ignored `artifacts/training-review/` directory and every sample remains `reviewed: false`.
+
+```bash
+pnpm training:review:stage \
+    --batch batch-001 \
+    --case fin-569-choco-seeker-of-paradise-1ce688fa-scryfall \
+    --case fin-585-laughing-mad-9268ccdb-scryfall
+```
+
+The review manifest records hashes, source fixture IDs, the crop region, and the rights/provenance
+basis. Staging does not grant or assert ownership of card imagery. The default note references
+Wizards' [Fan Content Policy](https://company.wizards.com/en/legal/fancontentpolicy) and labels the
+output as unofficial, noncommercial, review-only local material. Do not commit or promote a crop
+until its use, transcription, and visual quality are explicitly reviewed.
+
+### Promote an approved pair
+
 Place the files under `training/ocr/ground-truth/`:
 
 ```text

--- a/docs/ocr-training-data.md
+++ b/docs/ocr-training-data.md
@@ -1,0 +1,84 @@
+# OCR training data
+
+The custom OCR corpus is review-first. The repository currently contains a pinned, empty draft at
+`training/ocr/manifest.json`; it defines the base model and validation contract without pretending
+that unreviewed samples are ready to train.
+
+Tesseract's supported `tesstrain` workflow consumes single-line PNG or TIFF images paired with a
+plain-text transcription whose filename replaces the image extension with `.gt.txt`. Its training
+Makefile supports a fixed random seed and train/evaluation ratio, and `START_MODEL` selects the model
+to fine-tune. See the official [`tesstrain` README](https://github.com/tesseract-ocr/tesstrain) and
+[Tesseract training guide](https://tesseract-ocr.github.io/tessdoc/).
+
+## Corpus rules
+
+- Add a tightly cropped, single-line card-name image, not a full card or multi-line text block.
+- Use `.png` or `.tif`; pair `sample.png` with `sample.gt.txt`.
+- Store exactly one non-empty UTF-8/NFC transcription line. One final newline is allowed; leading,
+  trailing, embedded newline, and control characters are rejected.
+- Record SHA-256 for both files. The validator fails on changed bytes instead of silently accepting a
+  relabeled or regenerated sample.
+- Record whether the source is a real card image or synthetic, a stable source reference, and its
+  license. Set `reviewed: true` only after a human checks the crop and exact transcription.
+- Do not derive training samples from enabled regression fixtures. Those fixtures are the acceptance
+  gate; training on them would hide overfitting. Acquire separate captures or use a reviewed,
+  training-only source pool.
+- Keep generated checkpoints, downloaded upstream repositories, and local training output outside
+  the committed corpus. Only reviewed line pairs, their manifest, and an intentionally selected final
+  candidate belong in Git.
+
+The manifest pins `tessdata_best` revision
+`e12c65a915945e4c28e237a9b52bc4a8f39a0cec` as the float fine-tuning base. `tessdata_fast` is an
+integer runtime model and is not a valid fine-tuning base according to Tesseract's training guidance.
+
+## Add a reviewed pair
+
+Place the files under `training/ocr/ground-truth/`:
+
+```text
+training/ocr/ground-truth/mtg-0001.png
+training/ocr/ground-truth/mtg-0001.gt.txt
+```
+
+Then add the pair to `training/ocr/manifest.json` with exact hashes:
+
+```json
+{
+    "id": "mtg-0001",
+    "image": "ground-truth/mtg-0001.png",
+    "transcription": "ground-truth/mtg-0001.gt.txt",
+    "imageSha256": "<64 lowercase hex characters>",
+    "transcriptionSha256": "<64 lowercase hex characters>",
+    "reviewed": true,
+    "source": {
+        "kind": "card-image",
+        "reference": "capture-batch-2026-08/card-0001",
+        "license": "owned-capture"
+    }
+}
+```
+
+Validate structure, paths, file sizes, hashes, encoding, transcription shape, provenance, and the
+pinned base model:
+
+```bash
+pnpm training:data:check
+```
+
+The draft may contain zero samples while the source pool is being assembled. Before training, set
+the manifest status to `reviewed` and run the readiness gate:
+
+```bash
+pnpm training:data:check --require-ready
+```
+
+The readiness gate requires every sample to be reviewed and the fixed `trainRatio` to produce at
+least one training and one evaluation line. The current seed is `20260808` and the ratio is `0.9`;
+these values must be passed unchanged to `tesstrain` so repeated list generation is deterministic.
+
+## Promotion path
+
+Training completion is not promotion. Package the selected checkpoint as `eng.traineddata`, add it
+to a reviewed OCR candidate manifest with exact provenance and SHA-256, run the full regression
+corpus, and compare it to the bundled control with `pnpm regression:compare`. A candidate with any
+blocking regression does not replace the production model, even if aggregate accuracy improves.

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -66,6 +66,11 @@ pnpm test:regression --quality clean-scan --quality low-resolution
 
 # Use another manifest or output directory
 pnpm test:regression --manifest ./path/manifest.json --output ./path/reports
+
+# Run against another reviewed OCR candidate
+pnpm test:regression \
+    --ocr-model-manifest ./path/to/ocr-models.json \
+    --ocr-model official-eng-fast
 ```
 
 Execution stays sequential to keep OCR timings and CPU contention comparable.
@@ -74,6 +79,25 @@ Run multiple fixture IDs or quality groups in one command to reuse its worker.
 Each separate command starts a new worker.
 
 The generated `artifacts/regression` directory is ignored by Git.
+
+## OCR model candidates
+
+The default run loads `test/regression/ocr-models/manifest.json` and verifies the bundled control
+model's SHA-256 before starting Tesseract. Every candidate must identify its source URL and revision,
+license, model family, compatible Tesseract.js version, exact byte hash, and a local file named
+`eng.traineddata`. Candidate files are capped at 128 MiB and loaded with the OCR cache disabled.
+
+Keep each candidate in its own directory because Tesseract.js resolves English data as
+`<langPath>/eng.traineddata`. The benchmark JSON records the selected candidate's safe provenance,
+hash, and size; it does not record the candidate's local filesystem path. The Markdown report shows
+the candidate ID, family, abbreviated hash, and size.
+
+Candidate acquisition remains an explicit review step; the regression command does not download or
+replace model data. Prefer candidates from Tesseract's official
+[`tessdata`, `tessdata_fast`, and `tessdata_best` repositories](https://github.com/tesseract-ocr/tessdoc/blob/main/Data-Files.md).
+Keep the Tesseract.js/core version fixed during a model comparison because its official guidance
+notes that settings, language data, and engine version must all match for comparable output:
+[Tesseract.js FAQ](https://github.com/naptha/tesseract.js/blob/master/docs/faq.md).
 
 ## Manifest
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -99,6 +99,53 @@ Keep the Tesseract.js/core version fixed during a model comparison because its o
 notes that settings, language data, and engine version must all match for comparable output:
 [Tesseract.js FAQ](https://github.com/naptha/tesseract.js/blob/master/docs/faq.md).
 
+### Compare completed model runs
+
+Run every model against the same fixture manifest and filters, write each run to a separate output
+directory, then compare their JSON reports:
+
+```bash
+pnpm regression:compare \
+    --control artifacts/regression/models/bundled-eng-control/benchmark.json \
+    --candidate artifacts/regression/models/official-eng-fast/benchmark.json \
+    --candidate artifacts/regression/models/official-eng-best/benchmark.json \
+    --output artifacts/regression/models/comparison
+```
+
+The comparator refuses reports with different fixture ID sets. Its Markdown and JSON outputs show
+accuracy, blocking-gate, runtime, and model-size deltas plus every fixture whose pass/fail result
+changed. A model with a blocking regression is reported as a failed candidate even when its overall
+pass count increases.
+
+### Pinned upstream bakeoff: 2026-08-08
+
+The first controlled bakeoff kept Tesseract.js at 3.0.3 and ran all 79 enabled fixtures sequentially
+with OCR caching disabled. Timings are from one local run and should be treated as directional; the
+accuracy and fixture deltas are the promotion gate.
+
+| Model                    |      Size | Passed | Blocking | Mean runtime | P95 runtime |
+| ------------------------ | --------: | -----: | -------: | -----------: | ----------: |
+| Bundled control          | 20.86 MiB |  74/79 |    72/72 |   1026.22 ms |  2145.50 ms |
+| Official `tessdata_fast` |  3.92 MiB |  72/79 |    70/72 |    869.48 ms |  1907.77 ms |
+| Official `tessdata_best` | 14.69 MiB |  75/79 |    71/72 |   1063.18 ms |  2318.91 ms |
+
+Pinned inputs:
+
+- `tessdata_fast` revision `87416418657359cb625c412a48b6e1d6d41c29bd`, SHA-256
+  `7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2`
+- `tessdata_best` revision `e12c65a915945e4c28e237a9b52bc4a8f39a0cec`, SHA-256
+  `8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba`
+
+`tessdata_fast` fixed one non-blocking vintage fixture but regressed Worldly Tutor and the blocking
+Sarkhan Unbroken and Yavimaya Coast fixtures. `tessdata_best` fixed two non-blocking vintage fixtures
+but regressed the blocking Sarkhan Unbroken fixture. Neither candidate is eligible to replace the
+bundled control.
+
+Use the pinned `tessdata_best` model as the base for the custom-training experiment. Tesseract's
+official data-file guidance identifies `tessdata_best` as the float model intended for fine-tuning;
+`tessdata_fast` is an integer model that cannot be used as a training base. A trained candidate must
+return to this same comparison gate before any production promotion.
+
 ## Manifest
 
 Edit `test/regression/fixtures/manifest.json`. Paths are relative to the manifest file. The

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "ai:setup": "node scripts/setup-ai-context.mjs",
         "test": "mocha \"./test/**/*.spec.mjs\"",
         "test:regression": "node scripts/run-regression.mjs",
+        "regression:compare": "node scripts/compare-ocr-models.mjs",
         "fixtures:import": "node scripts/import-scryfall-fixtures.mjs",
         "regression": "node scripts/run-regression.mjs --no-fail-on-regression",
         "coverage": "c8 pnpm test",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "test:regression": "node scripts/run-regression.mjs",
         "regression:compare": "node scripts/compare-ocr-models.mjs",
         "training:data:check": "node scripts/validate-ocr-training-data.mjs",
+        "training:review:stage": "node scripts/stage-ocr-training-review.mjs",
         "fixtures:import": "node scripts/import-scryfall-fixtures.mjs",
         "regression": "node scripts/run-regression.mjs --no-fail-on-regression",
         "coverage": "c8 pnpm test",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "test": "mocha \"./test/**/*.spec.mjs\"",
         "test:regression": "node scripts/run-regression.mjs",
         "regression:compare": "node scripts/compare-ocr-models.mjs",
+        "training:data:check": "node scripts/validate-ocr-training-data.mjs",
         "fixtures:import": "node scripts/import-scryfall-fixtures.mjs",
         "regression": "node scripts/run-regression.mjs --no-fail-on-regression",
         "coverage": "c8 pnpm test",

--- a/scripts/compare-ocr-models.mjs
+++ b/scripts/compare-ocr-models.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Command } from "commander";
+import {
+    compareOcrModelReports,
+    writeOcrModelComparison
+} from "../src/regression/ocr-model-comparison.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const defaultOutput = path.join(repositoryRoot, "artifacts/regression/model-comparison");
+
+function collect(value, previous) {
+    return previous.concat(value);
+}
+
+function buildProgram() {
+    return new Command()
+        .name("compare-ocr-models")
+        .description("Compare like-for-like OCR model regression benchmark reports")
+        .requiredOption("--control <path>", "control benchmark.json report")
+        .option("--candidate <path>", "candidate benchmark.json report (repeatable)", collect, [])
+        .option("-o, --output <directory>", "comparison report directory", defaultOutput);
+}
+
+async function readReport(reportPath) {
+    const absolutePath = path.resolve(reportPath);
+    try {
+        return JSON.parse(await readFile(absolutePath, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to read benchmark report ${absolutePath}: ${error.message}`, {
+            cause: error
+        });
+    }
+}
+
+async function main(argv = process.argv, overrides = {}) {
+    const {
+        readReport: readReportFn = readReport,
+        compareOcrModelReports: compareReportsFn = compareOcrModelReports,
+        writeOcrModelComparison: writeComparisonFn = writeOcrModelComparison,
+        writeLine = console.log
+    } = overrides;
+    const options = buildProgram().parse(argv).opts();
+    if (options.candidate.length === 0) {
+        throw new Error("At least one --candidate report is required");
+    }
+
+    const [control, ...candidates] = await Promise.all(
+        [options.control, ...options.candidate].map((reportPath) => readReportFn(reportPath))
+    );
+    const comparison = compareReportsFn(control, candidates);
+    const paths = await writeComparisonFn(comparison, options.output);
+    writeLine(`Markdown: ${paths.markdownPath}`);
+    writeLine(`JSON: ${paths.jsonPath}`);
+    return comparison;
+}
+
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error(error?.stack || error);
+        process.exitCode = 1;
+    });
+}
+
+export { buildProgram, main, readReport };

--- a/scripts/run-regression.mjs
+++ b/scripts/run-regression.mjs
@@ -3,6 +3,7 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command } from "commander";
+import { loadOcrModelManifest } from "../src/regression/ocr-model-candidate.mjs";
 import { QUALITY_LEVELS, loadManifest } from "../src/regression/manifest.mjs";
 import { runRegression } from "../src/regression/regression-runner.mjs";
 import { writeBenchmarkReport } from "../src/regression/report.mjs";
@@ -11,6 +12,11 @@ const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptDirectory, "..");
 const defaultManifest = path.join(repositoryRoot, "test/regression/fixtures/manifest.json");
 const defaultOutput = path.join(repositoryRoot, "artifacts/regression");
+const defaultOcrModelManifest = path.join(
+    repositoryRoot,
+    "test/regression/ocr-models/manifest.json"
+);
+const defaultOcrModel = "bundled-eng-control";
 
 function collect(value, previous) {
     return previous.concat(value);
@@ -22,6 +28,12 @@ function buildProgram() {
         .description("Run deterministic OCR and card-matching regression fixtures")
         .option("-m, --manifest <path>", "fixture manifest", defaultManifest)
         .option("-o, --output <directory>", "benchmark report directory", defaultOutput)
+        .option(
+            "--ocr-model-manifest <path>",
+            "reviewed OCR model candidate manifest",
+            defaultOcrModelManifest
+        )
+        .option("--ocr-model <id>", "OCR model candidate ID", defaultOcrModel)
         .option("-c, --case <id>", "run a fixture id (repeatable)", collect, [])
         .option(
             "-q, --quality <level>",
@@ -32,37 +44,53 @@ function buildProgram() {
         .option("--no-fail-on-regression", "write the report but exit zero when fixtures fail");
 }
 
-async function main(argv = process.argv) {
+async function main(argv = process.argv, overrides = {}) {
+    const {
+        loadManifest: loadFixtureManifest = loadManifest,
+        loadOcrModelManifest: loadModelManifest = loadOcrModelManifest,
+        runRegression: runRegressionFn = runRegression,
+        writeBenchmarkReport: writeBenchmarkReportFn = writeBenchmarkReport,
+        writeLine = console.log
+    } = overrides;
     const options = buildProgram().parse(argv).opts();
     const unknownQualities = options.quality.filter((quality) => !QUALITY_LEVELS.includes(quality));
     if (unknownQualities.length > 0) {
         throw new Error(`Unknown quality level(s): ${unknownQualities.join(", ")}`);
     }
 
-    const manifest = await loadManifest(options.manifest);
-    const report = await runRegression(manifest, {
+    const manifest = await loadFixtureManifest(options.manifest);
+    const modelManifest = await loadModelManifest(options.ocrModelManifest);
+    const ocrModel = modelManifest.candidates.find(
+        (candidate) => candidate.id === options.ocrModel && candidate.enabled !== false
+    );
+    if (!ocrModel) {
+        throw new Error(`Unknown OCR model candidate: ${options.ocrModel}`);
+    }
+    const report = await runRegressionFn(manifest, {
         caseIds: options.case,
-        qualities: options.quality
+        qualities: options.quality,
+        ocrModel
     });
-    const paths = await writeBenchmarkReport(report, options.output);
-    console.log(
+    const paths = await writeBenchmarkReportFn(report, options.output);
+    writeLine(`OCR model: ${ocrModel.id}`);
+    writeLine(
         `Regression: ${report.summary.passed}/${report.summary.total} passed (${report.summary.passRate}%)`
     );
-    console.log(
+    writeLine(
         `CI gate: ${report.gate.passed}/${report.gate.total} blocking fixtures passed; ${report.gate.nonBlockingFailed}/${report.gate.nonBlocking} non-blocking fixtures failed`
     );
-    console.log("Application persistence, image-hash cache, and OCR cache: disabled");
-    console.log("Tesseract worker: shared sequentially for this regression run");
+    writeLine("Application persistence, image-hash cache, and OCR cache: disabled");
+    writeLine("Tesseract worker: shared sequentially for this regression run");
     if (report.pending.cases > 0) {
-        console.log(`Disabled fixtures: ${report.pending.cases}`);
+        writeLine(`Disabled fixtures: ${report.pending.cases}`);
     }
     if (report.pending.placeholderCases > 0) {
-        console.log(
+        writeLine(
             `Fixtures containing CHANGE_ME: ${report.pending.placeholderCases} (search the manifest to label them)`
         );
     }
-    console.log(`Markdown report: ${paths.markdownPath}`);
-    console.log(`JSON report: ${paths.jsonPath}`);
+    writeLine(`Markdown report: ${paths.markdownPath}`);
+    writeLine(`JSON report: ${paths.jsonPath}`);
 
     if (options.failOnRegression && report.gate.failed > 0) {
         process.exitCode = 1;

--- a/scripts/stage-ocr-training-review.mjs
+++ b/scripts/stage-ocr-training-review.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Command } from "commander";
+import { loadManifest } from "../src/regression/manifest.mjs";
+import { stageTrainingReviewBatch } from "../src/training/training-review-stager.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const defaultManifest = path.join(repositoryRoot, "test/regression/fixtures/manifest.json");
+const defaultOutputRoot = path.join(repositoryRoot, "artifacts/training-review");
+const defaultRightsBasis =
+    "Wizards Fan Content Policy (https://company.wizards.com/en/legal/fancontentpolicy); " +
+    "unofficial, noncommercial, review-only local artifact";
+const BATCH_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+
+function collect(value, previous) {
+    return previous.concat(value);
+}
+
+function buildProgram() {
+    return new Command()
+        .name("stage-ocr-training-review")
+        .description("Stage local, unreviewed OCR line crops from disabled regression candidates")
+        .requiredOption("--batch <id>", "safe review batch identifier")
+        .option("-c, --case <id>", "disabled regression fixture ID (repeatable)", collect, [])
+        .option("-m, --manifest <path>", "regression fixture manifest", defaultManifest)
+        .option("--output-root <directory>", "ignored review artifact root", defaultOutputRoot)
+        .option("--rights-basis <text>", "source rights/provenance note", defaultRightsBasis);
+}
+
+async function main(argv = process.argv, overrides = {}) {
+    const {
+        loadManifest: loadRegressionManifest = loadManifest,
+        stageTrainingReviewBatch: stageBatch = stageTrainingReviewBatch,
+        writeLine = console.log
+    } = overrides;
+    const options = buildProgram().parse(argv).opts();
+    if (!BATCH_PATTERN.test(options.batch)) {
+        throw new Error(
+            "Batch ID must use lowercase letters, numbers, dots, dashes, or underscores"
+        );
+    }
+    if (options.case.length === 0) {
+        throw new Error("At least one --case fixture ID is required");
+    }
+
+    const regressionManifest = await loadRegressionManifest(options.manifest);
+    const outputDirectory = path.resolve(options.outputRoot, options.batch);
+    const report = await stageBatch(regressionManifest, {
+        caseIds: options.case,
+        outputDirectory,
+        rightsBasis: options.rightsBasis
+    });
+    writeLine(`Training review batch: ${report.samples.length} unreviewed sample(s)`);
+    writeLine(`Review directory: ${outputDirectory}`);
+    return report;
+}
+
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error(error?.stack || error);
+        process.exitCode = 1;
+    });
+}
+
+export { buildProgram, main };

--- a/scripts/validate-ocr-training-data.mjs
+++ b/scripts/validate-ocr-training-data.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Command } from "commander";
+import {
+    assertTrainingDataReady,
+    loadTrainingDataManifest
+} from "../src/training/training-data-manifest.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const defaultManifest = path.join(repositoryRoot, "training/ocr/manifest.json");
+
+function buildProgram() {
+    return new Command()
+        .name("validate-ocr-training-data")
+        .description("Verify reviewed Tesseract line images, transcriptions, and provenance")
+        .option("-m, --manifest <path>", "training-data manifest", defaultManifest)
+        .option("--require-ready", "fail unless the corpus is reviewed and can be split");
+}
+
+async function main(argv = process.argv, overrides = {}) {
+    const {
+        loadTrainingDataManifest: loadManifest = loadTrainingDataManifest,
+        assertTrainingDataReady: assertReady = assertTrainingDataReady,
+        writeLine = console.log
+    } = overrides;
+    const options = buildProgram().parse(argv).opts();
+    const manifest = await loadManifest(options.manifest);
+
+    writeLine(
+        `Training data: ${manifest.samples.length} verified sample(s); status ${manifest.status}`
+    );
+    writeLine(`Base model: ${manifest.baseModel.id}`);
+    if (options.requireReady) {
+        const readiness = assertReady(manifest);
+        writeLine(
+            `Deterministic split: ${readiness.train} train / ${readiness.evaluation} evaluation`
+        );
+    }
+    return manifest;
+}
+
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error(error?.stack || error);
+        process.exitCode = 1;
+    });
+}
+
+export { buildProgram, main };

--- a/src/regression/ocr-model-candidate.mjs
+++ b/src/regression/ocr-model-candidate.mjs
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+const MAX_OCR_MODEL_BYTES = 128 * 1024 * 1024;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+const ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+
+function requireObject(value, label) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(`${label} must be an object`);
+    }
+}
+
+function requireString(value, label) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+        throw new Error(`${label} must be a non-empty string`);
+    }
+}
+
+function validateSource(source, label) {
+    requireObject(source, label);
+    requireString(source.url, `${label}.url`);
+    requireString(source.revision, `${label}.revision`);
+    requireString(source.license, `${label}.license`);
+    let sourceUrl;
+    try {
+        sourceUrl = new URL(source.url);
+    } catch {
+        throw new Error(`${label}.url must be a valid URL`);
+    }
+    if (sourceUrl.protocol !== "https:") {
+        throw new Error(`${label}.url must use HTTPS`);
+    }
+}
+
+function validateEngine(engine, label) {
+    requireObject(engine, label);
+    requireString(engine.package, `${label}.package`);
+    requireString(engine.version, `${label}.version`);
+}
+
+function validateOcrModelManifest(rawManifest, manifestPath) {
+    requireObject(rawManifest, "OCR model manifest");
+    if (rawManifest.version !== 1) {
+        throw new Error(`Unsupported OCR model manifest version: ${rawManifest.version}`);
+    }
+    if (!Array.isArray(rawManifest.candidates) || rawManifest.candidates.length === 0) {
+        throw new Error("OCR model manifest must contain at least one candidate");
+    }
+
+    const absoluteManifestPath = path.resolve(manifestPath);
+    const manifestDirectory = path.dirname(absoluteManifestPath);
+    const ids = new Set();
+    const candidates = rawManifest.candidates.map((candidate, index) => {
+        const label = `candidates[${index}]`;
+        requireObject(candidate, label);
+        requireString(candidate.id, `${label}.id`);
+        if (!ID_PATTERN.test(candidate.id)) {
+            throw new Error(
+                `${label}.id must use lowercase letters, numbers, dots, dashes, or underscores`
+            );
+        }
+        if (ids.has(candidate.id)) {
+            throw new Error(`Duplicate OCR model candidate id: ${candidate.id}`);
+        }
+        ids.add(candidate.id);
+        requireString(candidate.model, `${label}.model`);
+        if (path.basename(candidate.model) !== "eng.traineddata") {
+            throw new Error(`${label}.model must be named eng.traineddata`);
+        }
+        requireString(candidate.family, `${label}.family`);
+        requireString(candidate.sha256, `${label}.sha256`);
+        if (!SHA256_PATTERN.test(candidate.sha256)) {
+            throw new Error(`${label}.sha256 must be a 64-character hexadecimal SHA-256`);
+        }
+        if (candidate.enabled !== undefined && typeof candidate.enabled !== "boolean") {
+            throw new Error(`${label}.enabled must be a boolean`);
+        }
+        validateSource(candidate.source, `${label}.source`);
+        validateEngine(candidate.engine, `${label}.engine`);
+
+        const modelPath = path.resolve(manifestDirectory, candidate.model);
+        return {
+            ...candidate,
+            sha256: candidate.sha256.toLowerCase(),
+            modelPath,
+            languagePath: path.dirname(modelPath)
+        };
+    });
+
+    return {
+        ...rawManifest,
+        path: absoluteManifestPath,
+        directory: manifestDirectory,
+        candidates
+    };
+}
+
+async function sha256File(filePath) {
+    const hash = createHash("sha256");
+    for await (const chunk of createReadStream(filePath)) {
+        hash.update(chunk);
+    }
+    return hash.digest("hex");
+}
+
+async function verifyCandidate(candidate) {
+    let fileStats;
+    try {
+        fileStats = await stat(candidate.modelPath);
+    } catch (error) {
+        throw new Error(`OCR model candidate file does not exist: ${candidate.modelPath}`, {
+            cause: error
+        });
+    }
+    if (!fileStats.isFile()) {
+        throw new Error(`OCR model candidate is not a regular file: ${candidate.modelPath}`);
+    }
+    if (fileStats.size === 0 || fileStats.size > MAX_OCR_MODEL_BYTES) {
+        throw new Error(
+            `OCR model candidate ${candidate.id} must be between 1 and ${MAX_OCR_MODEL_BYTES} bytes`
+        );
+    }
+    const actualSha256 = await sha256File(candidate.modelPath);
+    if (actualSha256 !== candidate.sha256) {
+        throw new Error(
+            `SHA-256 mismatch for OCR model candidate ${candidate.id}: expected ${candidate.sha256}, received ${actualSha256}`
+        );
+    }
+    return { ...candidate, sizeBytes: fileStats.size };
+}
+
+async function loadOcrModelManifest(manifestPath) {
+    const absolutePath = path.resolve(manifestPath);
+    let rawManifest;
+    try {
+        rawManifest = JSON.parse(await readFile(absolutePath, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to read OCR model manifest ${absolutePath}: ${error.message}`, {
+            cause: error
+        });
+    }
+    const manifest = validateOcrModelManifest(rawManifest, absolutePath);
+    const candidates = await Promise.all(manifest.candidates.map(verifyCandidate));
+    return { ...manifest, candidates };
+}
+
+export { MAX_OCR_MODEL_BYTES, loadOcrModelManifest, sha256File, validateOcrModelManifest };
+
+export default { loadOcrModelManifest, validateOcrModelManifest };

--- a/src/regression/ocr-model-comparison.mjs
+++ b/src/regression/ocr-model-comparison.mjs
@@ -1,0 +1,221 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+function round(value) {
+    return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function signed(value, suffix = "") {
+    const rounded = round(value);
+    return `${rounded >= 0 ? "+" : ""}${rounded}${suffix}`;
+}
+
+function markdownCell(value) {
+    return String(value ?? "")
+        .replace(/\r?\n/g, " ")
+        .replace(/\|/g, "\\|")
+        .trim();
+}
+
+function validateReport(report, label) {
+    if (!report || typeof report !== "object") {
+        throw new Error(`${label} report must be an object`);
+    }
+    if (!report.ocrModel?.id) {
+        throw new Error(`${label} report does not identify its OCR model`);
+    }
+    if (!report.summary || !report.gate || !Array.isArray(report.results)) {
+        throw new Error(`${label} report is missing summary, gate, or fixture results`);
+    }
+
+    const ids = report.results.map((result) => result.id);
+    if (ids.some((id) => typeof id !== "string" || id.length === 0)) {
+        throw new Error(`${label} report contains a fixture without an ID`);
+    }
+    if (new Set(ids).size !== ids.length) {
+        throw new Error(`${label} report contains duplicate fixture IDs`);
+    }
+}
+
+function assertSameFixtureSet(control, candidate) {
+    const controlIds = control.results.map((result) => result.id).sort();
+    const candidateIds = candidate.results.map((result) => result.id).sort();
+    if (
+        controlIds.length !== candidateIds.length ||
+        controlIds.some((id, index) => id !== candidateIds[index])
+    ) {
+        throw new Error(`${candidate.ocrModel.id} fixture IDs do not match control`);
+    }
+}
+
+function summarizeChange(controlResult, candidateResult, kind) {
+    return {
+        id: candidateResult.id,
+        blocking: candidateResult.blocking !== false,
+        kind,
+        expectedName: candidateResult.expected?.name,
+        controlOcr: controlResult.ocr?.cleanText,
+        candidateOcr: candidateResult.ocr?.cleanText,
+        controlConfidence: controlResult.ocr?.confidence,
+        candidateConfidence: candidateResult.ocr?.confidence,
+        failures: candidateResult.failures || []
+    };
+}
+
+function compareCandidate(control, candidate) {
+    assertSameFixtureSet(control, candidate);
+    const controlById = new Map(control.results.map((result) => [result.id, result]));
+    const improvements = [];
+    const regressions = [];
+
+    candidate.results.forEach((candidateResult) => {
+        const controlResult = controlById.get(candidateResult.id);
+        if (controlResult.passed === candidateResult.passed) {
+            return;
+        }
+        const kind = candidateResult.passed ? "improvement" : "regression";
+        const change = summarizeChange(controlResult, candidateResult, kind);
+        (candidateResult.passed ? improvements : regressions).push(change);
+    });
+
+    return {
+        model: candidate.ocrModel,
+        metrics: {
+            passed: candidate.summary.passed,
+            total: candidate.summary.total,
+            passRate: candidate.summary.passRate,
+            passedDelta: candidate.summary.passed - control.summary.passed,
+            blockingPassed: candidate.gate.passed,
+            blockingTotal: candidate.gate.total,
+            blockingPassedDelta: candidate.gate.passed - control.gate.passed,
+            nonBlockingFailed: candidate.gate.nonBlockingFailed,
+            nonBlockingFailedDelta:
+                candidate.gate.nonBlockingFailed - control.gate.nonBlockingFailed,
+            meanRuntimeMs: candidate.summary.meanRuntimeMs,
+            meanRuntimeMsDelta: round(
+                candidate.summary.meanRuntimeMs - control.summary.meanRuntimeMs
+            ),
+            p95RuntimeMs: candidate.summary.p95RuntimeMs,
+            p95RuntimeMsDelta: round(candidate.summary.p95RuntimeMs - control.summary.p95RuntimeMs),
+            totalRuntimeMs: candidate.summary.totalRuntimeMs,
+            totalRuntimeMsDelta: round(
+                candidate.summary.totalRuntimeMs - control.summary.totalRuntimeMs
+            ),
+            sizeBytes: candidate.ocrModel.sizeBytes,
+            sizeBytesDelta: candidate.ocrModel.sizeBytes - control.ocrModel.sizeBytes
+        },
+        gatePassed: candidate.gate.failed === 0 && regressions.every((change) => !change.blocking),
+        changes: {
+            improvements,
+            regressions,
+            blockingRegressions: regressions.filter((change) => change.blocking)
+        }
+    };
+}
+
+function compareOcrModelReports(control, candidates) {
+    validateReport(control, "control");
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+        throw new Error("At least one candidate report is required");
+    }
+    candidates.forEach((candidate) => validateReport(candidate, "candidate"));
+
+    return {
+        schemaVersion: 1,
+        control: {
+            model: control.ocrModel,
+            metrics: {
+                passed: control.summary.passed,
+                total: control.summary.total,
+                passRate: control.summary.passRate,
+                blockingPassed: control.gate.passed,
+                blockingTotal: control.gate.total,
+                nonBlockingFailed: control.gate.nonBlockingFailed,
+                meanRuntimeMs: control.summary.meanRuntimeMs,
+                p95RuntimeMs: control.summary.p95RuntimeMs,
+                totalRuntimeMs: control.summary.totalRuntimeMs,
+                sizeBytes: control.ocrModel.sizeBytes
+            }
+        },
+        candidates: candidates.map((candidate) => compareCandidate(control, candidate))
+    };
+}
+
+function formatOcrModelComparison(comparison) {
+    const control = comparison.control;
+    const lines = [
+        "# OCR model regression comparison",
+        "",
+        "| Model | Family | Accuracy | Blocking | Gate | Mean runtime | P95 runtime | Model size |",
+        "| --- | --- | ---: | ---: | --- | ---: | ---: | ---: |",
+        `| ${markdownCell(control.model.id)} | ${markdownCell(control.model.family)} | ${
+            control.metrics.passed
+        }/${control.metrics.total} | ${control.metrics.blockingPassed}/${
+            control.metrics.blockingTotal
+        } | CONTROL | ${control.metrics.meanRuntimeMs} ms | ${
+            control.metrics.p95RuntimeMs
+        } ms | ${control.metrics.sizeBytes} B |`
+    ];
+
+    comparison.candidates.forEach((candidate) => {
+        const metrics = candidate.metrics;
+        lines.push(
+            `| ${markdownCell(candidate.model.id)} | ${markdownCell(candidate.model.family)} | ${
+                metrics.passed
+            }/${metrics.total} | ${metrics.blockingPassed}/${metrics.blockingTotal} | ${
+                candidate.gatePassed ? "PASS" : "FAIL"
+            } | ${metrics.meanRuntimeMs} ms (${signed(
+                metrics.meanRuntimeMsDelta,
+                " ms"
+            )}) | ${metrics.p95RuntimeMs} ms (${signed(
+                metrics.p95RuntimeMsDelta,
+                " ms"
+            )}) | ${metrics.sizeBytes} B (${signed(metrics.sizeBytesDelta, " B")}) |`
+        );
+    });
+
+    comparison.candidates.forEach((candidate) => {
+        lines.push(
+            "",
+            `## ${markdownCell(candidate.model.id)} fixture changes`,
+            "",
+            `- Net passes: ${signed(candidate.metrics.passedDelta)}`,
+            `- Blocking passes: ${signed(candidate.metrics.blockingPassedDelta)}`,
+            `- Non-blocking failures: ${signed(candidate.metrics.nonBlockingFailedDelta)}`,
+            "",
+            "| Fixture | Scope | Change | Control OCR | Candidate OCR | Candidate failure |",
+            "| --- | --- | --- | --- | --- | --- |"
+        );
+
+        const changes = [...candidate.changes.improvements, ...candidate.changes.regressions];
+        if (changes.length === 0) {
+            lines.push("| — | — | no pass/fail changes | — | — | — |");
+        } else {
+            changes.forEach((change) => {
+                lines.push(
+                    `| ${markdownCell(change.id)} | ${
+                        change.blocking ? "blocking" : "non-blocking"
+                    } | ${change.kind} | ${markdownCell(change.controlOcr)} | ${markdownCell(
+                        change.candidateOcr
+                    )} | ${markdownCell(change.failures.join("; ") || "—")} |`
+                );
+            });
+        }
+    });
+
+    return `${lines.join("\n")}\n`;
+}
+
+async function writeOcrModelComparison(comparison, outputDirectory) {
+    const absoluteOutput = path.resolve(outputDirectory);
+    await mkdir(absoluteOutput, { recursive: true });
+    const jsonPath = path.join(absoluteOutput, "comparison.json");
+    const markdownPath = path.join(absoluteOutput, "comparison.md");
+    await Promise.all([
+        writeFile(jsonPath, `${JSON.stringify(comparison, null, 2)}\n`, "utf8"),
+        writeFile(markdownPath, formatOcrModelComparison(comparison), "utf8")
+    ]);
+    return { jsonPath, markdownPath };
+}
+
+export { compareOcrModelReports, formatOcrModelComparison, writeOcrModelComparison };

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -20,6 +20,12 @@ const silentLogger = {
     error: () => {}
 };
 
+function reportOcrModel(ocrModel) {
+    if (!ocrModel) return undefined;
+    const { id, family, sha256, sizeBytes, source, engine } = ocrModel;
+    return { id, family, sha256, sizeBytes, source, engine };
+}
+
 function normalized(value) {
     return String(value || "")
         .replace(/[^a-z0-9]/gi, "")
@@ -311,6 +317,13 @@ function summarizeGate(results) {
 }
 
 async function runRegression(manifest, options = {}) {
+    const ocrOptions = options.ocrModel
+        ? {
+              ...noCacheOcrOptions,
+              langPath: options.ocrModel.languagePath,
+              gzip: false
+          }
+        : noCacheOcrOptions;
     const dependencies = {
         ImageProcessor: imageProcessorModule,
         MatchName: matchNameModule,
@@ -319,7 +332,7 @@ async function runRegression(manifest, options = {}) {
         createOcrSession: textExtractionModule.createOcrSession,
         ...(options.dependencies || {}),
         // Regression isolation is an invariant, not a caller-selectable optimization.
-        ocrOptions: noCacheOcrOptions
+        ocrOptions
     };
     const activeCatalog = manifest.catalog.filter((card) => card.enabled !== false);
     const activeCases = manifest.cases.filter((fixture) => fixture.enabled !== false);
@@ -341,7 +354,7 @@ async function runRegression(manifest, options = {}) {
         dependencies.ImageProcessor === imageProcessorModule ||
         typeof options.dependencies?.createOcrSession === "function";
     const ocrSession = managesOcrSession
-        ? await dependencies.createOcrSession({ ...noCacheOcrOptions, logger: silentLogger })
+        ? await dependencies.createOcrSession({ ...ocrOptions, logger: silentLogger })
         : null;
     if (ocrSession) {
         dependencies.ocrOptions = { ...dependencies.ocrOptions, session: ocrSession };
@@ -356,11 +369,14 @@ async function runRegression(manifest, options = {}) {
             generatedAt: new Date().toISOString(),
             manifest: manifest.path,
             offline: true,
+            ocrModel: reportOcrModel(options.ocrModel),
             isolation: {
                 applicationPersistence: "disabled",
                 imageHashCache: "disabled",
                 ocrCache: "disabled",
-                ocrLanguageSource: "patched bundled eng.traineddata",
+                ocrLanguageSource: options.ocrModel
+                    ? `OCR candidate ${options.ocrModel.id}`
+                    : "patched bundled eng.traineddata",
                 ocrWorkerLifecycle: "shared process; adaptive state reset per crop",
                 temporaryArtifacts: "deleted after each case"
             },

--- a/src/regression/report.mjs
+++ b/src/regression/report.mjs
@@ -18,6 +18,14 @@ function formatBenchmarkReport(report) {
         "",
         `Mode: ${report.offline ? "offline (no live API calls)" : "online"}`,
         "",
+        report.ocrModel
+            ? `OCR model: ${markdownCell(report.ocrModel.id)} (${markdownCell(
+                  report.ocrModel.family
+              )}; ${markdownCell(report.ocrModel.sha256?.slice(0, 12))}…; ${
+                  report.ocrModel.sizeBytes
+              } bytes)`
+            : "OCR model: unreported",
+        "",
         `Isolation: application persistence ${report.isolation?.applicationPersistence || "unknown"}; image-hash cache ${report.isolation?.imageHashCache || "unknown"}; OCR cache ${report.isolation?.ocrCache || "unknown"}`,
         "",
         "## Summary",

--- a/src/training/training-data-manifest.mjs
+++ b/src/training/training-data-manifest.mjs
@@ -1,0 +1,281 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+const MAX_TRAINING_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_TRANSCRIPTION_BYTES = 1024;
+const ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+const IMAGE_EXTENSIONS = [".png", ".tif"];
+
+function requireObject(value, label) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(`${label} must be an object`);
+    }
+}
+
+function requireString(value, label) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+        throw new Error(`${label} must be a non-empty string`);
+    }
+}
+
+function requireSha256(value, label) {
+    requireString(value, label);
+    if (!SHA256_PATTERN.test(value)) {
+        throw new Error(`${label} must be a 64-character hexadecimal SHA-256`);
+    }
+}
+
+function resolveContainedPath(directory, relativePath, label) {
+    requireString(relativePath, label);
+    if (path.isAbsolute(relativePath)) {
+        throw new Error(`${label} must be relative to the manifest directory`);
+    }
+    const absolutePath = path.resolve(directory, relativePath);
+    const relative = path.relative(directory, absolutePath);
+    if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        throw new Error(`${label} must stay inside the manifest directory`);
+    }
+    return absolutePath;
+}
+
+function validateBaseModel(baseModel) {
+    requireObject(baseModel, "baseModel");
+    requireString(baseModel.id, "baseModel.id");
+    if (baseModel.family !== "tessdata_best") {
+        throw new Error("baseModel.family must be tessdata_best for fine-tuning");
+    }
+    requireSha256(baseModel.sha256, "baseModel.sha256");
+    requireObject(baseModel.source, "baseModel.source");
+    requireString(baseModel.source.url, "baseModel.source.url");
+    requireString(baseModel.source.revision, "baseModel.source.revision");
+    requireString(baseModel.source.license, "baseModel.source.license");
+    let sourceUrl;
+    try {
+        sourceUrl = new URL(baseModel.source.url);
+    } catch {
+        throw new Error("baseModel.source.url must be a valid URL");
+    }
+    if (sourceUrl.protocol !== "https:") {
+        throw new Error("baseModel.source.url must use HTTPS");
+    }
+}
+
+function validateSample(sample, index, directory) {
+    const label = `samples[${index}]`;
+    requireObject(sample, label);
+    requireString(sample.id, `${label}.id`);
+    if (!ID_PATTERN.test(sample.id)) {
+        throw new Error(
+            `${label}.id must use lowercase letters, numbers, dots, dashes, or underscores`
+        );
+    }
+    requireSha256(sample.imageSha256, `${label}.imageSha256`);
+    requireSha256(sample.transcriptionSha256, `${label}.transcriptionSha256`);
+    if (typeof sample.reviewed !== "boolean") {
+        throw new Error(`${label}.reviewed must be a boolean`);
+    }
+    requireObject(sample.source, `${label}.source`);
+    if (!["card-image", "synthetic"].includes(sample.source.kind)) {
+        throw new Error(`${label}.source.kind must be card-image or synthetic`);
+    }
+    requireString(sample.source.reference, `${label}.source.reference`);
+    requireString(sample.source.license, `${label}.source.license`);
+
+    const imagePath = resolveContainedPath(directory, sample.image, `${label}.image`);
+    const extension = path.extname(sample.image).toLowerCase();
+    if (!IMAGE_EXTENSIONS.includes(extension)) {
+        throw new Error(`${label}.image must be a .png or .tif line image`);
+    }
+    const expectedTranscription = `${sample.image.slice(0, -extension.length)}.gt.txt`;
+    if (sample.transcription !== expectedTranscription) {
+        throw new Error(
+            `${label}.transcription must replace the image extension with .gt.txt (${expectedTranscription})`
+        );
+    }
+    const transcriptionPath = resolveContainedPath(
+        directory,
+        sample.transcription,
+        `${label}.transcription`
+    );
+
+    return {
+        ...sample,
+        imageSha256: sample.imageSha256.toLowerCase(),
+        transcriptionSha256: sample.transcriptionSha256.toLowerCase(),
+        imagePath,
+        transcriptionPath
+    };
+}
+
+function validateTrainingDataManifest(rawManifest, manifestPath) {
+    requireObject(rawManifest, "training-data manifest");
+    if (rawManifest.version !== 1) {
+        throw new Error(`Unsupported training-data manifest version: ${rawManifest.version}`);
+    }
+    if (!["draft", "reviewed"].includes(rawManifest.status)) {
+        throw new Error("status must be draft or reviewed");
+    }
+    requireString(rawManifest.modelName, "modelName");
+    if (!ID_PATTERN.test(rawManifest.modelName)) {
+        throw new Error(
+            "modelName must use lowercase letters, numbers, dots, dashes, or underscores"
+        );
+    }
+    if (!Number.isSafeInteger(rawManifest.randomSeed) || rawManifest.randomSeed < 0) {
+        throw new Error("randomSeed must be a non-negative safe integer");
+    }
+    if (
+        typeof rawManifest.trainRatio !== "number" ||
+        rawManifest.trainRatio <= 0 ||
+        rawManifest.trainRatio >= 1
+    ) {
+        throw new Error("trainRatio must be a number greater than 0 and less than 1");
+    }
+    validateBaseModel(rawManifest.baseModel);
+    if (!Array.isArray(rawManifest.samples)) {
+        throw new Error("samples must be an array");
+    }
+
+    const absoluteManifestPath = path.resolve(manifestPath);
+    const directory = path.dirname(absoluteManifestPath);
+    const samples = rawManifest.samples.map((sample, index) =>
+        validateSample(sample, index, directory)
+    );
+    const ids = new Set();
+    samples.forEach((sample) => {
+        if (ids.has(sample.id)) {
+            throw new Error(`Duplicate training sample id: ${sample.id}`);
+        }
+        ids.add(sample.id);
+    });
+
+    return {
+        ...rawManifest,
+        path: absoluteManifestPath,
+        directory,
+        baseModel: {
+            ...rawManifest.baseModel,
+            sha256: rawManifest.baseModel.sha256.toLowerCase()
+        },
+        samples
+    };
+}
+
+function sha256Buffer(buffer) {
+    return createHash("sha256").update(buffer).digest("hex");
+}
+
+function containsControlCharacters(text) {
+    return Array.from(text).some((character) => {
+        const codePoint = character.charCodeAt(0);
+        return codePoint <= 31 || codePoint === 127;
+    });
+}
+
+async function readBoundedFile(filePath, maximumBytes, label) {
+    let fileStats;
+    try {
+        fileStats = await stat(filePath);
+    } catch (error) {
+        throw new Error(`${label} does not exist: ${filePath}`, { cause: error });
+    }
+    if (!fileStats.isFile()) {
+        throw new Error(`${label} is not a regular file: ${filePath}`);
+    }
+    if (fileStats.size === 0 || fileStats.size > maximumBytes) {
+        throw new Error(`${label} must be between 1 and ${maximumBytes} bytes`);
+    }
+    return readFile(filePath);
+}
+
+function parseTranscription(buffer, sampleId) {
+    const rawText = buffer.toString("utf8");
+    if (!Buffer.from(rawText, "utf8").equals(buffer)) {
+        throw new Error(`Training transcription ${sampleId} must be valid UTF-8`);
+    }
+    const text = rawText.endsWith("\n") ? rawText.slice(0, -1) : rawText;
+    if (
+        text.length === 0 ||
+        text.trim() !== text ||
+        text.includes("\n") ||
+        text.includes("\r") ||
+        containsControlCharacters(text)
+    ) {
+        throw new Error(
+            `Training transcription ${sampleId} must contain exactly one non-empty line`
+        );
+    }
+    if (text.normalize("NFC") !== text) {
+        throw new Error(`Training transcription ${sampleId} must use NFC Unicode normalization`);
+    }
+    return text;
+}
+
+async function verifySample(sample) {
+    const [image, transcription] = await Promise.all([
+        readBoundedFile(sample.imagePath, MAX_TRAINING_IMAGE_BYTES, `Training image ${sample.id}`),
+        readBoundedFile(
+            sample.transcriptionPath,
+            MAX_TRANSCRIPTION_BYTES,
+            `Training transcription ${sample.id}`
+        )
+    ]);
+    const actualImageSha256 = sha256Buffer(image);
+    if (actualImageSha256 !== sample.imageSha256) {
+        throw new Error(
+            `SHA-256 mismatch for training image ${sample.id}: expected ${sample.imageSha256}, received ${actualImageSha256}`
+        );
+    }
+    const actualTranscriptionSha256 = sha256Buffer(transcription);
+    if (actualTranscriptionSha256 !== sample.transcriptionSha256) {
+        throw new Error(
+            `SHA-256 mismatch for training transcription ${sample.id}: expected ${sample.transcriptionSha256}, received ${actualTranscriptionSha256}`
+        );
+    }
+    return { ...sample, text: parseTranscription(transcription, sample.id) };
+}
+
+async function loadTrainingDataManifest(manifestPath) {
+    const absolutePath = path.resolve(manifestPath);
+    let rawManifest;
+    try {
+        rawManifest = JSON.parse(await readFile(absolutePath, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to read training-data manifest ${absolutePath}: ${error.message}`, {
+            cause: error
+        });
+    }
+    const manifest = validateTrainingDataManifest(rawManifest, absolutePath);
+    const samples = await Promise.all(manifest.samples.map(verifySample));
+    return { ...manifest, samples };
+}
+
+function assertTrainingDataReady(manifest) {
+    if (manifest.status !== "reviewed") {
+        throw new Error("Training-data manifest status must be reviewed");
+    }
+    if (manifest.samples.some((sample) => sample.reviewed !== true)) {
+        throw new Error("Training-data manifest contains unreviewed samples");
+    }
+    if (manifest.samples.length < 2) {
+        throw new Error("Training-data manifest needs at least two samples");
+    }
+    const train = Math.floor(manifest.samples.length * manifest.trainRatio);
+    const evaluation = manifest.samples.length - train;
+    if (train < 1 || evaluation < 1) {
+        throw new Error(
+            "Training-data ratio must produce at least one train and evaluation sample"
+        );
+    }
+    return { total: manifest.samples.length, train, evaluation };
+}
+
+export {
+    MAX_TRAINING_IMAGE_BYTES,
+    MAX_TRANSCRIPTION_BYTES,
+    assertTrainingDataReady,
+    loadTrainingDataManifest,
+    validateTrainingDataManifest
+};

--- a/src/training/training-review-stager.mjs
+++ b/src/training/training-review-stager.mjs
@@ -16,6 +16,49 @@ function requireNonEmptyString(value, label) {
     }
 }
 
+function markdownText(value) {
+    return String(value)
+        .replace(/\r?\n/g, " ")
+        .replace(/\\/g, "\\\\")
+        .replace(/`/g, "\\`")
+        .replace(/\[/g, "\\[")
+        .replace(/\]/g, "\\]")
+        .trim();
+}
+
+function formatReviewSheet(report) {
+    const lines = [
+        "# OCR training review batch",
+        "",
+        `Status: ${report.status}`,
+        "",
+        `Rights/provenance basis: ${report.rightsBasis}`,
+        "",
+        "Nothing in this directory is approved training data until every applicable checkbox and decision is completed."
+    ];
+    report.samples.forEach((sample) => {
+        const transcription = markdownText(sample.transcription);
+        lines.push(
+            "",
+            `## ${transcription}`,
+            "",
+            `Source fixture: \`${sample.sourceCaseId}\``,
+            "",
+            `Expected transcription: \`${transcription}\``,
+            "",
+            `![${transcription}](./${sample.image})`,
+            "",
+            "- [ ] Crop contains the complete exact transcription",
+            "- [ ] Characters are legible and belong to a single text line",
+            "- [ ] Transcription matches capitalization and punctuation",
+            "- [ ] Rights/provenance basis is acceptable for this use",
+            "- Decision: `approve` / `reject`",
+            "- Review notes:"
+        );
+    });
+    return `${lines.join("\n")}\n`;
+}
+
 function selectCases(regressionManifest, caseIds) {
     if (!regressionManifest || !Array.isArray(regressionManifest.cases)) {
         throw new Error("A loaded regression manifest is required");
@@ -119,11 +162,17 @@ async function stageTrainingReviewBatch(regressionManifest, options) {
             rightsBasis,
             samples
         };
-        await writeFile(
-            path.join(absoluteOutput, "review-manifest.json"),
-            `${JSON.stringify(report, null, 2)}\n`,
-            { encoding: "utf8", flag: "wx" }
-        );
+        await Promise.all([
+            writeFile(
+                path.join(absoluteOutput, "review-manifest.json"),
+                `${JSON.stringify(report, null, 2)}\n`,
+                { encoding: "utf8", flag: "wx" }
+            ),
+            writeFile(path.join(absoluteOutput, "review.md"), formatReviewSheet(report), {
+                encoding: "utf8",
+                flag: "wx"
+            })
+        ]);
         return report;
     } catch (error) {
         await rm(absoluteOutput, { recursive: true, force: true });
@@ -131,4 +180,4 @@ async function stageTrainingReviewBatch(regressionManifest, options) {
     }
 }
 
-export { MAX_REVIEW_BATCH_CASES, selectCases, stageTrainingReviewBatch };
+export { MAX_REVIEW_BATCH_CASES, formatReviewSheet, selectCases, stageTrainingReviewBatch };

--- a/src/training/training-review-stager.mjs
+++ b/src/training/training-review-stager.mjs
@@ -1,0 +1,134 @@
+import { createHash } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { prepareOcrVariants } from "../image-processing/ocr-preprocessing.mjs";
+
+const MAX_REVIEW_BATCH_CASES = 50;
+const ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+
+function sha256(value) {
+    return createHash("sha256").update(value).digest("hex");
+}
+
+function requireNonEmptyString(value, label) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+        throw new Error(`${label} must be a non-empty string`);
+    }
+}
+
+function selectCases(regressionManifest, caseIds) {
+    if (!regressionManifest || !Array.isArray(regressionManifest.cases)) {
+        throw new Error("A loaded regression manifest is required");
+    }
+    if (!Array.isArray(caseIds) || caseIds.length === 0) {
+        throw new Error("At least one training review case is required");
+    }
+    if (caseIds.length > MAX_REVIEW_BATCH_CASES) {
+        throw new Error(`Training review batches are limited to ${MAX_REVIEW_BATCH_CASES} cases`);
+    }
+    if (new Set(caseIds).size !== caseIds.length) {
+        throw new Error("Training review case IDs must be unique");
+    }
+
+    const casesById = new Map(regressionManifest.cases.map((fixture) => [fixture.id, fixture]));
+    return caseIds.map((caseId) => {
+        const fixture = casesById.get(caseId);
+        if (!fixture) {
+            throw new Error(`Unknown regression fixture: ${caseId}`);
+        }
+        if (fixture.enabled !== false) {
+            throw new Error(
+                `${caseId} is enabled in the regression gate and cannot be training data`
+            );
+        }
+        if (!ID_PATTERN.test(fixture.id)) {
+            throw new Error(`${caseId} is not safe to use as a training review filename`);
+        }
+        const transcription = fixture.expected?.name;
+        requireNonEmptyString(transcription, `${caseId} expected name`);
+        if (transcription.includes("CHANGE_ME")) {
+            throw new Error(`${caseId} still has placeholder ground truth`);
+        }
+        if (transcription.includes("//")) {
+            throw new Error(
+                `${caseId} uses a compound card name; supply face-specific ground truth before staging`
+            );
+        }
+        return fixture;
+    });
+}
+
+async function stageTrainingReviewBatch(regressionManifest, options) {
+    const {
+        caseIds,
+        outputDirectory,
+        rightsBasis,
+        prepareOcrVariants: prepareVariants = prepareOcrVariants,
+        now = () => new Date()
+    } = options || {};
+    requireNonEmptyString(outputDirectory, "outputDirectory");
+    requireNonEmptyString(rightsBasis, "rightsBasis");
+    const fixtures = selectCases(regressionManifest, caseIds);
+    const absoluteOutput = path.resolve(outputDirectory);
+    await mkdir(path.dirname(absoluteOutput), { recursive: true });
+    await mkdir(absoluteOutput);
+
+    try {
+        const samples = [];
+        for (const fixture of fixtures) {
+            const prepared = await prepareVariants(fixture.imagePath, "name");
+            const variant = prepared.variants?.find(
+                (candidate) => candidate.region === "name-core"
+            );
+            if (
+                !variant?.buffer ||
+                !Buffer.isBuffer(variant.buffer) ||
+                variant.buffer.length === 0
+            ) {
+                throw new Error(`${fixture.id} did not produce a non-empty name-core crop`);
+            }
+
+            const transcription = fixture.expected.name;
+            const transcriptionBuffer = Buffer.from(transcription, "utf8");
+            const imageFile = `${fixture.id}.png`;
+            const transcriptionFile = `${fixture.id}.gt.txt`;
+            await Promise.all([
+                writeFile(path.join(absoluteOutput, imageFile), variant.buffer, { flag: "wx" }),
+                writeFile(path.join(absoluteOutput, transcriptionFile), transcriptionBuffer, {
+                    flag: "wx"
+                })
+            ]);
+            samples.push({
+                id: fixture.id,
+                image: imageFile,
+                transcriptionFile,
+                transcription,
+                imageSha256: sha256(variant.buffer),
+                transcriptionSha256: sha256(transcriptionBuffer),
+                sourceCaseId: fixture.id,
+                region: "name-core",
+                reviewed: false
+            });
+        }
+
+        const report = {
+            version: 1,
+            status: "unreviewed",
+            generatedAt: now().toISOString(),
+            sourceManifest: regressionManifest.path,
+            rightsBasis,
+            samples
+        };
+        await writeFile(
+            path.join(absoluteOutput, "review-manifest.json"),
+            `${JSON.stringify(report, null, 2)}\n`,
+            { encoding: "utf8", flag: "wx" }
+        );
+        return report;
+    } catch (error) {
+        await rm(absoluteOutput, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+export { MAX_REVIEW_BATCH_CASES, selectCases, stageTrainingReviewBatch };

--- a/test/regression/ocr-model-candidate.spec.mjs
+++ b/test/regression/ocr-model-candidate.spec.mjs
@@ -1,0 +1,143 @@
+import { assert } from "chai";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    loadOcrModelManifest,
+    validateOcrModelManifest
+} from "../../src/regression/ocr-model-candidate.mjs";
+
+function candidate(overrides = {}) {
+    return {
+        id: "bundled-eng-control",
+        model: "models/control/eng.traineddata",
+        family: "combined",
+        sha256: "a".repeat(64),
+        source: {
+            url: "https://github.com/dills122/MTG-Card-Analyzer",
+            revision: "dcc5d0e",
+            license: "Apache-2.0"
+        },
+        engine: {
+            package: "tesseract.js",
+            version: "3.0.3"
+        },
+        ...overrides
+    };
+}
+
+describe("OCR model candidate manifest::", () => {
+    let directory;
+
+    afterEach(async () => {
+        if (directory) {
+            await rm(directory, { recursive: true, force: true });
+            directory = undefined;
+        }
+    });
+
+    it("resolves a versioned candidate with explicit provenance", () => {
+        const manifestPath = "/fixtures/ocr-models/manifest.json";
+        const manifest = validateOcrModelManifest(
+            { version: 1, candidates: [candidate()] },
+            manifestPath
+        );
+
+        assert.equal(manifest.path, manifestPath);
+        assert.equal(manifest.candidates[0].id, "bundled-eng-control");
+        assert.equal(
+            manifest.candidates[0].modelPath,
+            "/fixtures/ocr-models/models/control/eng.traineddata"
+        );
+        assert.equal(manifest.candidates[0].languagePath, "/fixtures/ocr-models/models/control");
+        assert.equal(manifest.candidates[0].source.license, "Apache-2.0");
+        assert.equal(manifest.candidates[0].engine.version, "3.0.3");
+    });
+
+    it("tracks the reviewed bundled model as the immutable control candidate", async () => {
+        const manifestPath = fileURLToPath(new URL("./ocr-models/manifest.json", import.meta.url));
+
+        const manifest = await loadOcrModelManifest(manifestPath);
+
+        assert.equal(manifest.candidates.length, 1);
+        assert.include(manifest.candidates[0], {
+            id: "bundled-eng-control",
+            sha256: "7e084d31c8262ec2bacf90ac4288fde165c0c6db35fe7d2b8c8ff271b8876234",
+            sizeBytes: 21876572
+        });
+    });
+
+    it("rejects duplicate candidate IDs and non-English model filenames", () => {
+        assert.throws(
+            () =>
+                validateOcrModelManifest(
+                    { version: 1, candidates: [candidate(), candidate()] },
+                    "/fixtures/manifest.json"
+                ),
+            "Duplicate OCR model candidate id"
+        );
+        assert.throws(
+            () =>
+                validateOcrModelManifest(
+                    {
+                        version: 1,
+                        candidates: [candidate({ model: "models/control/custom.traineddata" })]
+                    },
+                    "/fixtures/manifest.json"
+                ),
+            "must be named eng.traineddata"
+        );
+    });
+
+    it("loads a candidate only when its bytes match the reviewed SHA-256", async () => {
+        directory = await mkdtemp(path.join(os.tmpdir(), "mtg-ocr-model-manifest-"));
+        const modelDirectory = path.join(directory, "models/control");
+        const modelPath = path.join(modelDirectory, "eng.traineddata");
+        const modelBytes = Buffer.from("reviewed OCR model bytes");
+        await mkdir(modelDirectory, { recursive: true });
+        await writeFile(modelPath, modelBytes);
+        const sha256 = createHash("sha256").update(modelBytes).digest("hex");
+        const manifestPath = path.join(directory, "manifest.json");
+        await writeFile(
+            manifestPath,
+            JSON.stringify({
+                version: 1,
+                candidates: [candidate({ model: "models/control/eng.traineddata", sha256 })]
+            })
+        );
+
+        const manifest = await loadOcrModelManifest(manifestPath);
+
+        assert.equal(manifest.candidates[0].sha256, sha256);
+        assert.equal(manifest.candidates[0].sizeBytes, modelBytes.length);
+    });
+
+    it("rejects model bytes that do not match the reviewed SHA-256", async () => {
+        directory = await mkdtemp(path.join(os.tmpdir(), "mtg-ocr-model-manifest-"));
+        const modelDirectory = path.join(directory, "models/control");
+        await mkdir(modelDirectory, { recursive: true });
+        await writeFile(path.join(modelDirectory, "eng.traineddata"), "unexpected bytes");
+        const manifestPath = path.join(directory, "manifest.json");
+        await writeFile(
+            manifestPath,
+            JSON.stringify({
+                version: 1,
+                candidates: [candidate({ model: "models/control/eng.traineddata" })]
+            })
+        );
+
+        let error;
+        try {
+            await loadOcrModelManifest(manifestPath);
+        } catch (caught) {
+            error = caught;
+        }
+        assert.instanceOf(error, Error);
+        assert.include(
+            error.message,
+            "SHA-256 mismatch for OCR model candidate bundled-eng-control"
+        );
+    });
+});

--- a/test/regression/ocr-model-comparison.spec.mjs
+++ b/test/regression/ocr-model-comparison.spec.mjs
@@ -1,0 +1,182 @@
+import { assert } from "chai";
+import {
+    compareOcrModelReports,
+    formatOcrModelComparison
+} from "../../src/regression/ocr-model-comparison.mjs";
+
+function createReport({
+    id,
+    family,
+    passed,
+    blockingPassed,
+    nonBlockingFailed,
+    meanRuntimeMs,
+    p95RuntimeMs,
+    sizeBytes,
+    results
+}) {
+    return {
+        schemaVersion: 1,
+        manifest: "/fixtures/manifest.json",
+        ocrModel: { id, family, sizeBytes, sha256: id.padEnd(64, "0") },
+        summary: {
+            total: results.length,
+            passed,
+            failed: results.length - passed,
+            passRate: (passed / results.length) * 100,
+            meanRuntimeMs,
+            p95RuntimeMs,
+            totalRuntimeMs: meanRuntimeMs * results.length
+        },
+        gate: {
+            total: results.filter((result) => result.blocking).length,
+            passed: blockingPassed,
+            failed: results.filter((result) => result.blocking).length - blockingPassed,
+            nonBlocking: results.filter((result) => !result.blocking).length,
+            nonBlockingFailed
+        },
+        results
+    };
+}
+
+const fixture = (id, { passed, blocking = true, text, confidence = 80, failures = [] }) => ({
+    id,
+    blocking,
+    expected: { name: id },
+    ocr: { cleanText: text, confidence },
+    runtimeMs: 100,
+    passed,
+    failures
+});
+
+describe("OCR model comparison", () => {
+    it("reports candidate metric deltas, improvements, and blocking regressions", () => {
+        const control = createReport({
+            id: "control",
+            family: "bundled",
+            passed: 2,
+            blockingPassed: 1,
+            nonBlockingFailed: 1,
+            meanRuntimeMs: 100,
+            p95RuntimeMs: 140,
+            sizeBytes: 20,
+            results: [
+                fixture("stable", { passed: true, text: "STABLE" }),
+                fixture("improved", { passed: false, blocking: false, text: "WRONG" }),
+                fixture("regressed", { passed: true, text: "REGRESSED" })
+            ]
+        });
+        const candidate = createReport({
+            id: "candidate",
+            family: "best",
+            passed: 2,
+            blockingPassed: 1,
+            nonBlockingFailed: 0,
+            meanRuntimeMs: 125,
+            p95RuntimeMs: 180,
+            sizeBytes: 15,
+            results: [
+                fixture("stable", { passed: true, text: "STABLE" }),
+                fixture("improved", {
+                    passed: true,
+                    blocking: false,
+                    text: "IMPROVED",
+                    confidence: 90
+                }),
+                fixture("regressed", {
+                    passed: false,
+                    text: "BROKEN",
+                    confidence: 40,
+                    failures: ["name mismatch"]
+                })
+            ]
+        });
+
+        const comparison = compareOcrModelReports(control, [candidate]);
+        const result = comparison.candidates[0];
+
+        assert.equal(result.model.id, "candidate");
+        assert.equal(result.metrics.passedDelta, 0);
+        assert.equal(result.metrics.meanRuntimeMsDelta, 25);
+        assert.equal(result.metrics.p95RuntimeMsDelta, 40);
+        assert.equal(result.metrics.sizeBytesDelta, -5);
+        assert.deepEqual(
+            result.changes.improvements.map((change) => change.id),
+            ["improved"]
+        );
+        assert.deepEqual(
+            result.changes.regressions.map((change) => change.id),
+            ["regressed"]
+        );
+        assert.deepEqual(
+            result.changes.blockingRegressions.map((change) => change.id),
+            ["regressed"]
+        );
+        assert.isFalse(result.gatePassed);
+    });
+
+    it("rejects comparisons that do not use the same fixture IDs", () => {
+        const control = createReport({
+            id: "control",
+            family: "bundled",
+            passed: 1,
+            blockingPassed: 1,
+            nonBlockingFailed: 0,
+            meanRuntimeMs: 100,
+            p95RuntimeMs: 100,
+            sizeBytes: 20,
+            results: [fixture("one", { passed: true, text: "ONE" })]
+        });
+        const candidate = createReport({
+            id: "candidate",
+            family: "best",
+            passed: 1,
+            blockingPassed: 1,
+            nonBlockingFailed: 0,
+            meanRuntimeMs: 100,
+            p95RuntimeMs: 100,
+            sizeBytes: 15,
+            results: [fixture("different", { passed: true, text: "DIFFERENT" })]
+        });
+
+        assert.throws(
+            () => compareOcrModelReports(control, [candidate]),
+            "candidate fixture IDs do not match control"
+        );
+    });
+
+    it("formats a compact Markdown decision report", () => {
+        const control = createReport({
+            id: "control",
+            family: "bundled",
+            passed: 1,
+            blockingPassed: 1,
+            nonBlockingFailed: 0,
+            meanRuntimeMs: 100,
+            p95RuntimeMs: 100,
+            sizeBytes: 20,
+            results: [fixture("fixture", { passed: true, text: "FIXTURE" })]
+        });
+        const candidate = createReport({
+            id: "candidate",
+            family: "best",
+            passed: 0,
+            blockingPassed: 0,
+            nonBlockingFailed: 0,
+            meanRuntimeMs: 120,
+            p95RuntimeMs: 120,
+            sizeBytes: 15,
+            results: [fixture("fixture", { passed: false, text: "BROKEN", failures: ["no match"] })]
+        });
+
+        const markdown = formatOcrModelComparison(compareOcrModelReports(control, [candidate]));
+
+        assert.include(markdown, "# OCR model regression comparison");
+        assert.include(markdown, "| candidate | best | 0/1 | 0/1 | FAIL | 120 ms (+20 ms)");
+        assert.include(markdown, "## candidate fixture changes");
+        assert.include(
+            markdown,
+            "| fixture | blocking | regression | FIXTURE | BROKEN | no match |"
+        );
+    });
+});

--- a/test/regression/ocr-models/manifest.json
+++ b/test/regression/ocr-models/manifest.json
@@ -1,0 +1,20 @@
+{
+    "version": 1,
+    "candidates": [
+        {
+            "id": "bundled-eng-control",
+            "model": "../../../eng.traineddata",
+            "family": "project-bundled-control",
+            "sha256": "7e084d31c8262ec2bacf90ac4288fde165c0c6db35fe7d2b8c8ff271b8876234",
+            "source": {
+                "url": "https://github.com/dills122/MTG-Card-Analyzer",
+                "revision": "dcc5d0e",
+                "license": "Apache-2.0"
+            },
+            "engine": {
+                "package": "tesseract.js",
+                "version": "3.0.3"
+            }
+        }
+    ]
+}

--- a/test/regression/regression-runner.spec.mjs
+++ b/test/regression/regression-runner.spec.mjs
@@ -283,9 +283,25 @@ describe("Regression framework::", () => {
             }
         };
         const receivedSessions = [];
+        let receivedSessionOptions;
         let createSessionCalls = 0;
+        const ocrModel = {
+            id: "official-eng-fast",
+            family: "tessdata_fast",
+            sha256: "b".repeat(64),
+            sizeBytes: 4_113_088,
+            modelPath: "/fixtures/models/fast/eng.traineddata",
+            languagePath: "/fixtures/models/fast",
+            source: {
+                url: "https://github.com/tesseract-ocr/tessdata_fast",
+                revision: "reviewed-ref",
+                license: "Apache-2.0"
+            },
+            engine: { package: "tesseract.js", version: "3.0.3" }
+        };
 
         const report = await runRegression(manifest, {
+            ocrModel,
             dependencies: {
                 ImageProcessor: {
                     create: ({ ocrOptions }) => {
@@ -311,8 +327,9 @@ describe("Regression framework::", () => {
                     })
                 },
                 materializeFixture: async (fixture) => fixture.imagePath,
-                createOcrSession: async () => {
+                createOcrSession: async (options) => {
                     createSessionCalls += 1;
+                    receivedSessionOptions = options;
                     return ocrSession;
                 }
             }
@@ -320,8 +337,22 @@ describe("Regression framework::", () => {
 
         assert.equal(report.summary.passed, 2);
         assert.equal(createSessionCalls, 1);
+        assert.include(receivedSessionOptions, {
+            cacheMethod: "none",
+            langPath: "/fixtures/models/fast",
+            gzip: false
+        });
         assert.deepEqual(receivedSessions, [ocrSession, ocrSession]);
         assert.equal(ocrSession.terminateCalls, 1);
+        assert.deepEqual(report.ocrModel, {
+            id: "official-eng-fast",
+            family: "tessdata_fast",
+            sha256: "b".repeat(64),
+            sizeBytes: 4_113_088,
+            source: ocrModel.source,
+            engine: ocrModel.engine
+        });
+        assert.equal(report.isolation.ocrLanguageSource, "OCR candidate official-eng-fast");
         assert.equal(
             report.isolation.ocrWorkerLifecycle,
             "shared process; adaptive state reset per crop"
@@ -367,6 +398,12 @@ describe("Regression framework::", () => {
             generatedAt: "2026-08-07T00:00:00.000Z",
             manifest: "/fixtures/manifest.json",
             offline: true,
+            ocrModel: {
+                id: "official-eng-fast",
+                family: "tessdata_fast",
+                sha256: "b".repeat(64),
+                sizeBytes: 4_113_088
+            },
             isolation: {
                 applicationPersistence: "disabled",
                 imageHashCache: "disabled",
@@ -389,6 +426,9 @@ describe("Regression framework::", () => {
         assert.include(markdown, "CI gate: PASS");
         assert.include(markdown, "NON-BLOCKING FAIL");
         assert.include(markdown, "image-hash cache disabled");
+        assert.include(markdown, "official-eng-fast");
+        assert.include(markdown, "tessdata_fast");
+        assert.include(markdown, `${"b".repeat(12)}…`);
         assert.include(markdown, "20 ms");
     });
 });

--- a/test/scripts/compare-ocr-models.spec.mjs
+++ b/test/scripts/compare-ocr-models.spec.mjs
@@ -1,0 +1,74 @@
+import { assert } from "chai";
+import { buildProgram, main } from "../../scripts/compare-ocr-models.mjs";
+
+describe("compare-ocr-models CLI::", () => {
+    it("parses one control and repeated candidate report paths", () => {
+        const options = buildProgram()
+            .parse([
+                "node",
+                "compare-ocr-models.mjs",
+                "--control",
+                "/reports/control.json",
+                "--candidate",
+                "/reports/fast.json",
+                "--candidate",
+                "/reports/best.json",
+                "--output",
+                "/reports/comparison"
+            ])
+            .opts();
+
+        assert.equal(options.control, "/reports/control.json");
+        assert.deepEqual(options.candidate, ["/reports/fast.json", "/reports/best.json"]);
+        assert.equal(options.output, "/reports/comparison");
+    });
+
+    it("loads, compares, and writes the selected reports", async () => {
+        const loadedPaths = [];
+        const written = [];
+        const lines = [];
+        const control = { ocrModel: { id: "control" } };
+        const candidate = { ocrModel: { id: "best" } };
+        const comparison = { schemaVersion: 1 };
+
+        const result = await main(
+            [
+                "node",
+                "compare-ocr-models.mjs",
+                "--control",
+                "/reports/control.json",
+                "--candidate",
+                "/reports/best.json",
+                "--output",
+                "/reports/comparison"
+            ],
+            {
+                readReport: async (reportPath) => {
+                    loadedPaths.push(reportPath);
+                    return reportPath.includes("control") ? control : candidate;
+                },
+                compareOcrModelReports: (receivedControl, receivedCandidates) => {
+                    assert.strictEqual(receivedControl, control);
+                    assert.deepEqual(receivedCandidates, [candidate]);
+                    return comparison;
+                },
+                writeOcrModelComparison: async (receivedComparison, outputDirectory) => {
+                    written.push({ receivedComparison, outputDirectory });
+                    return {
+                        markdownPath: "/reports/comparison/comparison.md",
+                        jsonPath: "/reports/comparison/comparison.json"
+                    };
+                },
+                writeLine: (line) => lines.push(line)
+            }
+        );
+
+        assert.strictEqual(result, comparison);
+        assert.deepEqual(loadedPaths, ["/reports/control.json", "/reports/best.json"]);
+        assert.deepEqual(written, [
+            { receivedComparison: comparison, outputDirectory: "/reports/comparison" }
+        ]);
+        assert.include(lines, "Markdown: /reports/comparison/comparison.md");
+        assert.include(lines, "JSON: /reports/comparison/comparison.json");
+    });
+});

--- a/test/scripts/run-regression.spec.mjs
+++ b/test/scripts/run-regression.spec.mjs
@@ -1,0 +1,83 @@
+import { assert } from "chai";
+import { buildProgram, main } from "../../scripts/run-regression.mjs";
+
+describe("run-regression CLI::", () => {
+    it("parses an explicit OCR candidate manifest and candidate ID", () => {
+        const options = buildProgram()
+            .parse([
+                "node",
+                "run-regression.mjs",
+                "--ocr-model-manifest",
+                "/fixtures/models.json",
+                "--ocr-model",
+                "official-eng-fast"
+            ])
+            .opts();
+
+        assert.equal(options.ocrModelManifest, "/fixtures/models.json");
+        assert.equal(options.ocrModel, "official-eng-fast");
+    });
+
+    it("runs the regression with the selected, verified OCR candidate", async () => {
+        const selectedCandidate = {
+            id: "official-eng-fast",
+            languagePath: "/fixtures/fast",
+            sha256: "b".repeat(64)
+        };
+        let receivedOptions;
+        const lines = [];
+        const report = {
+            summary: { passed: 1, total: 1, passRate: 100 },
+            gate: { passed: 1, total: 1, failed: 0, nonBlocking: 0, nonBlockingFailed: 0 },
+            pending: { cases: 0, placeholderCases: 0 }
+        };
+
+        const result = await main(
+            [
+                "node",
+                "run-regression.mjs",
+                "--ocr-model-manifest",
+                "/fixtures/models.json",
+                "--ocr-model",
+                "official-eng-fast"
+            ],
+            {
+                loadManifest: async () => ({ path: "/fixtures/regression.json" }),
+                loadOcrModelManifest: async () => ({ candidates: [selectedCandidate] }),
+                runRegression: async (_manifest, options) => {
+                    receivedOptions = options;
+                    return report;
+                },
+                writeBenchmarkReport: async () => ({
+                    markdownPath: "/reports/benchmark.md",
+                    jsonPath: "/reports/benchmark.json"
+                }),
+                writeLine: (line) => lines.push(line)
+            }
+        );
+
+        assert.strictEqual(result, report);
+        assert.strictEqual(receivedOptions.ocrModel, selectedCandidate);
+        assert.include(lines, "OCR model: official-eng-fast");
+    });
+
+    it("rejects an OCR candidate ID that is not in the verified manifest", async () => {
+        let error;
+        try {
+            await main(["node", "run-regression.mjs", "--ocr-model", "missing-model"], {
+                loadManifest: async () => ({ path: "/fixtures/regression.json" }),
+                loadOcrModelManifest: async () => ({
+                    candidates: [{ id: "missing-model", enabled: false }]
+                }),
+                runRegression: async () => {
+                    throw new Error("disabled candidate must not run");
+                }
+            });
+        } catch (caught) {
+            error = caught;
+        }
+
+        assert.instanceOf(error, Error);
+        assert.include(error.message, "Unknown OCR model candidate: missing-model");
+    });
+});

--- a/test/scripts/stage-ocr-training-review.spec.mjs
+++ b/test/scripts/stage-ocr-training-review.spec.mjs
@@ -1,0 +1,66 @@
+import { assert } from "chai";
+import { buildProgram, main } from "../../scripts/stage-ocr-training-review.mjs";
+
+describe("stage-ocr-training-review CLI::", () => {
+    it("parses a bounded batch and repeated disabled fixture IDs", () => {
+        const options = buildProgram()
+            .parse([
+                "node",
+                "stage-ocr-training-review.mjs",
+                "--batch",
+                "batch-001",
+                "--case",
+                "candidate-one",
+                "--case",
+                "candidate-two",
+                "--output-root",
+                "/review"
+            ])
+            .opts();
+
+        assert.equal(options.batch, "batch-001");
+        assert.deepEqual(options.case, ["candidate-one", "candidate-two"]);
+        assert.equal(options.outputRoot, "/review");
+    });
+
+    it("loads the regression manifest and stages the requested review batch", async () => {
+        const regressionManifest = { path: "/fixtures/manifest.json" };
+        const report = { status: "unreviewed", samples: [{ id: "candidate-one" }] };
+        const lines = [];
+        let stagingInput;
+
+        const result = await main(
+            [
+                "node",
+                "stage-ocr-training-review.mjs",
+                "--batch",
+                "batch-001",
+                "--case",
+                "candidate-one",
+                "--manifest",
+                "/fixtures/manifest.json",
+                "--output-root",
+                "/review"
+            ],
+            {
+                loadManifest: async (manifestPath) => {
+                    assert.equal(manifestPath, "/fixtures/manifest.json");
+                    return regressionManifest;
+                },
+                stageTrainingReviewBatch: async (receivedManifest, options) => {
+                    stagingInput = { receivedManifest, options };
+                    return report;
+                },
+                writeLine: (line) => lines.push(line)
+            }
+        );
+
+        assert.strictEqual(result, report);
+        assert.strictEqual(stagingInput.receivedManifest, regressionManifest);
+        assert.deepEqual(stagingInput.options.caseIds, ["candidate-one"]);
+        assert.equal(stagingInput.options.outputDirectory, "/review/batch-001");
+        assert.include(stagingInput.options.rightsBasis, "Wizards Fan Content Policy");
+        assert.include(lines, "Training review batch: 1 unreviewed sample(s)");
+        assert.include(lines, "Review directory: /review/batch-001");
+    });
+});

--- a/test/scripts/validate-ocr-training-data.spec.mjs
+++ b/test/scripts/validate-ocr-training-data.spec.mjs
@@ -1,0 +1,57 @@
+import { assert } from "chai";
+import { buildProgram, main } from "../../scripts/validate-ocr-training-data.mjs";
+
+describe("validate-ocr-training-data CLI::", () => {
+    it("parses an explicit manifest and readiness gate", () => {
+        const options = buildProgram()
+            .parse([
+                "node",
+                "validate-ocr-training-data.mjs",
+                "--manifest",
+                "/training/manifest.json",
+                "--require-ready"
+            ])
+            .opts();
+
+        assert.equal(options.manifest, "/training/manifest.json");
+        assert.isTrue(options.requireReady);
+    });
+
+    it("verifies the manifest and reports deterministic split counts", async () => {
+        const manifest = {
+            status: "reviewed",
+            modelName: "eng_mtg",
+            baseModel: { id: "official-eng-best" },
+            samples: [{ id: "one" }, { id: "two" }]
+        };
+        const lines = [];
+        let readinessInput;
+
+        const result = await main(
+            [
+                "node",
+                "validate-ocr-training-data.mjs",
+                "--manifest",
+                "/training/manifest.json",
+                "--require-ready"
+            ],
+            {
+                loadTrainingDataManifest: async (manifestPath) => {
+                    assert.equal(manifestPath, "/training/manifest.json");
+                    return manifest;
+                },
+                assertTrainingDataReady: (receivedManifest) => {
+                    readinessInput = receivedManifest;
+                    return { total: 2, train: 1, evaluation: 1 };
+                },
+                writeLine: (line) => lines.push(line)
+            }
+        );
+
+        assert.strictEqual(result, manifest);
+        assert.strictEqual(readinessInput, manifest);
+        assert.include(lines, "Training data: 2 verified sample(s); status reviewed");
+        assert.include(lines, "Deterministic split: 1 train / 1 evaluation");
+        assert.include(lines, "Base model: official-eng-best");
+    });
+});

--- a/test/training/training-data-manifest.spec.mjs
+++ b/test/training/training-data-manifest.spec.mjs
@@ -1,0 +1,390 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { rejects } from "node:assert/strict";
+import { assert } from "chai";
+import {
+    assertTrainingDataReady,
+    loadTrainingDataManifest,
+    validateTrainingDataManifest
+} from "../../src/training/training-data-manifest.mjs";
+
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+
+function baseManifest(overrides = {}) {
+    return {
+        version: 1,
+        status: "draft",
+        modelName: "eng_mtg",
+        randomSeed: 20260808,
+        trainRatio: 0.9,
+        baseModel: {
+            id: "official-eng-best",
+            family: "tessdata_best",
+            sha256: "8".repeat(64),
+            source: {
+                url: "https://github.com/tesseract-ocr/tessdata_best",
+                revision: "e12c65a915945e4c28e237a9b52bc4a8f39a0cec",
+                license: "Apache-2.0"
+            }
+        },
+        samples: [],
+        ...overrides
+    };
+}
+
+function validSample(id = "sample") {
+    return {
+        id,
+        image: `${id}.png`,
+        transcription: `${id}.gt.txt`,
+        imageSha256: "1".repeat(64),
+        transcriptionSha256: "2".repeat(64),
+        reviewed: true,
+        source: {
+            kind: "card-image",
+            reference: `fixture:${id}`,
+            license: "fixture-reviewed"
+        }
+    };
+}
+
+describe("OCR training-data manifest", () => {
+    it("accepts an empty draft with a pinned tessdata_best base", () => {
+        const manifestPath = "/repo/training/ocr/manifest.json";
+
+        const manifest = validateTrainingDataManifest(baseManifest(), manifestPath);
+
+        assert.equal(manifest.path, manifestPath);
+        assert.equal(manifest.baseModel.family, "tessdata_best");
+        assert.deepEqual(manifest.samples, []);
+    });
+
+    it("loads reviewed single-line image/transcription pairs and verifies their hashes", async () => {
+        const directory = await mkdtemp(path.join(os.tmpdir(), "mtg-training-data-"));
+        try {
+            const image = Buffer.from("fake png bytes");
+            const firstText = "Sarkhan Unbroken";
+            const secondText = "Yavimaya Coast";
+            await writeFile(path.join(directory, "sarkhan.png"), image);
+            await writeFile(path.join(directory, "sarkhan.gt.txt"), firstText);
+            await writeFile(path.join(directory, "yavimaya.png"), image);
+            await writeFile(path.join(directory, "yavimaya.gt.txt"), secondText);
+            const manifestPath = path.join(directory, "manifest.json");
+            const sample = (id, text) => ({
+                id,
+                image: `${id}.png`,
+                transcription: `${id}.gt.txt`,
+                imageSha256: sha256(image),
+                transcriptionSha256: sha256(text),
+                reviewed: true,
+                source: {
+                    kind: "card-image",
+                    reference: `fixture:${id}`,
+                    license: "fixture-reviewed"
+                }
+            });
+            await writeFile(
+                manifestPath,
+                JSON.stringify(
+                    baseManifest({
+                        status: "reviewed",
+                        samples: [sample("sarkhan", firstText), sample("yavimaya", secondText)]
+                    })
+                )
+            );
+
+            const manifest = await loadTrainingDataManifest(manifestPath);
+            const readiness = assertTrainingDataReady(manifest);
+
+            assert.equal(manifest.samples[0].text, firstText);
+            assert.equal(manifest.samples[1].text, secondText);
+            assert.deepEqual(readiness, { total: 2, train: 1, evaluation: 1 });
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects a transcription that is not single-line plain text", async () => {
+        const directory = await mkdtemp(path.join(os.tmpdir(), "mtg-training-data-"));
+        try {
+            const image = Buffer.from("fake png bytes");
+            const text = "Sarkhan\nUnbroken";
+            await writeFile(path.join(directory, "sarkhan.png"), image);
+            await writeFile(path.join(directory, "sarkhan.gt.txt"), text);
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeFile(
+                manifestPath,
+                JSON.stringify(
+                    baseManifest({
+                        samples: [
+                            {
+                                id: "sarkhan",
+                                image: "sarkhan.png",
+                                transcription: "sarkhan.gt.txt",
+                                imageSha256: sha256(image),
+                                transcriptionSha256: sha256(text),
+                                reviewed: true,
+                                source: {
+                                    kind: "card-image",
+                                    reference: "fixture:sarkhan",
+                                    license: "fixture-reviewed"
+                                }
+                            }
+                        ]
+                    })
+                )
+            );
+
+            await rejects(
+                loadTrainingDataManifest(manifestPath),
+                /must contain exactly one non-empty line/
+            );
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects checksum drift and paths outside the manifest directory", async () => {
+        const directory = await mkdtemp(path.join(os.tmpdir(), "mtg-training-data-"));
+        try {
+            const image = Buffer.from("fake png bytes");
+            const text = "Pacifism";
+            await writeFile(path.join(directory, "pacifism.png"), image);
+            await writeFile(path.join(directory, "pacifism.gt.txt"), text);
+            const sample = {
+                id: "pacifism",
+                image: "pacifism.png",
+                transcription: "pacifism.gt.txt",
+                imageSha256: "0".repeat(64),
+                transcriptionSha256: sha256(text),
+                reviewed: true,
+                source: {
+                    kind: "card-image",
+                    reference: "fixture:pacifism",
+                    license: "fixture-reviewed"
+                }
+            };
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeFile(manifestPath, JSON.stringify(baseManifest({ samples: [sample] })));
+
+            await rejects(
+                loadTrainingDataManifest(manifestPath),
+                /SHA-256 mismatch for training image pacifism/
+            );
+            assert.throws(
+                () =>
+                    validateTrainingDataManifest(
+                        baseManifest({
+                            samples: [
+                                {
+                                    ...sample,
+                                    image: "../outside.png",
+                                    transcription: "../outside.gt.txt"
+                                }
+                            ]
+                        }),
+                        manifestPath
+                    ),
+                "must stay inside the manifest directory"
+            );
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects malformed training metadata before reading sample files", () => {
+        const manifestPath = "/repo/training/ocr/manifest.json";
+        const baseModel = baseManifest().baseModel;
+        const cases = [
+            [baseManifest({ status: "ready" }), "status must be draft or reviewed"],
+            [baseManifest({ modelName: "Bad Name" }), "modelName must use lowercase"],
+            [baseManifest({ randomSeed: -1 }), "randomSeed must be a non-negative safe integer"],
+            [
+                baseManifest({ trainRatio: 1 }),
+                "trainRatio must be a number greater than 0 and less than 1"
+            ],
+            [
+                baseManifest({ baseModel: { ...baseModel, family: "tessdata_fast" } }),
+                "baseModel.family must be tessdata_best"
+            ],
+            [
+                baseManifest({
+                    baseModel: {
+                        ...baseModel,
+                        source: { ...baseModel.source, url: "http://example.com/model" }
+                    }
+                }),
+                "baseModel.source.url must use HTTPS"
+            ],
+            [
+                baseManifest({ samples: [{ ...validSample(), id: "Bad Sample" }] }),
+                "samples[0].id must use lowercase"
+            ],
+            [
+                baseManifest({ samples: [{ ...validSample(), reviewed: "yes" }] }),
+                "samples[0].reviewed must be a boolean"
+            ],
+            [
+                baseManifest({
+                    samples: [
+                        {
+                            ...validSample(),
+                            source: { ...validSample().source, kind: "unknown" }
+                        }
+                    ]
+                }),
+                "samples[0].source.kind must be card-image or synthetic"
+            ],
+            [
+                baseManifest({
+                    samples: [
+                        {
+                            ...validSample(),
+                            image: "sample.jpg",
+                            transcription: "sample.gt.txt"
+                        }
+                    ]
+                }),
+                "samples[0].image must be a .png or .tif"
+            ],
+            [
+                baseManifest({
+                    samples: [{ ...validSample(), transcription: "different.gt.txt" }]
+                }),
+                "samples[0].transcription must replace the image extension"
+            ],
+            [
+                baseManifest({ samples: [validSample(), validSample()] }),
+                "Duplicate training sample id: sample"
+            ]
+        ];
+
+        cases.forEach(([manifest, message]) => {
+            assert.throws(() => validateTrainingDataManifest(manifest, manifestPath), message);
+        });
+    });
+
+    it("rejects missing files and transcription checksum drift", async () => {
+        const directory = await mkdtemp(path.join(os.tmpdir(), "mtg-training-data-"));
+        try {
+            const manifestPath = path.join(directory, "manifest.json");
+            await writeFile(path.join(directory, "missing.gt.txt"), "Missing");
+            await writeFile(
+                manifestPath,
+                JSON.stringify(baseManifest({ samples: [validSample("missing")] }))
+            );
+            await rejects(
+                loadTrainingDataManifest(manifestPath),
+                /Training image missing does not exist/
+            );
+
+            const image = Buffer.from("fake png bytes");
+            const text = "Pacifism";
+            await writeFile(path.join(directory, "pacifism.png"), image);
+            await writeFile(path.join(directory, "pacifism.gt.txt"), text);
+            await writeFile(
+                manifestPath,
+                JSON.stringify(
+                    baseManifest({
+                        samples: [
+                            {
+                                ...validSample("pacifism"),
+                                imageSha256: sha256(image),
+                                transcriptionSha256: "0".repeat(64)
+                            }
+                        ]
+                    })
+                )
+            );
+
+            await rejects(
+                loadTrainingDataManifest(manifestPath),
+                /SHA-256 mismatch for training transcription pacifism/
+            );
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects invalid UTF-8 and non-NFC transcriptions", async () => {
+        const directory = await mkdtemp(path.join(os.tmpdir(), "mtg-training-data-"));
+        try {
+            const image = Buffer.from("fake png bytes");
+            const manifestPath = path.join(directory, "manifest.json");
+            const writeCase = async (id, transcription) => {
+                await writeFile(path.join(directory, `${id}.png`), image);
+                await writeFile(path.join(directory, `${id}.gt.txt`), transcription);
+                await writeFile(
+                    manifestPath,
+                    JSON.stringify(
+                        baseManifest({
+                            samples: [
+                                {
+                                    ...validSample(id),
+                                    imageSha256: sha256(image),
+                                    transcriptionSha256: sha256(transcription)
+                                }
+                            ]
+                        })
+                    )
+                );
+            };
+
+            await writeCase("invalid-utf8", Buffer.from([0xc3, 0x28]));
+            await rejects(loadTrainingDataManifest(manifestPath), /must be valid UTF-8/);
+
+            await writeCase("non-nfc", "Cafe\u0301");
+            await rejects(
+                loadTrainingDataManifest(manifestPath),
+                /must use NFC Unicode normalization/
+            );
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("does not mark drafts or unreviewed samples as training-ready", () => {
+        const manifestPath = "/repo/training/ocr/manifest.json";
+        const draft = validateTrainingDataManifest(baseManifest(), manifestPath);
+        const unreviewed = validateTrainingDataManifest(
+            baseManifest({
+                status: "reviewed",
+                samples: [
+                    {
+                        id: "sample",
+                        image: "sample.png",
+                        transcription: "sample.gt.txt",
+                        imageSha256: "1".repeat(64),
+                        transcriptionSha256: "2".repeat(64),
+                        reviewed: false,
+                        source: {
+                            kind: "card-image",
+                            reference: "fixture:sample",
+                            license: "fixture-reviewed"
+                        }
+                    }
+                ]
+            }),
+            manifestPath
+        );
+
+        assert.throws(() => assertTrainingDataReady(draft), "status must be reviewed");
+        assert.throws(() => assertTrainingDataReady(unreviewed), "contains unreviewed samples");
+        assert.throws(
+            () =>
+                assertTrainingDataReady(
+                    validateTrainingDataManifest(
+                        baseManifest({
+                            status: "reviewed",
+                            trainRatio: 0.1,
+                            samples: [validSample("one"), validSample("two")]
+                        }),
+                        manifestPath
+                    )
+                ),
+            "ratio must produce at least one train and evaluation sample"
+        );
+    });
+});

--- a/test/training/training-review-stager.spec.mjs
+++ b/test/training/training-review-stager.spec.mjs
@@ -1,0 +1,114 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { rejects } from "node:assert/strict";
+import { assert } from "chai";
+import { stageTrainingReviewBatch } from "../../src/training/training-review-stager.mjs";
+
+function regressionManifest() {
+    return {
+        path: "/fixtures/manifest.json",
+        cases: [
+            {
+                id: "candidate-one",
+                enabled: false,
+                imagePath: "/fixtures/one.jpg",
+                expected: { name: "Candidate One" }
+            },
+            {
+                id: "candidate-two",
+                enabled: false,
+                imagePath: "/fixtures/two.jpg",
+                expected: { name: "Candidate Two" }
+            },
+            {
+                id: "blocking-fixture",
+                imagePath: "/fixtures/blocking.jpg",
+                expected: { name: "Blocking Fixture" }
+            },
+            {
+                id: "compound-fixture",
+                enabled: false,
+                imagePath: "/fixtures/compound.jpg",
+                expected: { name: "Front // Back" }
+            }
+        ]
+    };
+}
+
+describe("OCR training review stager", () => {
+    it("writes unreviewed name-core pairs and a provenance report", async () => {
+        const parent = await mkdtemp(path.join(os.tmpdir(), "mtg-training-review-"));
+        const outputDirectory = path.join(parent, "batch-001");
+        try {
+            const preparedSources = [];
+            const report = await stageTrainingReviewBatch(regressionManifest(), {
+                caseIds: ["candidate-one", "candidate-two"],
+                outputDirectory,
+                rightsBasis: "Wizards Fan Content Policy; review-only local artifact",
+                prepareOcrVariants: async (sourcePath) => {
+                    preparedSources.push(sourcePath);
+                    return {
+                        variants: [
+                            { region: "name-wide", buffer: Buffer.from("wide") },
+                            { region: "name-core", buffer: Buffer.from(`core:${sourcePath}`) }
+                        ]
+                    };
+                }
+            });
+
+            assert.deepEqual(preparedSources, ["/fixtures/one.jpg", "/fixtures/two.jpg"]);
+            assert.equal(report.status, "unreviewed");
+            assert.equal(report.samples.length, 2);
+            assert.deepInclude(report.samples[0], {
+                id: "candidate-one",
+                transcription: "Candidate One",
+                sourceCaseId: "candidate-one",
+                region: "name-core",
+                reviewed: false
+            });
+            assert.equal(
+                await readFile(path.join(outputDirectory, "candidate-one.gt.txt"), "utf8"),
+                "Candidate One"
+            );
+            assert.equal(
+                await readFile(path.join(outputDirectory, "candidate-one.png"), "utf8"),
+                "core:/fixtures/one.jpg"
+            );
+            const writtenReport = JSON.parse(
+                await readFile(path.join(outputDirectory, "review-manifest.json"), "utf8")
+            );
+            assert.equal(writtenReport.samples[1].sourceCaseId, "candidate-two");
+            assert.match(writtenReport.samples[0].imageSha256, /^[a-f0-9]{64}$/);
+            assert.match(writtenReport.samples[0].transcriptionSha256, /^[a-f0-9]{64}$/);
+        } finally {
+            await rm(parent, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects enabled regression fixtures to prevent evaluation leakage", async () => {
+        const outputDirectory = path.join(os.tmpdir(), "must-not-be-created");
+
+        await rejects(
+            stageTrainingReviewBatch(regressionManifest(), {
+                caseIds: ["blocking-fixture"],
+                outputDirectory,
+                rightsBasis: "review-only",
+                prepareOcrVariants: async () => ({ variants: [] })
+            }),
+            /blocking-fixture is enabled in the regression gate/
+        );
+    });
+
+    it("rejects compound labels until face-specific ground truth is supplied", async () => {
+        await rejects(
+            stageTrainingReviewBatch(regressionManifest(), {
+                caseIds: ["compound-fixture"],
+                outputDirectory: path.join(os.tmpdir(), "must-not-be-created"),
+                rightsBasis: "review-only",
+                prepareOcrVariants: async () => ({ variants: [] })
+            }),
+            /compound-fixture uses a compound card name/
+        );
+    });
+});

--- a/test/training/training-review-stager.spec.mjs
+++ b/test/training/training-review-stager.spec.mjs
@@ -1,9 +1,13 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { rejects } from "node:assert/strict";
 import { assert } from "chai";
-import { stageTrainingReviewBatch } from "../../src/training/training-review-stager.mjs";
+import {
+    MAX_REVIEW_BATCH_CASES,
+    selectCases,
+    stageTrainingReviewBatch
+} from "../../src/training/training-review-stager.mjs";
 
 function regressionManifest() {
     return {
@@ -81,6 +85,12 @@ describe("OCR training review stager", () => {
             assert.equal(writtenReport.samples[1].sourceCaseId, "candidate-two");
             assert.match(writtenReport.samples[0].imageSha256, /^[a-f0-9]{64}$/);
             assert.match(writtenReport.samples[0].transcriptionSha256, /^[a-f0-9]{64}$/);
+            const reviewSheet = await readFile(path.join(outputDirectory, "review.md"), "utf8");
+            assert.include(reviewSheet, "# OCR training review batch");
+            assert.include(reviewSheet, "## Candidate One");
+            assert.include(reviewSheet, "![Candidate One](./candidate-one.png)");
+            assert.include(reviewSheet, "- [ ] Crop contains the complete exact transcription");
+            assert.include(reviewSheet, "- Decision: `approve` / `reject`");
         } finally {
             await rm(parent, { recursive: true, force: true });
         }
@@ -109,6 +119,99 @@ describe("OCR training review stager", () => {
                 prepareOcrVariants: async () => ({ variants: [] })
             }),
             /compound-fixture uses a compound card name/
+        );
+    });
+
+    it("rejects malformed, unsafe, duplicate, unknown, and placeholder selections", () => {
+        const manifest = regressionManifest();
+        const unsafeFixture = {
+            id: "../unsafe",
+            enabled: false,
+            imagePath: "/fixtures/unsafe.jpg",
+            expected: { name: "Unsafe" }
+        };
+        const placeholderFixture = {
+            id: "placeholder",
+            enabled: false,
+            imagePath: "/fixtures/placeholder.jpg",
+            expected: { name: "CHANGE_ME" }
+        };
+        const missingNameFixture = {
+            id: "missing-name",
+            enabled: false,
+            imagePath: "/fixtures/missing-name.jpg",
+            expected: {}
+        };
+
+        assert.throws(() => selectCases(null, ["candidate-one"]), "loaded regression manifest");
+        assert.throws(() => selectCases(manifest, []), "At least one training review case");
+        assert.throws(
+            () => selectCases(manifest, Array(MAX_REVIEW_BATCH_CASES + 1).fill("candidate-one")),
+            `limited to ${MAX_REVIEW_BATCH_CASES}`
+        );
+        assert.throws(
+            () => selectCases(manifest, ["candidate-one", "candidate-one"]),
+            "case IDs must be unique"
+        );
+        assert.throws(() => selectCases(manifest, ["unknown"]), "Unknown regression fixture");
+        assert.throws(
+            () =>
+                selectCases({ ...manifest, cases: [...manifest.cases, unsafeFixture] }, [
+                    "../unsafe"
+                ]),
+            "not safe to use as a training review filename"
+        );
+        assert.throws(
+            () =>
+                selectCases({ ...manifest, cases: [...manifest.cases, placeholderFixture] }, [
+                    "placeholder"
+                ]),
+            "still has placeholder ground truth"
+        );
+        assert.throws(
+            () =>
+                selectCases({ ...manifest, cases: [...manifest.cases, missingNameFixture] }, [
+                    "missing-name"
+                ]),
+            "expected name must be a non-empty string"
+        );
+    });
+
+    it("removes a partial review directory when crop generation fails", async () => {
+        const parent = await mkdtemp(path.join(os.tmpdir(), "mtg-training-review-"));
+        const outputDirectory = path.join(parent, "failed-batch");
+        try {
+            await rejects(
+                stageTrainingReviewBatch(regressionManifest(), {
+                    caseIds: ["candidate-one"],
+                    outputDirectory,
+                    rightsBasis: "review-only",
+                    prepareOcrVariants: async () => ({ variants: [] })
+                }),
+                /did not produce a non-empty name-core crop/
+            );
+            await rejects(access(outputDirectory), /ENOENT/);
+        } finally {
+            await rm(parent, { recursive: true, force: true });
+        }
+    });
+
+    it("requires an output directory and rights/provenance basis", async () => {
+        await rejects(
+            stageTrainingReviewBatch(regressionManifest(), {
+                caseIds: ["candidate-one"],
+                outputDirectory: "",
+                rightsBasis: "review-only"
+            }),
+            /outputDirectory must be a non-empty string/
+        );
+        await rejects(
+            stageTrainingReviewBatch(regressionManifest(), {
+                caseIds: ["candidate-one"],
+                outputDirectory: "/tmp/not-created",
+                rightsBasis: ""
+            }),
+            /rightsBasis must be a non-empty string/
         );
     });
 });

--- a/training/ocr/manifest.json
+++ b/training/ocr/manifest.json
@@ -1,0 +1,18 @@
+{
+    "version": 1,
+    "status": "draft",
+    "modelName": "eng_mtg",
+    "randomSeed": 20260808,
+    "trainRatio": 0.9,
+    "baseModel": {
+        "id": "official-eng-best",
+        "family": "tessdata_best",
+        "sha256": "8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba",
+        "source": {
+            "url": "https://github.com/tesseract-ocr/tessdata_best",
+            "revision": "e12c65a915945e4c28e237a9b52bc4a8f39a0cec",
+            "license": "Apache-2.0"
+        }
+    },
+    "samples": []
+}


### PR DESCRIPTION
## Summary

- define a pinned, review-first OCR training-data manifest and strict validation contract
- add tooling to stage bounded local review batches from disabled regression fixtures
- allow regression runs against reviewed OCR model candidates with provenance and SHA-256 validation
- add deterministic candidate comparison reports against the bundled control model
- document the corpus review, training, evaluation, and promotion workflow

## Why

The project needs a safe path to improve its aging bundled Tesseract data without training on acceptance fixtures, accepting unreviewed labels, or promoting a model that regresses existing card identification. This change establishes that foundation before adding committed training samples or generated model binaries.

## Impact

The production OCR model and default runtime behavior are unchanged. The committed training manifest remains an empty draft; corpus approval and actual fine-tuning will happen separately after visual and provenance review.

## Validation

- `pnpm check:fast`
- `pnpm coverage:check`
  - 93.02% statements/lines
  - 78.96% branches
  - 92.22% functions
- `pnpm test:regression`
  - 124/125 total fixtures passed
  - 118/118 blocking fixtures passed
  - 1/7 non-blocking fixtures failed

## Follow-up

Review and promote an initial ground-truth corpus, add reproducible `tesstrain` automation, train candidate models, and evaluate them through this comparison gate.
