### PR TITLE
Align OCR training files with static analysis

### DIFF
--- a/docs/ocr-training-data.md
+++ b/docs/ocr-training-data.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # OCR training data
 
 The custom OCR corpus is review-first. The repository currently contains a pinned, empty draft at

--- a/docs/ocr-training-pilot-2026-08.md
+++ b/docs/ocr-training-pilot-2026-08.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD043 -->
+
 # OCR training pilot: August 2026
 
 ## Decision

--- a/training/ocr/Dockerfile
+++ b/training/ocr/Dockerfile
@@ -13,6 +13,9 @@ ARG TESSDATA_BEST_ENG_SHA256=8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1
 LABEL org.opencontainers.image.source="https://github.com/dills122/MTG-Card-Analyzer"
 LABEL org.opencontainers.image.description="Pinned offline Tesseract fine-tuning environment"
 
+# Ubuntu security package revisions move within the 24.04 suite; pinning them here would make
+# rebuilds brittle. Training inputs downloaded below remain pinned by revision and checksum.
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
## Summary

- scope Markdownlint exceptions to the two generated-width OCR training documents
- document why Ubuntu security packages remain unpinned in the training container
- keep the Tesseract training-data migration isolated for a separate follow-up

## Verification

- pnpm check:fast
- focused OCR training-plan tests (4 passing)

This is the seven-line static-analysis follow-up to merged PR #197; it does not change runtime or training behavior.