### PR TITLE
Replace legacy OCR model with official LSTM data

### DIFF
--- a/docs/ocr-training-data.md
+++ b/docs/ocr-training-data.md
@@ -2,9 +2,10 @@
 
 # OCR training data
 
-The custom OCR corpus is review-first. The repository currently contains a pinned, empty draft at
-`training/ocr/manifest.json`; it defines the base model and validation contract without pretending
-that unreviewed samples are ready to train.
+The custom OCR corpus is review-first. `training/ocr/manifest.json` currently records 22 reviewed
+single-line samples with pinned hashes and provenance; the deterministic split yields 19 training
+lines and three evaluation lines. The corpus remains separate from the bundled production model so
+rejected experiments cannot silently change runtime OCR behavior.
 
 Tesseract's supported `tesstrain` workflow consumes single-line PNG or TIFF images paired with a
 plain-text transcription whose filename replaces the image extension with `.gt.txt`. Its training
@@ -149,3 +150,8 @@ Training completion is not promotion. Package the selected checkpoint as `eng.tr
 to a reviewed OCR candidate manifest with exact provenance and SHA-256, run the full regression
 corpus, and compare it to the bundled control with `pnpm regression:compare`. A candidate with any
 blocking regression does not replace the production model, even if aggregate accuracy improves.
+
+The production bundle now uses the pinned official `tessdata_best` English LSTM model as its control.
+This replaced the original Pre-4.0 legacy-only archive after the stock LSTM model passed all 118
+blocking fixtures. The reviewed custom corpus is still available for future domain fine-tuning; no
+custom checkpoint has been promoted.

--- a/docs/ocr-training-pilot-2026-08.md
+++ b/docs/ocr-training-pilot-2026-08.md
@@ -55,3 +55,11 @@ The repeated failures identify a narrower data gap: the corpus needs reviewed vi
 modern full-art title examples acquired separately from the enabled regression fixtures. Keep the
 M10/M15 normal-frame lines, add those missing frame families, then rerun a short bounded checkpoint.
 All 118 blocking fixtures must pass before considering longer training.
+
+## Later production model migration
+
+On 2026-08-09, a separate stock-model bakeoff replaced the original Pre-4.0 legacy-only production
+archive with the pinned official `tessdata_best` English LSTM model. That model passed all 118
+blocking fixtures and 123 of 125 fixtures overall. It did not come from the 22-line custom corpus,
+so this migration does not change the rejection decision above: the reviewed corpus remains ready
+for a future, more diverse fine-tuning experiment and no custom checkpoint has been promoted.

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -14,8 +14,8 @@ The existing scan path already had strong reusable pieces:
   request bounded soft/inverted or rotated title variants.
 - `src/image-analysis/extract-text.mjs` runs Tesseract with each crop's declared page-segmentation
   mode and preserves bounded region, line, and token-window candidates. One bounded Tesseract
-  worker loads the pinned official `tessdata_best` English LSTM model. The LSTM-only archive does
-  not contain the obsolete `enable_new_segsearch` or `save_raw_choices` legacy directives.
+  worker loads the pinned official `tessdata_best` English LSTM model. The LSTM-only archive
+  does not contain the obsolete `enable_new_segsearch` or `save_raw_choices` legacy directives.
 - `src/fuzzy-matching/match-name.mjs` applies the production fuzzy-name thresholds.
 - `src/image-hashing/hash-image.mjs` provides the production perceptual hash and comparison
   metrics.

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -12,10 +12,11 @@ The existing scan path already had strong reusable pieces:
 - `src/image-processing/ocr-preprocessing.mjs` crops four likely name regions and applies
   grayscale, normalization, scaling, thresholding, inversion, and sharpening. Failed matches can
   request bounded soft/inverted or rotated title variants.
-- `src/image-analysis/extract-text.mjs` runs Tesseract with each crop's declared page-segmentation
-  mode and preserves bounded region, line, and token-window candidates. One bounded Tesseract
-  worker loads the pinned official `tessdata_best` English LSTM model. The LSTM-only archive
-  does not contain the obsolete `enable_new_segsearch` or `save_raw_choices` legacy directives.
+- `src/image-analysis/extract-text.mjs` runs Tesseract with each crop's declared
+  page-segmentation mode and preserves bounded region, line, and token-window
+  candidates. One bounded Tesseract worker loads the pinned official
+  `tessdata_best` English LSTM model. The LSTM-only archive does not contain
+  the obsolete `enable_new_segsearch` or `save_raw_choices` legacy directives.
 - `src/fuzzy-matching/match-name.mjs` applies the production fuzzy-name thresholds.
 - `src/image-hashing/hash-image.mjs` provides the production perceptual hash and comparison
   metrics.

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -14,8 +14,8 @@ The existing scan path already had strong reusable pieces:
   request bounded soft/inverted or rotated title variants.
 - `src/image-analysis/extract-text.mjs` runs Tesseract with each crop's declared page-segmentation
   mode and preserves bounded region, line, and token-window candidates. One bounded Tesseract
-  worker loads the reviewed English model;
-  its obsolete `enable_new_segsearch` and `save_raw_choices` directives are disabled in place.
+  worker loads the pinned official `tessdata_best` English LSTM model. The LSTM-only archive does
+  not contain the obsolete `enable_new_segsearch` or `save_raw_choices` legacy directives.
 - `src/fuzzy-matching/match-name.mjs` applies the production fuzzy-name thresholds.
 - `src/image-hashing/hash-image.mjs` provides the production perceptual hash and comparison
   metrics.
@@ -146,6 +146,28 @@ official data-file guidance identifies `tessdata_best` as the float model intend
 `tessdata_fast` is an integer model that cannot be used as a training base. A trained candidate must
 return to this same comparison gate before any production promotion.
 
+### Production LSTM promotion: 2026-08-09
+
+The original production bundle was a 20.86 MiB Pre-4.0 legacy-only archive. A current-format
+replacement bakeoff ran the complete 125-case corpus with Tesseract.js fixed at 3.0.3:
+
+| Model                         |      Size |  Passed | Blocking | Mean runtime | P95 runtime |
+| ----------------------------- | --------: | ------: | -------: | -----------: | ----------: |
+| Pre-4.0 bundled control       | 20.86 MiB | 124/125 |  118/118 |   1816.00 ms |  8010.73 ms |
+| Official `tessdata_best` LSTM | 14.69 MiB | 123/125 |  118/118 |   1503.16 ms |  4151.01 ms |
+
+The LSTM model preserved every blocking result, removed 6.18 MiB from the bundle, and reduced the
+directional mean and p95 runtimes. Its only regression was the already non-blocking Mirage
+`Illumination` fixture. The official combined `tessdata` model produced the same pass set while
+growing to 22.38 MiB, so the smaller LSTM-only model was selected.
+
+Production now pins `tessdata_best` revision
+`e12c65a915945e4c28e237a9b52bc4a8f39a0cec`, SHA-256
+`8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba`. The runtime diagnostics
+verify that exact hash, and the regression candidate manifest records the same source and engine
+provenance. Timings are directional local measurements; the zero-blocking-regression result is the
+promotion gate.
+
 ## Manifest
 
 Edit `test/regression/fixtures/manifest.json`. Paths are relative to the manifest file. The
@@ -165,8 +187,9 @@ Cases are blocking by default. Add `"blocking": false` only for a known, tracked
 must remain visible in every benchmark without failing CI. Non-blocking cases still run, retain
 their ordinary pass/fail result, and appear as `NON-BLOCKING FAIL` in the Markdown report. The
 seven vintage fixtures are temporarily non-blocking while GitHub issue #157 tracks the remaining
-vintage-card recognition work. The current benchmark recognizes six of those seven; the vintage
-`Island` fixture remains the known miss. All other enabled fixtures gate pull requests.
+vintage-card recognition work. The current LSTM benchmark recognizes five of those seven; the
+vintage `Island` and `Illumination` fixtures remain known misses. All other enabled fixtures gate
+pull requests.
 
 Minimal example:
 

--- a/src/diagnostics/env-check.mjs
+++ b/src/diagnostics/env-check.mjs
@@ -1,7 +1,12 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { DEFAULT_OCR_MODEL_PATH } from "../image-analysis/ocr-model.mjs";
+import {
+    DEFAULT_OCR_MODEL_FAMILY,
+    DEFAULT_OCR_MODEL_PATH,
+    DEFAULT_OCR_MODEL_SHA256
+} from "../image-analysis/ocr-model.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.join(__dirname, "../..");
@@ -9,6 +14,16 @@ const unsupportedOcrParameters = ["enable_new_segsearch", "save_raw_choices"];
 
 function findUnsupportedOcrParameters(model) {
     return unsupportedOcrParameters.filter((parameter) => model.includes(Buffer.from(parameter)));
+}
+
+function inspectDefaultOcrModel(model) {
+    const sha256 = createHash("sha256").update(model).digest("hex");
+    return {
+        sha256,
+        expectedSha256: DEFAULT_OCR_MODEL_SHA256,
+        matchesExpectedSha256: sha256 === DEFAULT_OCR_MODEL_SHA256,
+        unsupportedParameters: findUnsupportedOcrParameters(model)
+    };
 }
 
 // Sanity-checks the environment is actually usable, not just "file exists". Shared by
@@ -43,15 +58,18 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
 
     if (fs.existsSync(DEFAULT_OCR_MODEL_PATH)) {
         const model = fs.readFileSync(DEFAULT_OCR_MODEL_PATH);
-        const unsupportedParameters = findUnsupportedOcrParameters(model);
-        if (unsupportedParameters.length === 0) {
-            record("English OCR model available (patched eng.traineddata)", "pass");
+        const inspection = inspectDefaultOcrModel(model);
+        if (inspection.unsupportedParameters.length > 0) {
+            record(
+                `English OCR model contains unsupported parameters: ${inspection.unsupportedParameters.join(", ")}`,
+                "fail"
+            );
+        } else if (!inspection.matchesExpectedSha256) {
+            record("English OCR model does not match the pinned production SHA-256", "fail");
         } else {
             record(
-                `English OCR model contains unsupported parameters: ${unsupportedParameters.join(
-                    ", "
-                )}`,
-                "fail"
+                `English OCR model available (official ${DEFAULT_OCR_MODEL_FAMILY} LSTM)`,
+                "pass"
             );
         }
     } else {
@@ -124,6 +142,6 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
     return { checks, requiredFailures, warnings };
 }
 
-export { findUnsupportedOcrParameters, runEnvironmentCheck };
+export { findUnsupportedOcrParameters, inspectDefaultOcrModel, runEnvironmentCheck };
 
 export default { runEnvironmentCheck };

--- a/src/diagnostics/env-check.mjs
+++ b/src/diagnostics/env-check.mjs
@@ -26,6 +26,33 @@ function inspectDefaultOcrModel(model) {
     };
 }
 
+function checkDefaultOcrModel() {
+    if (!fs.existsSync(DEFAULT_OCR_MODEL_PATH)) {
+        return {
+            label: "English OCR model missing at repo root -- restore eng.traineddata.",
+            status: "fail"
+        };
+    }
+
+    const inspection = inspectDefaultOcrModel(fs.readFileSync(DEFAULT_OCR_MODEL_PATH));
+    if (inspection.unsupportedParameters.length > 0) {
+        return {
+            label: `English OCR model contains unsupported parameters: ${inspection.unsupportedParameters.join(", ")}`,
+            status: "fail"
+        };
+    }
+    if (!inspection.matchesExpectedSha256) {
+        return {
+            label: "English OCR model does not match the pinned production SHA-256",
+            status: "fail"
+        };
+    }
+    return {
+        label: `English OCR model available (official ${DEFAULT_OCR_MODEL_FAMILY} LSTM)`,
+        status: "pass"
+    };
+}
+
 // Sanity-checks the environment is actually usable, not just "file exists". Shared by
 // scripts/verify-env.mjs (dev setup) and `node index.mjs diagnostics` (support bundle) --
 // one source of truth for what "is this environment healthy" means, printed differently by
@@ -56,25 +83,8 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
         record(`Node ${process.versions.node} -- this project targets Node >=20`, "fail");
     }
 
-    if (fs.existsSync(DEFAULT_OCR_MODEL_PATH)) {
-        const model = fs.readFileSync(DEFAULT_OCR_MODEL_PATH);
-        const inspection = inspectDefaultOcrModel(model);
-        if (inspection.unsupportedParameters.length > 0) {
-            record(
-                `English OCR model contains unsupported parameters: ${inspection.unsupportedParameters.join(", ")}`,
-                "fail"
-            );
-        } else if (!inspection.matchesExpectedSha256) {
-            record("English OCR model does not match the pinned production SHA-256", "fail");
-        } else {
-            record(
-                `English OCR model available (official ${DEFAULT_OCR_MODEL_FAMILY} LSTM)`,
-                "pass"
-            );
-        }
-    } else {
-        record("English OCR model missing at repo root -- restore eng.traineddata.", "fail");
-    }
+    const ocrModelCheck = checkDefaultOcrModel();
+    record(ocrModelCheck.label, ocrModelCheck.status);
 
     const testImage = path.join(repoRoot, "test-images/PlatinumAngel.jpg");
     if (fs.existsSync(testImage)) {

--- a/src/image-analysis/ocr-model.mjs
+++ b/src/image-analysis/ocr-model.mjs
@@ -1,17 +1,29 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// The trained network preserves the reviewed OCR corpus. Its two obsolete configuration entries
-// are commented in place so modern Tesseract cores do not emit unsupported-parameter warnings.
+// Pinned official float LSTM model selected by the 125-case regression bakeoff.
+// Source: https://github.com/tesseract-ocr/tessdata_best/blob/e12c65a915945e4c28e237a9b52bc4a8f39a0cec/eng.traineddata
+const DEFAULT_OCR_MODEL_FAMILY = "tessdata_best";
+const DEFAULT_OCR_MODEL_REVISION = "e12c65a915945e4c28e237a9b52bc4a8f39a0cec";
+const DEFAULT_OCR_MODEL_SHA256 = "8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba";
 const DEFAULT_OCR_LANGUAGE_PATH = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "../.."
 );
 const DEFAULT_OCR_MODEL_PATH = path.join(DEFAULT_OCR_LANGUAGE_PATH, "eng.traineddata");
 
-export { DEFAULT_OCR_LANGUAGE_PATH, DEFAULT_OCR_MODEL_PATH };
+export {
+    DEFAULT_OCR_LANGUAGE_PATH,
+    DEFAULT_OCR_MODEL_FAMILY,
+    DEFAULT_OCR_MODEL_PATH,
+    DEFAULT_OCR_MODEL_REVISION,
+    DEFAULT_OCR_MODEL_SHA256
+};
 
 export default {
     DEFAULT_OCR_LANGUAGE_PATH,
-    DEFAULT_OCR_MODEL_PATH
+    DEFAULT_OCR_MODEL_FAMILY,
+    DEFAULT_OCR_MODEL_PATH,
+    DEFAULT_OCR_MODEL_REVISION,
+    DEFAULT_OCR_MODEL_SHA256
 };

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -376,7 +376,7 @@ async function runRegression(manifest, options = {}) {
                 ocrCache: "disabled",
                 ocrLanguageSource: options.ocrModel
                     ? `OCR candidate ${options.ocrModel.id}`
-                    : "patched bundled eng.traineddata",
+                    : "bundled official tessdata_best eng.traineddata",
                 ocrWorkerLifecycle: "shared process; adaptive state reset per crop",
                 temporaryArtifacts: "deleted after each case"
             },

--- a/test/diagnostics/env-check.spec.mjs
+++ b/test/diagnostics/env-check.spec.mjs
@@ -1,8 +1,10 @@
 import { assert } from "chai";
 import {
     findUnsupportedOcrParameters,
+    inspectDefaultOcrModel,
     runEnvironmentCheck
 } from "../../src/diagnostics/env-check.mjs";
+import { DEFAULT_OCR_MODEL_SHA256 } from "../../src/image-analysis/ocr-model.mjs";
 
 // Exercises the real local environment (same checks scripts/verify-env.mjs runs) rather than
 // mocking every fs/DB dependency -- the point of this module is "is the environment actually
@@ -29,7 +31,7 @@ describe("diagnostics::env-check", () => {
         assert.equal(nodeCheck.status, "pass", "this test suite itself requires Node >=20");
     });
 
-    it("checks the patched English OCR model used at runtime", async () => {
+    it("checks the pinned official LSTM English model used at runtime", async () => {
         const result = await runEnvironmentCheck();
         const modelCheck = result.checks.find((check) =>
             check.label.startsWith("English OCR model")
@@ -37,7 +39,16 @@ describe("diagnostics::env-check", () => {
 
         assert.exists(modelCheck);
         assert.equal(modelCheck.status, "pass");
-        assert.include(modelCheck.label, "patched eng.traineddata");
+        assert.include(modelCheck.label, "official tessdata_best LSTM");
+    });
+
+    it("rejects model bytes that do not match the pinned production SHA-256", () => {
+        const inspection = inspectDefaultOcrModel(Buffer.from("unexpected model"));
+
+        assert.equal(inspection.expectedSha256, DEFAULT_OCR_MODEL_SHA256);
+        assert.notEqual(inspection.sha256, inspection.expectedSha256);
+        assert.isFalse(inspection.matchesExpectedSha256);
+        assert.deepEqual(inspection.unsupportedParameters, []);
     });
 
     it("detects the obsolete parameters that cause Tesseract warning noise", () => {

--- a/test/regression/ocr-model-candidate.spec.mjs
+++ b/test/regression/ocr-model-candidate.spec.mjs
@@ -56,7 +56,7 @@ describe("OCR model candidate manifest::", () => {
         assert.equal(manifest.candidates[0].engine.version, "3.0.3");
     });
 
-    it("tracks the reviewed bundled model as the immutable control candidate", async () => {
+    it("tracks the pinned official LSTM model as the bundled control candidate", async () => {
         const manifestPath = fileURLToPath(new URL("./ocr-models/manifest.json", import.meta.url));
 
         const manifest = await loadOcrModelManifest(manifestPath);
@@ -64,9 +64,14 @@ describe("OCR model candidate manifest::", () => {
         assert.equal(manifest.candidates.length, 1);
         assert.include(manifest.candidates[0], {
             id: "bundled-eng-control",
-            sha256: "7e084d31c8262ec2bacf90ac4288fde165c0c6db35fe7d2b8c8ff271b8876234",
-            sizeBytes: 21876572
+            family: "tessdata_best",
+            sha256: "8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba",
+            sizeBytes: 15400601
         });
+        assert.equal(
+            manifest.candidates[0].source.revision,
+            "e12c65a915945e4c28e237a9b52bc4a8f39a0cec"
+        );
     });
 
     it("rejects duplicate candidate IDs and non-English model filenames", () => {

--- a/test/regression/ocr-models/manifest.json
+++ b/test/regression/ocr-models/manifest.json
@@ -4,11 +4,11 @@
         {
             "id": "bundled-eng-control",
             "model": "../../../eng.traineddata",
-            "family": "project-bundled-control",
-            "sha256": "7e084d31c8262ec2bacf90ac4288fde165c0c6db35fe7d2b8c8ff271b8876234",
+            "family": "tessdata_best",
+            "sha256": "8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba",
             "source": {
-                "url": "https://github.com/dills122/MTG-Card-Analyzer",
-                "revision": "dcc5d0e",
+                "url": "https://github.com/tesseract-ocr/tessdata_best",
+                "revision": "e12c65a915945e4c28e237a9b52bc4a8f39a0cec",
                 "license": "Apache-2.0"
             },
             "engine": {


### PR DESCRIPTION
## Summary

- replace the legacy pre-4.0 English OCR model with the pinned official `tessdata_best` LSTM model
- verify the bundled model family, upstream revision, size, and SHA-256 in diagnostics and regression metadata
- document model provenance, the promotion decision, and the retained custom-training corpus

## Why

The bundled legacy model depended on obsolete Tesseract parameters and produced repeated `enable_new_segsearch` and `save_raw_choices` warnings. The official LSTM model removes that compatibility noise and provides a supported base for future fine-tuning.

## Impact

- removes the obsolete model-parameter warnings
- reduces the bundled model from 20.86 MiB to 14.69 MiB
- preserves the blocking regression gate at 118/118
- scores 123/125 overall instead of the legacy model's 124/125, adding one documented non-blocking vintage-card miss (`Illumination`)
- keeps the reviewed 22-sample custom corpus separate and unpromoted for future training work

## Validation

- `pnpm check:fast`
- `pnpm test` — 407 passing
- `pnpm coverage:check` — 92.91% statements/lines, 78.51% branches, 92.13% functions
- `pnpm training:data:check --require-ready` — 22 verified samples, deterministic 19/3 split
- `node scripts/verify-env.mjs`
- `pnpm test:regression` — 123/125 overall and 118/118 blocking
- `git diff --check`

