### PR TITLE
Refresh user-facing documentation for current workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,27 @@ workflow. A normal build does not require AI Central.
 
 ## Before Opening a PR
 
-Run the full local gate — it's close to what CI checks:
+Run the standard local gate:
 
 ```bash
 pnpm check
 ```
 
-That's `lint` + `prettier:check` + `typecheck` + `test`. Individual pieces (`pnpm lint:fix`, `pnpm format`) can autofix most issues.
+That's `lint` + `prettier:check` + `typecheck` + `test`. Individual pieces (`pnpm lint:fix`,
+`pnpm format`) can autofix most issues.
+
+To mirror all CI jobs, run the fast static gate, the coverage-enforced unit suite, and the
+cold-cache OCR regression suite:
+
+```bash
+pnpm check:fast
+pnpm coverage:check
+pnpm test:regression
+```
+
+`coverage:check` runs the unit suite, so the three commands above are the complete CI-equivalent
+sequence. The OCR regression run is especially important for changes to image preprocessing,
+OCR, fuzzy matching, hashing, or print selection.
 
 Type checking is being introduced incrementally for this ESM JavaScript codebase. The strict
 checked-module list lives in `tsconfig.checked.json`; add a touched production module there once its
@@ -79,10 +93,10 @@ Quick orientation — see individual `index.mjs` files in each folder for the pu
 - `src/rds/` — legacy/optional MySQL persistence backend, not used by default
 - `src/processor/` — orchestrates the end-to-end scan pipeline
 - `src/config/` — single source of truth for runtime settings (CLI flag > env var > config file > default)
-- `index.mjs` — CLI entry point (`scan`, `log dump`, `log stats`)
-- `scripts/` — dev tooling: `setup.mjs` (ramp-up), `verify-env.mjs` (environment sanity check)
+- `index.mjs` — CLI entry point (`scan`, `log`, `collection`, `migrate`, `diagnostics`, `config`)
+- `scripts/` — setup, verification, regression, fixture-import, and OCR-training tooling
 - `docker-compose.yml` — local MySQL for the optional `rds` adapter
-- `docs/` — deeper guides (currently: local dev setup)
+- `docs/` — CLI, configuration, architecture, regression, OCR-training, and local setup guides
 
 ## Picking Up an Issue
 

--- a/Readme.md
+++ b/Readme.md
@@ -37,8 +37,10 @@ node scripts/setup.mjs
 node index.mjs scan ./test-images/PlatinumAngel.jpg
 ```
 
-The setup script installs dependencies, creates local configuration files, and seeds the card-name
-index. It is safe to run again and does not start MySQL unless you explicitly pass `--with-mysql`.
+The setup script installs dependencies, creates local configuration files without overwriting
+existing ones, and seeds the card-name index. On later runs, pass `--skip-seed` if the index is
+already populated: the current seeder appends the Scryfall catalog and can create duplicate name
+rows. Setup does not start MySQL unless you explicitly pass `--with-mysql`.
 
 If the scan does not complete, check the environment before digging into individual settings:
 

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -32,7 +32,10 @@ node scripts/verify-env.mjs --with-mysql # also checks the MySQL connection
 
 ## What `scripts/setup.mjs` does
 
-Deliberately dependency-free (only core Node modules) so it runs before `pnpm install` has ever succeeded on a fresh clone. Every step is idempotent — safe to re-run any time, won't clobber files you've already customized.
+The setup script itself is deliberately dependency-free (only core Node modules), so it can run
+before `pnpm install` has succeeded on a fresh clone. Configuration creation is non-clobbering, but
+installation and seeding repeat unless skipped. After a successful seed, use `--skip-seed` on later
+runs because the current seeder appends the catalog and can create duplicate name rows.
 
 | Step               | What happens                                                                                            |
 | ------------------ | ------------------------------------------------------------------------------------------------------- |
@@ -81,10 +84,14 @@ To wipe local MySQL state entirely: `docker compose down -v` (removes the volume
 pnpm check          # full gate: lint + prettier + typecheck + test
 pnpm test            # tests only
 pnpm coverage        # tests + coverage report (coverage/index.html)
+pnpm coverage:check  # tests + the coverage thresholds enforced by CI
+pnpm test:regression # cold-cache OCR and matching regression gate
 node scripts/verify-env.mjs  # is the environment actually usable
 ```
 
-`pnpm check` is what CI runs — get it green locally before opening a PR.
+`pnpm check` is the standard local gate. CI runs `pnpm check:fast`, `pnpm coverage:check`, and a
+separate `pnpm test:regression` job; see [CONTRIBUTING.md](../CONTRIBUTING.md#before-opening-a-pr)
+for the exact sequence.
 
 ## Troubleshooting
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,18 +5,18 @@ Run commands from the repository root with `node index.mjs`. Use `node index.mjs
 
 ## Commands at a glance
 
-| Command             | Purpose                                                          |
-| ------------------- | ---------------------------------------------------------------- |
-| `scan <filePath>`   | Identify a card image and optionally persist the result          |
-| `log dump`          | Print recent local operations-log entries                        |
-| `log stats`         | Summarize the local operations log                               |
-| `collection update` | Set an existing collection entry's quantity                      |
-| `collection remove` | Permanently delete a collection entry                            |
-| `migrate`           | Copy local NeDB collection data to the legacy RDS backend        |
-| `diagnostics`       | Print a sanitized environment and recent-activity support bundle |
-| `config list`       | Show all resolved settings and their sources                     |
-| `config get`        | Print one resolved setting                                       |
-| `config set`        | Validate and persist one setting                                 |
+| Command             | Purpose                                                   |
+| ------------------- | --------------------------------------------------------- |
+| `scan <filePath>`   | Identify a card image and optionally persist the result   |
+| `log dump`          | Print recent local operations-log entries                 |
+| `log stats`         | Summarize the local operations log                        |
+| `collection update` | Set an existing collection entry's quantity               |
+| `collection remove` | Permanently delete a collection entry                     |
+| `migrate`           | Copy local NeDB collection data to the legacy RDS backend |
+| `diagnostics`       | Print an environment and recent-activity support bundle   |
+| `config list`       | Show all resolved settings and their sources              |
+| `config get`        | Print one resolved setting                                |
+| `config set`        | Validate and persist one setting                          |
 
 ## Scan a card
 
@@ -101,9 +101,11 @@ node index.mjs diagnostics --with-mysql
 ```
 
 Diagnostics prints JSON containing application, Node.js, and platform versions; environment
-checks; sanitized active configuration; and recent operations. The bundle never includes MySQL
-credentials. With `--with-mysql`, the connection layer reads them only to perform the requested
-connection check. The command exits non-zero when a required environment check fails.
+checks; active configuration; and recent operations. It includes local config/database paths,
+source-image paths, OCR text, and scan details, so review the output before sharing it. The bundle
+never includes MySQL credentials. With `--with-mysql`, the connection layer reads them only to
+perform the requested connection check. MySQL connection failures and an empty card-name index are
+reported as warnings; the command exits non-zero only when a required environment check fails.
 
 Options:
 
@@ -120,8 +122,9 @@ node index.mjs config set queryingEnabled true
 node index.mjs config set collectionEnabled true --config ./another-config.json
 ```
 
-- `config list` shows every resolved value and whether it came from the CLI, environment, file, or
-  default.
+- `config list` shows every runtime setting and whether its value came from the environment, the
+  selected file, or a built-in default. `--config` selects the file; it does not make the values in
+  that file CLI-sourced.
 - `config get <key>` prints one resolved value.
 - `config set <key> <value>` validates and merges one setting into the active JSON file.
 

--- a/docs/regression-fixture-expansion-2026-08.md
+++ b/docs/regression-fixture-expansion-2026-08.md
@@ -2,6 +2,10 @@
 
 # Regression fixture expansion experiment — August 2026
 
+> Historical campaign record: counts and failure descriptions below reflect the corpus at the
+> time of this expansion. See [OCR regression testing](regression-testing.md) for the current
+> 125-case corpus, production model, and gate behavior.
+
 This experiment expands clean-scan end-to-end coverage in batches of five to eight. Each batch is imported
 from Scryfall, visually reviewed, enabled in the offline fixture catalog, and run through the
 targeted regression harness before the next batch starts.


### PR DESCRIPTION
## Summary

Audit the README and user-facing guides against the current CLI, configuration schema, setup
scripts, storage behavior, CI workflows, and regression manifests.

## What changed

- Clarify that rerunning setup preserves configuration but repeats card-name seeding unless
  `--skip-seed` is used.
- Align contributor and local-development commands with the current static, coverage, and
  cold-cache regression CI jobs.
- Refresh the contributor-facing CLI and documentation inventory.
- Explain which local paths and scan details diagnostics can contain before users share a support
  bundle.
- Correct how `config list` reports environment, file, and default sources.
- Mark the August 2026 fixture-expansion report as a historical snapshot and link to the current
  125-case guide.

## User impact

Users and contributors now get guidance that matches the current local-first workflow and CI
requirements. This PR changes documentation only; runtime behavior is unchanged.

## Validation

- `pnpm check:fast`
- `pnpm coverage:check` — 407 tests passed and all coverage thresholds were met
- `pnpm test:regression` — 123/125 overall, with all 118/118 blocking fixtures passing
- Documentation link and anchor audit
- `git diff --check`
