### PR TITLE
Fix scan lifecycle persistence and print ambiguity

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,7 +101,12 @@ Run `node index.mjs --help` for the command list or see the
 4. Failed title matches progressively try soft/inverted title variants, rotated title bands, and
    finally supplemental rules text, avoiding the extra OCR work for ordinary successful scans.
 5. Candidate printings come from Scryfall and are ranked with cached or downloaded image hashes.
-6. Results are printed and, only when enabled, written to the selected collection backend.
+6. Results are printed and, only when enabled, a single confirmed printing is written to the
+   collection backend. A resolved name with multiple possible sets is saved to needs-attention
+   instead of being treated as confirmed.
+
+The scan promise includes local cache/log completion and removal of its bounded OCR temporary
+directory, so the CLI does not exit while those writes or cleanup operations are still pending.
 
 <p align="center">
   <img width="320" src="test-images/PlatinumAngel.jpg" alt="Platinum Angel card used by the example scan">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,10 @@ The cache tier is local NeDB and does not follow `storageAdapter`. It contains:
 It is enabled by default and can be disabled with `--no-local-cache` or
 `LOCAL_CACHE_ENABLED=false`.
 
+Cache writes are asynchronous but part of scan completion: hash upserts and the operations-log
+record settle before the CLI exits. A cache failure remains non-fatal to identification and is
+reported through the logger. Backfill reports success only after all of its hash upserts complete.
+
 ### Persistence tier
 
 The persistence tier stores collection and needs-attention records. `storageAdapter` selects:
@@ -50,7 +54,14 @@ The persistence tier stores collection and needs-attention records. `storageAdap
 
 Collection persistence is off by default. A scan writes only when both `queryingEnabled` and
 `collectionEnabled` are true. Scanning the same unambiguous card again increments its quantity;
-explicit collection commands can correct or remove an entry.
+explicit collection commands can correct or remove an entry. “Unambiguous” means exactly one card
+name and exactly one printing set. Multiple possible sets are written to needs-attention rather
+than selecting the first set as confirmed collection data.
+
+The processor owns one bounded OCR work directory per scan and removes it in a `finally` path on
+success and failure. Set-symbol hashing follows the same ownership rule for its local and remote
+temporary directories. Cleanup is awaited, logged on failure, and never replaces the primary scan
+error.
 
 See [Configuration and local data](configuration.md) for precedence, paths, and settings.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -50,6 +50,11 @@ node index.mjs ./path/to/card.jpg
 needs-attention records only when both resolve to `true`. Without both, the full identification
 pipeline still runs and prints its results.
 
+Confirmed collection data requires exactly one matched card name and one matched printing set. If
+the name is clear but multiple sets remain possible, the scan writes one needs-attention record
+containing all candidate sets (when both persistence opt-ins are enabled). Dry runs and scans with
+collection tracking disabled continue to print the candidates without persistence writes.
+
 Pretty logging is enabled by default. It keeps pipeline detail visible with compact, aligned level
 labels, emits one OCR progress heartbeat per crop, and prints final card/set candidates without
 internal verification objects:
@@ -74,7 +79,9 @@ output.
 ## Inspect scan activity
 
 Every scan records an operations-log entry while the local cache is enabled. Entries include the
-input path, OCR text, match candidates, decision, duration, and any error.
+input path, OCR text, match candidates, decision, duration, and any error. The CLI awaits this log
+write and any image-hash cache writes before exiting. Cache failures are reported but do not replace
+the primary scan result.
 
 ```bash
 node index.mjs log dump

--- a/src/back-filler.mjs
+++ b/src/back-filler.mjs
@@ -37,8 +37,8 @@ async function backFillCardHashes(cardName) {
             });
         }
         cardHashes = [...new Set(cardHashes)];
-        if (cardHashes.length > 0) {
-            cardHashes.forEach((hash) => HashesStore.upsert(hash));
+        for (const hash of cardHashes) {
+            await HashesStore.upsert(hash);
         }
         logger.info(`Backfilled ${cardHashes.length} printing hash(es) for "${cardName}"`);
         return true;

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -129,8 +129,19 @@ class ProcessHashes {
                     };
                 })
             );
-            hashResults.forEach(({ setName, remoteImageHash }) => {
-                this._insertCardHash(setName, remoteImageHash);
+            for (const { setName, remoteImageHash } of hashResults) {
+                try {
+                    await this._insertCardHash(setName, remoteImageHash);
+                } catch (err) {
+                    // Hashes are a reusable cache, not collection truth. Wait for the
+                    // attempted write so process exit cannot drop it, but keep a cache
+                    // failure from failing an otherwise valid scan.
+                    this.logger.error(
+                        `Card-hash cache write failed for "${this.name}" (${setName}): ${
+                            err?.message || String(err)
+                        }`
+                    );
+                }
                 const comparisonResults = this.dependencies.Hash.compareHash(
                     this.localHash,
                     remoteImageHash
@@ -142,9 +153,9 @@ class ProcessHashes {
                         })
                     );
                 }
-            });
+            }
         } finally {
-            done();
+            await done();
         }
         const matchValues = config.remoteMatch;
         let bestMatches = comparisonResultsList.filter((match) => {
@@ -182,7 +193,9 @@ class ProcessHashes {
                 .slice(0, config.remoteBestGuess.maxCandidates)
                 .map((match) => omit(match, ["confidenceScore"]));
             this.logger.info(
-                `Using closest image matches for "${this.name}": ${bestMatches.map((match) => match.setName).join(", ")}`
+                `Using closest image matches for "${this.name}": ${bestMatches
+                    .map((match) => match.setName)
+                    .join(", ")}`
             );
         }
         this.logger.info(`Scryfall image matches for "${this.name}": ${bestMatches.length}`);
@@ -199,8 +212,16 @@ class ProcessHashes {
         const directory = await this.dependencies.createDirectory();
         return {
             tempDirectory: directory,
-            done: () => {
-                this.dependencies.cleanUpFiles(directory).catch(() => {});
+            done: async () => {
+                try {
+                    await this.dependencies.cleanUpFiles(directory);
+                } catch (err) {
+                    this.logger.error(
+                        `Unable to remove remote-hash temporary directory: ${
+                            err?.message || String(err)
+                        }`
+                    );
+                }
             }
         };
     }
@@ -250,11 +271,11 @@ class ProcessHashes {
         });
     }
 
-    _insertCardHash(setName, hash) {
+    async _insertCardHash(setName, hash) {
         // isFoil/isPromo/cardUrl aren't tracked through the matcher pipeline yet, so they're
         // left for the store's own defaults (false/"") -- same as before this was fixed to use
         // the store's real field names instead of a PascalCase fallback chain.
-        this.dependencies.CardHashes.upsert({
+        return this.dependencies.CardHashes.upsert({
             cardName: this.name,
             setName,
             cardHash: hash,

--- a/src/matcher/matching-processor.mjs
+++ b/src/matcher/matching-processor.mjs
@@ -111,7 +111,7 @@ class MatcherProcessor {
             this.hashMode = "set-symbol";
             this.localHash = hash;
         } finally {
-            this._cleanupSetSymbolDirectory();
+            await this._cleanupSetSymbolDirectoryAsync();
         }
     }
 
@@ -121,13 +121,19 @@ class MatcherProcessor {
         this.localHash = hash;
     }
 
-    _cleanupSetSymbolDirectory() {
+    async _cleanupSetSymbolDirectoryAsync() {
         if (!this.setSymbolDirectory) {
             return;
         }
         const dir = this.setSymbolDirectory;
         this.setSymbolDirectory = "";
-        this.dependencies.cleanUpFiles(dir).catch(() => {});
+        try {
+            await this.dependencies.cleanUpFiles(dir);
+        } catch (err) {
+            this.logger.error(
+                `Unable to remove set-symbol temporary directory: ${err?.message || String(err)}`
+            );
+        }
     }
 
     async _processMultiSetMatchesAsync() {
@@ -142,7 +148,9 @@ class MatcherProcessor {
             allowRemoteBestGuess: true
         });
         this.logger.info(
-            `Comparing ${this.cards.length} printings for "${this.name}" using ${this.hashMode || "full-card"} hashes`
+            `Comparing ${this.cards.length} printings for "${this.name}" using ${
+                this.hashMode || "full-card"
+            } hashes`
         );
         const dbPromise = processHashes
             .compareDbHashes()

--- a/src/processor/processor.mjs
+++ b/src/processor/processor.mjs
@@ -89,6 +89,8 @@ class ProcessorClass {
                 error: err?.message || String(err)
             });
             throw err;
+        } finally {
+            await this.cleanUpDirectoryAsync();
         }
     }
 
@@ -96,7 +98,7 @@ class ProcessorClass {
     // --no-local-cache is set. This is what #49 ("Transaction") became.
     async logOperationAsync(extra = {}) {
         try {
-            this.dependencies.storage.log.record({
+            await this.dependencies.storage.log.record({
                 filePath: this.filePath,
                 extractedText: this.nameExtractionResults
                     ? {
@@ -124,6 +126,25 @@ class ProcessorClass {
         } catch (logErr) {
             // The ops log is a diagnostic aid, never a reason to fail (or mask) a real scan.
             this.logger.error(logErr);
+        }
+    }
+
+    async cleanUpDirectoryAsync() {
+        if (!this.directory) {
+            return;
+        }
+        const directory = this.directory;
+        this.directory = "";
+        try {
+            await this.dependencies.fileIO.cleanUpFiles(directory);
+        } catch (cleanupErr) {
+            // Temporary cleanup is best-effort diagnostics work. It must settle before the
+            // scan completes, but it must not replace a matching/persistence error.
+            this.logger.error(
+                `Unable to remove scan temporary directory: ${
+                    cleanupErr?.message || String(cleanupErr)
+                }`
+            );
         }
     }
 
@@ -196,7 +217,9 @@ class ProcessorClass {
             this.printResults();
             return;
         }
-        if (this.matcherResults.length === 1) {
+        const hasConfirmedPrinting =
+            this.matcherResults.length === 1 && this.matcherResults[0].sets.length === 1;
+        if (hasConfirmedPrinting) {
             this.decision = "collection";
             await this.CreateCollectionsRecordAsync(this.matcherResults[0]);
             return;

--- a/src/storage/index.mjs
+++ b/src/storage/index.mjs
@@ -3,9 +3,6 @@ import { getConfig } from "../config/index.mjs";
 import { db as namesDb } from "../db-local/db.mjs";
 import cardHashCache from "../db-local/card-hash-cache.mjs";
 import opsLog from "../db-local/ops-log.mjs";
-import log from "../logger/log.mjs";
-
-const logger = log.create({ isPretty: true });
 
 // Two distinct tiers, deliberately not the same concept:
 //
@@ -50,28 +47,18 @@ async function getHashesByCardName(cardName) {
     return docs || [];
 }
 
-function upsertHash(record) {
+async function upsertHash(record) {
     if (!cacheEnabled()) {
-        return;
+        return null;
     }
-    // Fire-and-forget, same as before -- callers don't wait on the cache write, and a
-    // failure here shouldn't ever surface as an unhandled rejection. Still worth logging:
-    // a silently-dropped hash write means future scans miss a cache hit with no trace.
-    cardHashCache.insertEntity(record).catch((err) => {
-        logger.error(`Card-hash cache write failed: ${err?.message || String(err)}`);
-    });
+    return cardHashCache.insertEntity(record);
 }
 
-function logOperation(entry) {
+async function logOperation(entry) {
     if (!cacheEnabled()) {
-        return;
+        return null;
     }
-    // Fire-and-forget, same as before -- callers don't wait on the log write, and a failure
-    // here shouldn't ever surface as an unhandled rejection. Still worth logging: a silently-
-    // dropped ops-log entry means diagnostics go missing with no trace.
-    opsLog.logOperation(entry).catch((err) => {
-        logger.error(`Ops-log write failed: ${err?.message || String(err)}`);
-    });
+    return opsLog.logOperation(entry);
 }
 
 const storage = {

--- a/test/back-filler.spec.mjs
+++ b/test/back-filler.spec.mjs
@@ -58,6 +58,24 @@ describe("back-filler", () => {
         );
     });
 
+    it("reports failure only after a cache write rejects", async () => {
+        sandbox.stub(scryfall.Search, "searchList").resolves([
+            {
+                name: "Pacifism",
+                set_name: "Core Set 2020",
+                image_uris: { normal: "https://example.test/pacifism.jpg" }
+            }
+        ]);
+        sandbox.stub(imageHashing.Hash, "hashImage").callsArgWith(1, null, "fake-hash");
+        sandbox.stub(storage.hashes, "upsert").rejects(new Error("disk full"));
+        const consoleError = sandbox.stub(console, "error");
+
+        const success = await backFillCardHashes("Pacifism");
+
+        assert.isFalse(success);
+        assert.isTrue(consoleError.calledWithMatch(sinon.match(/disk full/)));
+    });
+
     it("backfills every stored card name", async () => {
         sandbox
             .stub(storage.names, "getAll")

--- a/test/cli/scan-lifecycle-process.spec.mjs
+++ b/test/cli/scan-lifecycle-process.spec.mjs
@@ -1,0 +1,97 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { assert } from "chai";
+
+const CHILD_FIXTURE = path.resolve("test/fixtures/scan-lifecycle-child.mjs");
+
+function runChild(mode, root, inputPath) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [CHILD_FIXTURE, mode, root, inputPath], {
+            cwd: process.cwd(),
+            env: {
+                ...process.env,
+                MTG_CONFIG_PATH: path.join(root, "missing-config.json")
+            },
+            stdio: ["ignore", "pipe", "pipe"]
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.setEncoding("utf8");
+        child.stderr.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => {
+            stdout += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+            stderr += chunk;
+        });
+        child.once("error", reject);
+        child.once("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+    });
+}
+
+async function readNedbRecords(filename) {
+    const contents = await readFile(filename, "utf8");
+    return contents
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+        .filter((record) => !record.$$deleted && !record.$$indexCreated);
+}
+
+describe("CLI scan lifecycle process boundary", () => {
+    let root;
+    let inputPath;
+
+    beforeEach(async () => {
+        root = await mkdtemp(path.join(os.tmpdir(), "mtg-scan-lifecycle-"));
+        inputPath = path.join(root, "card.jpg");
+        await writeFile(inputPath, "fixture input");
+    });
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true });
+    });
+
+    it("persists hash and operations-log writes before a successful CLI exit", async () => {
+        const result = await runChild("success", root, inputPath);
+
+        assert.equal(result.signal, null);
+        assert.equal(result.code, 0, result.stderr || result.stdout);
+        const hashes = await readNedbRecords(path.join(root, "card-hashes.db"));
+        const operations = await readNedbRecords(path.join(root, "operations.db"));
+        assert.isTrue(
+            hashes.some(
+                (hash) =>
+                    hash.cardName === "Pacifism" &&
+                    hash.setName === "Core Set 2020" &&
+                    hash.cardHash === "fixture-hash" &&
+                    hash.hashMode === "full-card"
+            )
+        );
+        assert.isTrue(
+            operations.some(
+                (operation) => operation.filePath === inputPath && operation.decision === "dry-run"
+            )
+        );
+        assert.notInclude(await readdir(root), "scan-temp");
+    });
+
+    it("persists the primary error log and removes temp files before a failed CLI exit", async () => {
+        const result = await runChild("failure", root, inputPath);
+
+        assert.equal(result.signal, null);
+        assert.equal(result.code, 1, result.stderr || result.stdout);
+        const operations = await readNedbRecords(path.join(root, "operations.db"));
+        assert.isTrue(
+            operations.some(
+                (operation) =>
+                    operation.filePath === inputPath &&
+                    operation.decision === "error" &&
+                    operation.error === "fixture matching failure"
+            )
+        );
+        assert.notInclude(await readdir(root), "scan-temp");
+    });
+});

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -145,6 +145,33 @@ describe("Integration::", () => {
             assert.isTrue(matches.filter((match) => match.setName === FAKE_SET).length === 2);
         });
 
+        it("awaits card-hash cache writes before remote comparison completes", async () => {
+            let finishWrite;
+            const pendingWrite = new Promise((resolve) => {
+                finishWrite = resolve;
+            });
+            stubs.insertHashStub.returns(pendingWrite);
+            sandbox.stub(Hash, "hashImage").callsArgWith(1, null, FAKE_HASH);
+            const hasher = ProcessHashes.create({
+                cards: [{ image_uris: { normal: "https://example.test/card.jpg" }, set_name: "A" }],
+                localHash: CLOSE_DIFF_HASH,
+                name: "Test"
+            });
+            let settled = false;
+
+            const comparison = hasher.compareRemoteImages().finally(() => {
+                settled = true;
+            });
+            while (!stubs.insertHashStub.called) {
+                await new Promise((resolve) => setImmediate(resolve));
+            }
+
+            assert.isFalse(settled);
+            finishWrite();
+            await comparison;
+            assert.isTrue(settled);
+        });
+
         it("Should return no results for compareRemoteHashes", async () => {
             stubs.hashImageStub = sandbox
                 .stub(Hash, "hashImage")
@@ -228,6 +255,72 @@ describe("Integration::", () => {
             assert.isTrue(stubs.symbolStub.calledOnce);
             assert.isTrue(stubs.hashImageStub.calledOnce);
             assert.equal(stubs.hashImageStub.firstCall.args[0], "http://www.fake.url/img");
+        });
+
+        it("awaits remote set-symbol directory cleanup", async () => {
+            sandbox.stub(Hash, "hashImage").callsArgWith(1, null, FAKE_HASH);
+            const hasher = ProcessHashes.create({
+                cards: [
+                    {
+                        image_uris: { normal: "https://example.test/card.jpg" },
+                        set_name: "SET_A"
+                    }
+                ],
+                localHash: CLOSE_DIFF_HASH,
+                name: "Test",
+                hashMode: "set-symbol"
+            });
+            sandbox.stub(hasher.dependencies, "createDirectory").resolves("/tmp/remote-hash-dir");
+            sandbox.stub(hasher, "_hashRemoteSetSymbol").resolves(FAKE_HASH);
+            let finishCleanup;
+            const cleanup = sandbox.stub(hasher.dependencies, "cleanUpFiles").returns(
+                new Promise((resolve) => {
+                    finishCleanup = resolve;
+                })
+            );
+            let settled = false;
+
+            const comparison = hasher.compareRemoteImages().finally(() => {
+                settled = true;
+            });
+            while (!cleanup.called) {
+                await new Promise((resolve) => setImmediate(resolve));
+            }
+
+            assert.isFalse(settled);
+            finishCleanup();
+            await comparison;
+            assert.isTrue(settled);
+        });
+
+        it("does not mask a remote hash error when cleanup also fails", async () => {
+            const primaryError = new Error("remote hash failed");
+            const error = sandbox.stub();
+            const hasher = ProcessHashes.create({
+                cards: [
+                    {
+                        image_uris: { normal: "https://example.test/card.jpg" },
+                        set_name: "SET_A"
+                    }
+                ],
+                localHash: CLOSE_DIFF_HASH,
+                name: "Test",
+                hashMode: "set-symbol",
+                logger: { info: sandbox.stub(), error }
+            });
+            sandbox.stub(hasher.dependencies, "createDirectory").resolves("/tmp/remote-hash-dir");
+            sandbox.stub(hasher, "_hashRemoteForComparison").rejects(primaryError);
+            sandbox.stub(hasher.dependencies, "cleanUpFiles").rejects(new Error("cleanup failed"));
+
+            let caughtError;
+            try {
+                await hasher.compareRemoteImages();
+            } catch (err) {
+                caughtError = err;
+            }
+
+            assert.equal(caughtError, primaryError);
+            assert.isTrue(error.calledWithMatch(sinon.match(/cleanup failed/)));
         });
 
         // Scryfall's image CDN 400s a header-less request; jimp's own URL loader sends none by

--- a/test/fixtures/scan-lifecycle-child.mjs
+++ b/test/fixtures/scan-lifecycle-child.mjs
@@ -1,0 +1,96 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { run } from "../../index.mjs";
+import processorModule from "../../src/processor/index.mjs";
+import storage from "../../src/storage/index.mjs";
+
+const [, , mode, root, inputPath] = process.argv;
+const scanDirectory = path.join(root, "scan-temp");
+
+const fileIO = {
+    async createDirectory() {
+        await mkdir(scanDirectory);
+        await writeFile(path.join(scanDirectory, "ocr-snippet.txt"), "temporary OCR data");
+        return scanDirectory;
+    },
+    cleanUpFiles(directory) {
+        return rm(directory, { recursive: true, force: true });
+    }
+};
+
+const imageProcessor = {
+    create({ directory }) {
+        return {
+            imagePath: path.join(directory, "name.png"),
+            extract(callback) {
+                callback(null, {
+                    cleanText: "Pacifism",
+                    dirtyText: "Pacifism",
+                    textCandidates: ["Pacifism"]
+                });
+            }
+        };
+    }
+};
+
+const matchName = {
+    create() {
+        return {
+            matchedText: "Pacifism",
+            async match() {
+                return [{ name: "Pacifism", percentage: 1 }];
+            }
+        };
+    }
+};
+
+const matchProcessor = {
+    create() {
+        return {
+            matchResultDetails: [],
+            async executeAsync() {
+                if (mode === "failure") {
+                    throw new Error("fixture matching failure");
+                }
+                await storage.hashes.upsert({
+                    cardName: "Pacifism",
+                    setName: "Core Set 2020",
+                    cardHash: "fixture-hash",
+                    hashMode: "full-card"
+                });
+                return ["Core Set 2020"];
+            }
+        };
+    }
+};
+
+await run({
+    argv: ["scan", inputPath],
+    commanderFactory: async () => ({
+        command: "scan",
+        filePath: inputPath,
+        flags: {
+            cardNamesDb: root,
+            cardHashDb: root,
+            query: false,
+            pretty: false,
+            enableCollection: false,
+            debug: false,
+            localCache: true,
+            _localCacheExplicit: true
+        }
+    }),
+    processorFactory: (params) =>
+        processorModule.Processor.create({
+            ...params,
+            dependencies: {
+                imageProcessor,
+                fileIO,
+                matchName,
+                matchProcessor,
+                storage
+            }
+        }),
+    ocrShutdown: async () => {},
+    exit: (code) => process.exit(code)
+});

--- a/test/matcher/matching-processor.spec.mjs
+++ b/test/matcher/matching-processor.spec.mjs
@@ -222,4 +222,69 @@ describe("MatcherProcessor::", () => {
             done();
         });
     });
+
+    it("awaits local set-symbol cleanup before comparing hashes", async () => {
+        const processHashesInstance = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().resolves([{ setName: "M21" }])
+        };
+        sandbox.stub(dependencies, "searchPrintings").resolves([
+            { set_name: "M21", image_uris: { normal: "https://example.com/m21.jpg" } },
+            { set_name: "M20", image_uris: { normal: "https://example.com/m20.jpg" } }
+        ]);
+        sandbox.stub(dependencies, "hashImage").resolves("FAKE_LOCAL_HASH");
+        sandbox.stub(dependencies, "createDirectory").resolves("/tmp/set-symbol-dir");
+        sandbox
+            .stub(dependencies, "writeSetSymbolSnippet")
+            .resolves("/tmp/set-symbol-dir/set-symbol.png");
+        let finishCleanup;
+        const cleanup = sandbox.stub(dependencies, "cleanUpFiles").returns(
+            new Promise((resolve) => {
+                finishCleanup = resolve;
+            })
+        );
+        const processHashesStub = sandbox
+            .stub(dependencies.processHashes, "create")
+            .returns(processHashesInstance);
+        const processor = create({ name: "Pacifism", filePath: "/tmp/pacifism.jpg" });
+
+        const execution = processor.executeAsync();
+        while (!cleanup.called) {
+            await new Promise((resolve) => setImmediate(resolve));
+        }
+
+        assert.isFalse(processHashesStub.called);
+        finishCleanup();
+        const result = await execution;
+        assert.deepEqual(result, ["M21"]);
+        assert.isTrue(processHashesStub.calledOnce);
+    });
+
+    it("does not mask a full-card hash error when set-symbol cleanup also fails", async () => {
+        const primaryError = new Error("full hash failed");
+        const error = sandbox.stub();
+        sandbox.stub(dependencies, "searchPrintings").resolves([
+            { set_name: "M21", image_uris: { normal: "https://example.com/m21.jpg" } },
+            { set_name: "M20", image_uris: { normal: "https://example.com/m20.jpg" } }
+        ]);
+        sandbox.stub(dependencies, "createDirectory").resolves("/tmp/set-symbol-dir");
+        sandbox.stub(dependencies, "writeSetSymbolSnippet").rejects(new Error("crop failed"));
+        sandbox.stub(dependencies, "cleanUpFiles").rejects(new Error("cleanup failed"));
+        sandbox.stub(dependencies, "hashImage").rejects(primaryError);
+        const processor = create({
+            name: "Pacifism",
+            filePath: "/tmp/pacifism.jpg",
+            logger: { info: sandbox.stub(), error }
+        });
+
+        let caughtError;
+        try {
+            await processor.executeAsync();
+        } catch (err) {
+            caughtError = err;
+        }
+
+        assert.equal(caughtError, primaryError);
+        assert.isTrue(error.calledWithMatch(sinon.match(/cleanup failed/)));
+    });
 });

--- a/test/processing/processor.spec.mjs
+++ b/test/processing/processor.spec.mjs
@@ -36,6 +36,7 @@ describe("Integration::", () => {
                 dirtyText: EXTRACTED_TEXT
             });
         stubs.CreateDirectoryStub = sandbox.stub().resolves(DIR);
+        stubs.CleanUpFilesStub = sandbox.stub().resolves();
         stubs.MatchNameCreateStub = sandbox.stub().returns(MatchNameInstance);
         stubs.MatchNameMatchStub = sandbox.stub(MatchNameInstance, "match").resolves([
             {
@@ -49,7 +50,7 @@ describe("Integration::", () => {
             .resolves([COLLECTION_NAME]); //Empty right now and will have to be a multi call oen since in async.each
         stubs.NeedsAttentionInsertStub = sandbox.stub().resolves(null);
         stubs.CollectionInsertStub = sandbox.stub().resolves(null);
-        stubs.logRecordStub = sandbox.stub();
+        stubs.logRecordStub = sandbox.stub().resolves();
         stubs.GetAdditionalCardInfoStub = sandbox.stub().resolves({
             object: "card",
             id: "31279d7c-5246-40b2-a8c7-0be4a5f24a29",
@@ -159,14 +160,18 @@ describe("Integration::", () => {
             }
         });
         stubs.Base64Stub = sandbox.stub().resolves(NAME_BASE_64);
+        stubs.NeedsAttentionCreateStub = sandbox
+            .stub()
+            .returns({ insert: stubs.NeedsAttentionInsertStub });
         dependencies = {
             imageProcessor: { create: stubs.ImageProcessorCreateStub },
-            fileIO: { createDirectory: stubs.CreateDirectoryStub },
+            fileIO: {
+                createDirectory: stubs.CreateDirectoryStub,
+                cleanUpFiles: stubs.CleanUpFilesStub
+            },
             matchName: { create: stubs.MatchNameCreateStub },
             matchProcessor: { create: stubs.MatchProcessorCreateStub },
-            needsAttention: {
-                create: sandbox.stub().returns({ insert: stubs.NeedsAttentionInsertStub })
-            },
+            needsAttention: { create: stubs.NeedsAttentionCreateStub },
             collection: {
                 create: sandbox.stub().returns({ insert: stubs.CollectionInsertStub })
             },
@@ -189,7 +194,8 @@ describe("Integration::", () => {
                 assert.isTrue(stubs.ImageProcessorCreateStub.calledOnce);
                 assert.isTrue(stubs.ImageProcessorExtractStub.calledOnce);
                 assert.isTrue(stubs.CreateDirectoryStub.calledOnce);
-                assert.deepEqual(processorInstance.directory, DIR);
+                assert.isTrue(stubs.CleanUpFilesStub.calledOnceWithExactly(DIR));
+                assert.equal(processorInstance.directory, "");
                 assert.isTrue(stubs.MatchNameCreateStub.calledOnce);
                 assert.isTrue(stubs.MatchNameMatchStub.calledOnce);
                 assert.isTrue(stubs.MatchProcessorCreateStub.calledOnce);
@@ -230,7 +236,8 @@ describe("Integration::", () => {
             });
             processorInstance.execute((err) => {
                 assert.isTrue(stubs.CreateDirectoryStub.calledOnce);
-                assert.deepEqual(processorInstance.directory, DIR);
+                assert.isTrue(stubs.CleanUpFilesStub.calledOnceWithExactly(DIR));
+                assert.equal(processorInstance.directory, "");
                 assert.isTrue(stubs.ImageProcessorCreateStub.calledOnce);
                 assert.isTrue(stubs.ImageProcessorExtractStub.calledOnce);
                 assert.isTrue(stubs.MatchNameCreateStub.calledOnce);
@@ -251,7 +258,8 @@ describe("Integration::", () => {
             });
             processorInstance.execute((err) => {
                 assert.isTrue(stubs.CreateDirectoryStub.calledOnce);
-                assert.deepEqual(processorInstance.directory, DIR);
+                assert.isTrue(stubs.CleanUpFilesStub.calledOnceWithExactly(DIR));
+                assert.equal(processorInstance.directory, "");
                 assert.equal(stubs.ImageProcessorCreateStub.callCount, 4);
                 assert.equal(stubs.ImageProcessorExtractStub.callCount, 4);
                 assert.deepEqual(
@@ -279,6 +287,42 @@ describe("Integration::", () => {
             assert.isTrue(stubs.ImageProcessorExtractStub.calledOnce);
             assert.isTrue(stubs.MatchProcessorExecuteStub.calledOnce);
             assert.isTrue(stubs.CollectionInsertStub.calledOnce);
+            assert.isTrue(stubs.CleanUpFilesStub.calledOnceWithExactly(DIR));
+        });
+
+        it("routes one name with multiple possible sets to needs attention", async () => {
+            stubs.MatchProcessorExecuteStub.resolves([COLLECTION_NAME, COLLECTION_NAME_TWO]);
+            const processorInstance = createProcessor({
+                filePath: FAKE_PATH,
+                queryingEnabled: true,
+                collectionEnabled: true
+            });
+
+            await processorInstance.execute();
+
+            assert.equal(processorInstance.decision, "needs-attention");
+            assert.isFalse(stubs.CollectionInsertStub.called);
+            assert.isFalse(stubs.GetAdditionalCardInfoStub.called);
+            assert.isTrue(stubs.NeedsAttentionInsertStub.calledOnce);
+            assert.deepInclude(stubs.NeedsAttentionCreateStub.firstCall.args[0], {
+                cardName: "Pacifism",
+                possibleSets: `${COLLECTION_NAME},${COLLECTION_NAME_TWO}`
+            });
+        });
+
+        it("keeps an ambiguous printing result non-persistent during a dry run", async () => {
+            stubs.MatchProcessorExecuteStub.resolves([COLLECTION_NAME, COLLECTION_NAME_TWO]);
+            const processorInstance = createProcessor({
+                filePath: FAKE_PATH,
+                queryingEnabled: false,
+                collectionEnabled: true
+            });
+
+            await processorInstance.execute();
+
+            assert.equal(processorInstance.decision, "dry-run");
+            assert.isFalse(stubs.CollectionInsertStub.called);
+            assert.isFalse(stubs.NeedsAttentionInsertStub.called);
         });
 
         it("skips collection persistence when --query is on but the module is disabled", async () => {
@@ -341,6 +385,80 @@ describe("Integration::", () => {
             assert.equal(caughtError, expectedError);
             assert.isFalse(stubs.CollectionInsertStub.calledOnce);
             assert.isFalse(stubs.NeedsAttentionInsertStub.calledOnce);
+            assert.isTrue(stubs.CleanUpFilesStub.calledOnceWithExactly(DIR));
+        });
+
+        it("awaits temporary cleanup before resolving", async () => {
+            let finishCleanup;
+            stubs.CleanUpFilesStub.returns(
+                new Promise((resolve) => {
+                    finishCleanup = resolve;
+                })
+            );
+            const processorInstance = createProcessor({ filePath: FAKE_PATH });
+            let settled = false;
+
+            const execution = processorInstance.execute().finally(() => {
+                settled = true;
+            });
+            while (!stubs.CleanUpFilesStub.called) {
+                await new Promise((resolve) => setImmediate(resolve));
+            }
+
+            assert.isFalse(settled);
+            finishCleanup();
+            await execution;
+            assert.isTrue(settled);
+        });
+
+        it("awaits the operations-log write before cleanup and resolution", async () => {
+            let finishLogWrite;
+            stubs.logRecordStub.returns(
+                new Promise((resolve) => {
+                    finishLogWrite = resolve;
+                })
+            );
+            const processorInstance = createProcessor({ filePath: FAKE_PATH });
+            let settled = false;
+
+            const execution = processorInstance.execute().finally(() => {
+                settled = true;
+            });
+            while (!stubs.logRecordStub.called) {
+                await new Promise((resolve) => setImmediate(resolve));
+            }
+
+            assert.isFalse(settled);
+            assert.isFalse(stubs.CleanUpFilesStub.called);
+            finishLogWrite();
+            await execution;
+            assert.isTrue(stubs.CleanUpFilesStub.calledOnceWithExactly(DIR));
+            assert.isTrue(settled);
+        });
+
+        it("does not replace the primary scan error when cleanup fails", async () => {
+            const primaryError = new Error("failed to match");
+            stubs.MatchProcessorExecuteStub.rejects(primaryError);
+            stubs.CleanUpFilesStub.rejects(new Error("cleanup failed"));
+            const error = sandbox.stub();
+            const processorInstance = createProcessor({
+                filePath: FAKE_PATH,
+                logger: {
+                    info: sandbox.stub(),
+                    error,
+                    output: sandbox.stub()
+                }
+            });
+
+            let caughtError;
+            try {
+                await processorInstance.execute();
+            } catch (err) {
+                caughtError = err;
+            }
+
+            assert.equal(caughtError, primaryError);
+            assert.isTrue(error.calledWithMatch(sinon.match(/cleanup failed/)));
         });
 
         it("logs only name/sets per matcher result when debugLogging is off (default)", (done) => {


### PR DESCRIPTION
## Summary

- make scan cache and operations-log writes durable across CLI process exit
- remove OCR and set-symbol temporary directories on both success and failure
- route ambiguous printing matches to needs-attention instead of confirmed collection data

## Root Cause

The cache and operations-log storage wrappers discarded their persistence promises, and their
callers completed before NeDB writes necessarily reached disk. Processor and hashing cleanup paths
also launched asynchronous removal without awaiting it, while the top-level processor never removed
its OCR work directory. Finally, collection routing treated one matched card name as confirmed even
when that name still had multiple possible printing sets.

## What Changed

- return and await card-hash and operations-log persistence promises
- await backfill hash upserts and report failed writes truthfully
- await processor, local set-symbol, and remote-hash cleanup in `finally` paths
- log cleanup failures without replacing the primary scan error
- require exactly one card name and one printing set before collection persistence
- preserve dry-run and separate `--query` / `--enable-collection` opt-in contracts
- add child-process CLI tests that inspect NeDB data and temporary directories after exit
- document lifecycle completion and ambiguous-print handling

## Validation

- `pnpm check:fast`
- `pnpm test` — 420 passing
- `pnpm coverage:check` — 93.01% statements/lines, 92.9% functions, 78.73% branches
- `pnpm test:regression` — 156/158 overall; 151/151 blocking fixtures passed, with two known non-blocking misses

## Scope Notes

- no dependency, regression expectation, or image-fixture changes
- cache failures remain non-fatal to otherwise valid scans
- based on `origin/master` at `e39009e`
