### PR TITLE
Fix card-name seeding and index health checks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,9 +38,11 @@ node index.mjs scan ./test-images/PlatinumAngel.jpg
 ```
 
 The setup script installs dependencies, creates local configuration files without overwriting
-existing ones, and seeds the card-name index. On later runs, pass `--skip-seed` if the index is
-already populated: the current seeder appends the Scryfall catalog and can create duplicate name
-rows. Setup does not start MySQL unless you explicitly pass `--with-mysql`.
+existing ones, and seeds the card-name index. Seeding is safe to repeat: it applies the same
+normalization contract used by matching, rejects unmatchable catalog entries, and repairs invalid
+or duplicate rows while upserting names. A required seed failure makes setup exit nonzero; use
+`--skip-seed` only when diagnostics already reports a healthy index. Setup does not start MySQL
+unless you explicitly pass `--with-mysql`.
 
 If the scan does not complete, check the environment before digging into individual settings:
 

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -34,8 +34,9 @@ node scripts/verify-env.mjs --with-mysql # also checks the MySQL connection
 
 The setup script itself is deliberately dependency-free (only core Node modules), so it can run
 before `pnpm install` has succeeded on a fresh clone. Configuration creation is non-clobbering, but
-installation and seeding repeat unless skipped. After a successful seed, use `--skip-seed` on later
-runs because the current seeder appends the catalog and can create duplicate name rows.
+installation and seeding repeat unless skipped. Seeding is idempotent, so rerunning setup updates
+the existing index without duplicating it. Use `--skip-seed` only when
+`node scripts/verify-env.mjs` already reports a healthy card-name index.
 
 | Step               | What happens                                                                                            |
 | ------------------ | ------------------------------------------------------------------------------------------------------- |
@@ -48,8 +49,11 @@ runs because the current seeder appends the catalog and can create duplicate nam
 
 Flags compose: `node scripts/setup.mjs --with-mysql --skip-seed` skips seeding but still sets up MySQL.
 
-Name seeding prints one start summary and one completion summary. Inserts run with bounded
-concurrency, so large Scryfall catalogs do not create an unbounded burst of database work.
+Name seeding prints one start summary and one completion summary. It validates names with the same
+normalization used by matching, skips upstream names that cannot produce a match key, deduplicates
+the catalog, repairs existing invalid/duplicate rows, and upserts with bounded concurrency. An
+empty or entirely unmatchable catalog is a failure. Because scans require the local name index,
+setup exits nonzero when the required seed fails.
 
 With `--with-mysql`, the generated `secure.config.cjs` matches `docker-compose.yml`'s actual defaults (host/port/user/password/database) so `pnpm setup-db` works immediately — it does **not** just copy the generic template (which has placeholder values and would fail to connect).
 
@@ -106,7 +110,10 @@ node scripts/verify-env.mjs
 ```
 
 **`node scripts/setup.mjs` fails at the seed step**
-Almost always no network access to Scryfall. The script won't hard-fail over it — re-run `node ./src/db-local/bulk-insert.mjs` once you have network.
+The Scryfall request failed or returned no matchable catalog names. Setup exits nonzero because
+scans cannot work without the name index. Restore network/catalog access and rerun setup, or run
+`node ./src/db-local/bulk-insert.mjs` directly. Use `--skip-seed` only if diagnostics confirms an
+already healthy index.
 
 **`--with-mysql` fails at "Waiting for MySQL to become healthy"**
 Docker isn't running, or the container crashed. Check `pnpm docker:logs`. `docker compose ps` shows container status.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -104,8 +104,10 @@ Diagnostics prints JSON containing application, Node.js, and platform versions; 
 checks; active configuration; and recent operations. It includes local config/database paths,
 source-image paths, OCR text, and scan details, so review the output before sharing it. The bundle
 never includes MySQL credentials. With `--with-mysql`, the connection layer reads them only to
-perform the requested connection check. MySQL connection failures and an empty card-name index are
-reported as warnings; the command exits non-zero only when a required environment check fails.
+perform the requested connection check. Card-name diagnostics report total, valid, unique,
+invalid, and duplicate row counts. An empty, entirely invalid, or implausibly small name index is a
+required failure and makes the command exit nonzero; repairable invalid/duplicate rows in an
+otherwise usable index are warnings. MySQL connection failures remain optional warnings.
 
 Options:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,12 @@ the hash cache should live somewhere else.
 Disabling the local cache turns off the image-hash cache and operations log. It does not disable
 the card-name index, which is required for matching and has no remote fallback.
 
+The card-name seeder stores a normalized key beside each canonical name. Rerunning it is
+idempotent: catalog entries are validated with the matching normalization contract, duplicate and
+invalid legacy rows are removed, and remaining names are upserted. `diagnostics` reports the
+index's total, valid, unique, invalid, and duplicate row counts rather than treating any non-empty
+file as healthy.
+
 See [Architecture](architecture.md#storage-boundaries) for the difference between cache and
 persistence data.
 

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -146,13 +146,18 @@ if (!flags.skipSeed) {
         const ok = run("node", ["./src/db-local/bulk-insert.mjs"]);
         if (!ok) {
             console.warn(
-                "  ⚠ Seeding failed (likely no network access). Run `node ./src/db-local/bulk-insert.mjs` yourself later."
+                "  ✗ Required card-name seed failed. Scans will not work until seeding succeeds; fix the reported catalog/network error and rerun setup."
             );
         }
-        return true; // never hard-fail setup over a network hiccup
+        return ok;
     });
 } else {
-    step("Skipping name-seed step (--skip-seed)", () => true);
+    step("Skipping name-seed step (--skip-seed)", () => {
+        console.warn(
+            "  ⚠ Seed skipped. This is safe only when diagnostics already reports a healthy card-name index."
+        );
+        return true;
+    });
 }
 
 if (flags.withMysql) {

--- a/scripts/verify-env.mjs
+++ b/scripts/verify-env.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Sanity-checks the local dev environment: is everything actually usable, not just present.
 // Run after scripts/setup.mjs, or any time something feels broken. Exits 1 if a required
-// check fails; optional checks (MySQL, seeded names) only warn.
+// check fails. An unusable required name index fails; optional MySQL checks and repairable
+// name-index corruption only warn.
 //
 // Thin CLI wrapper around src/diagnostics/env-check.mjs, which also backs
 // `node index.mjs diagnostics`. Usage: node scripts/verify-env.mjs [--with-mysql]

--- a/src/db-local/bulk-insert.mjs
+++ b/src/db-local/bulk-insert.mjs
@@ -5,20 +5,36 @@ import { seedCardNames } from "./seed-card-names.mjs";
 
 const { getCardNames } = scryfallApi;
 
-function insertStoredName(name) {
-    return db.insert({ name });
+function getStoredNames() {
+    return db.find({});
+}
+
+function upsertStoredName({ name, normalizedName, existingRecord }) {
+    const query = existingRecord?._id ? { _id: existingRecord._id } : { normalizedName };
+    return db.update(query, { $set: { name, normalizedName } }, { upsert: !existingRecord });
+}
+
+function removeStoredName(record) {
+    if (!record?._id) {
+        throw new Error("Stored card-name row is missing its database identifier");
+    }
+    return db.remove({ _id: record._id }, {});
 }
 
 async function executeBulkInsert(options = {}) {
     const {
         getCardNames: fetchCardNames = getCardNames,
-        insertName = insertStoredName,
+        getStoredNames: readStoredNames = getStoredNames,
+        upsertName = upsertStoredName,
+        removeName = removeStoredName,
         logger = console,
         concurrency
     } = options;
     return seedCardNames({
         getCardNames: fetchCardNames,
-        insertName,
+        getStoredNames: readStoredNames,
+        upsertName,
+        removeName,
         logger,
         concurrency
     });
@@ -26,13 +42,20 @@ async function executeBulkInsert(options = {}) {
 
 const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isDirectRun) {
-    executeBulkInsert().catch((error) => {
-        console.error(`Card-name seed failed: ${error?.message || String(error)}`);
-        process.exitCode = 1;
-    });
+    process.exitCode = await runBulkInsertCli();
 }
 
-export { executeBulkInsert };
+async function runBulkInsertCli({ execute = executeBulkInsert, logger = console } = {}) {
+    try {
+        await execute();
+        return 0;
+    } catch (error) {
+        logger.error(`Card-name seed failed: ${error?.message || String(error)}`);
+        return 1;
+    }
+}
+
+export { executeBulkInsert, runBulkInsertCli };
 
 export default {
     executeBulkInsert

--- a/src/db-local/db.mjs
+++ b/src/db-local/db.mjs
@@ -6,9 +6,12 @@ function resolveDbFilename() {
     return resolvePath(getConfig().cardNamesDbPath, "cardNames.db");
 }
 
-const { find, insert, count } = createNedbStore({ resolveFilename: resolveDbFilename });
+const { find, insert, update, remove, count } = createNedbStore({
+    resolveFilename: resolveDbFilename,
+    indexes: [{ fieldName: "normalizedName" }]
+});
 
-const db = { find, insert, count };
+const db = { find, insert, update, remove, count };
 
 export { db, resolveDbFilename };
 

--- a/src/db-local/seed-card-names.mjs
+++ b/src/db-local/seed-card-names.mjs
@@ -1,37 +1,123 @@
+import { normalizeForMatch } from "../fuzzy-matching/name-index.mjs";
+
 const DEFAULT_CONCURRENCY = 8;
 const MAX_CONCURRENCY = 32;
 
 async function seedCardNames({
     getCardNames,
-    insertName,
+    getStoredNames,
+    upsertName,
+    removeName,
     logger = console,
     concurrency = DEFAULT_CONCURRENCY
 }) {
-    const names = await getCardNames();
-    if (!Array.isArray(names)) {
+    const rawNames = await getCardNames();
+    if (!Array.isArray(rawNames)) {
         throw new Error("Scryfall card-name response must be an array");
     }
-    if (names.some((name) => typeof name !== "string" || !name.trim())) {
-        throw new Error("Scryfall card names must be non-empty strings");
-    }
-    if (names.length === 0) {
-        logger.log("No card names returned; nothing to seed.");
-        return { inserted: 0 };
+    const catalog = prepareCatalog(rawNames);
+    if (catalog.namesByNormalized.size === 0) {
+        throw new Error("Scryfall card-name catalog contains no matchable names");
     }
 
-    logger.log(`Seeding ${names.length} card names...`);
-    const workerCount = Math.min(names.length, normalizeConcurrency(concurrency));
+    const storedNames = await getStoredNames();
+    if (!Array.isArray(storedNames)) {
+        throw new Error("Stored card-name response must be an array");
+    }
+    const stored = prepareStoredRecords(storedNames);
+
+    logger.log(
+        `Seeding ${catalog.namesByNormalized.size} matchable card names (${catalog.rejected} rejected, ${catalog.duplicates} duplicate catalog entries)...`
+    );
+
+    await runBounded(stored.recordsToRemove, concurrency, removeName);
+
+    const writes = [];
+    for (const [normalizedName, existingRecord] of stored.recordByNormalized) {
+        if (!catalog.namesByNormalized.has(normalizedName)) {
+            const name = existingRecord.name.trim();
+            if (existingRecord.name !== name || existingRecord.normalizedName !== normalizedName) {
+                writes.push({ name, normalizedName, existingRecord, kind: "updated" });
+            }
+        }
+    }
+    for (const [normalizedName, name] of catalog.namesByNormalized) {
+        const existingRecord = stored.recordByNormalized.get(normalizedName);
+        if (!existingRecord) {
+            writes.push({ name, normalizedName, kind: "inserted" });
+        } else if (
+            existingRecord.name !== name ||
+            existingRecord.normalizedName !== normalizedName
+        ) {
+            writes.push({ name, normalizedName, existingRecord, kind: "updated" });
+        }
+    }
+    await runBounded(writes, concurrency, upsertName);
+
+    const inserted = writes.filter((write) => write.kind === "inserted").length;
+    const updated = writes.length - inserted;
+    const result = {
+        fetched: rawNames.length,
+        accepted: catalog.namesByNormalized.size,
+        rejected: catalog.rejected,
+        catalogDuplicates: catalog.duplicates,
+        inserted,
+        updated,
+        removed: stored.recordsToRemove.length,
+        unchanged: stored.recordByNormalized.size - updated
+    };
+    logger.log(
+        `Card-name seed complete: ${inserted} inserted, ${updated} updated, ${result.removed} invalid/duplicate rows removed, ${result.unchanged} unchanged.`
+    );
+    return result;
+}
+
+function prepareCatalog(names) {
+    const namesByNormalized = new Map();
+    let rejected = 0;
+    let duplicates = 0;
+    for (const value of names) {
+        const normalizedName = typeof value === "string" ? normalizeForMatch(value) : "";
+        if (!normalizedName) {
+            rejected += 1;
+            continue;
+        }
+        if (namesByNormalized.has(normalizedName)) {
+            duplicates += 1;
+            continue;
+        }
+        namesByNormalized.set(normalizedName, value.trim());
+    }
+    return { namesByNormalized, rejected, duplicates };
+}
+
+function prepareStoredRecords(records) {
+    const recordByNormalized = new Map();
+    const recordsToRemove = [];
+    for (const record of records) {
+        const normalizedName =
+            typeof record?.name === "string" ? normalizeForMatch(record.name) : "";
+        if (!normalizedName || recordByNormalized.has(normalizedName)) {
+            recordsToRemove.push(record);
+            continue;
+        }
+        recordByNormalized.set(normalizedName, record);
+    }
+    return { recordByNormalized, recordsToRemove };
+}
+
+async function runBounded(items, concurrency, operation) {
+    if (items.length === 0) return;
+    const workerCount = Math.min(items.length, normalizeConcurrency(concurrency));
     let nextIndex = 0;
     const workers = Array.from({ length: workerCount }, async () => {
-        while (nextIndex < names.length) {
+        while (nextIndex < items.length) {
             const index = nextIndex;
             nextIndex += 1;
-            await insertName(names[index]);
+            await operation(items[index]);
         }
     });
     await Promise.all(workers);
-    logger.log(`Seeded ${names.length} card names.`);
-    return { inserted: names.length };
 }
 
 function normalizeConcurrency(value) {
@@ -42,6 +128,6 @@ function normalizeConcurrency(value) {
     return Math.min(parsed, MAX_CONCURRENCY);
 }
 
-export { seedCardNames };
+export { prepareCatalog, prepareStoredRecords, seedCardNames };
 
 export default seedCardNames;

--- a/src/diagnostics/env-check.mjs
+++ b/src/diagnostics/env-check.mjs
@@ -7,10 +7,12 @@ import {
     DEFAULT_OCR_MODEL_PATH,
     DEFAULT_OCR_MODEL_SHA256
 } from "../image-analysis/ocr-model.mjs";
+import { analyzeNameRecords } from "../fuzzy-matching/name-index.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.join(__dirname, "../..");
 const unsupportedOcrParameters = ["enable_new_segsearch", "save_raw_choices"];
+const MIN_USABLE_CARD_NAMES = 1000;
 
 function findUnsupportedOcrParameters(model) {
     return unsupportedOcrParameters.filter((parameter) => model.includes(Buffer.from(parameter)));
@@ -53,6 +55,33 @@ function checkDefaultOcrModel() {
     };
 }
 
+function evaluateCardNameIndex(records) {
+    const health = analyzeNameRecords(records);
+    const counts = `${health.uniqueNames} unique matchable names, ${health.invalidRows} invalid rows, ${health.duplicateRows} duplicate rows`;
+    if (health.uniqueNames < MIN_USABLE_CARD_NAMES) {
+        return {
+            health,
+            label: `card names DB is unusable (${counts}; expected at least ${MIN_USABLE_CARD_NAMES}) -- run \`node ./src/db-local/bulk-insert.mjs\` to repair it`,
+            status: "fail",
+            required: true
+        };
+    }
+    if (health.invalidRows > 0 || health.duplicateRows > 0) {
+        return {
+            health,
+            label: `card names DB needs repair (${counts}) -- rerun \`node ./src/db-local/bulk-insert.mjs\``,
+            status: "fail",
+            required: false
+        };
+    }
+    return {
+        health,
+        label: `card names DB healthy (${health.uniqueNames} unique matchable names)`,
+        status: "pass",
+        required: true
+    };
+}
+
 // Sanity-checks the environment is actually usable, not just "file exists". Shared by
 // scripts/verify-env.mjs (dev setup) and `node index.mjs diagnostics` (support bundle) --
 // one source of truth for what "is this environment healthy" means, printed differently by
@@ -64,6 +93,7 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
     const checks = [];
     let requiredFailures = 0;
     const warnings = [];
+    let cardNameIndex;
 
     function record(label, status, required = true) {
         checks.push({ label, status });
@@ -115,16 +145,10 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
         record(`local cache dir is writable (${dir})`, "pass");
 
         const { db: namesDb } = await import("../db-local/db.mjs");
-        const nameCount = await namesDb.count({});
-        if (nameCount > 0) {
-            record(`card names DB seeded (${nameCount} names)`, "pass");
-        } else {
-            record(
-                "card names DB is empty -- run `node ./src/db-local/bulk-insert.mjs` to seed it",
-                "fail",
-                false
-            );
-        }
+        const nameRecords = (await namesDb.find({})) || [];
+        const indexCheck = evaluateCardNameIndex(nameRecords);
+        cardNameIndex = indexCheck.health;
+        record(indexCheck.label, indexCheck.status, indexCheck.required);
     } catch (err) {
         record(`could not initialize local cache: ${err.message}`, "fail");
     }
@@ -149,9 +173,15 @@ async function runEnvironmentCheck({ withMysql = false } = {}) {
         }
     }
 
-    return { checks, requiredFailures, warnings };
+    return { checks, requiredFailures, warnings, cardNameIndex };
 }
 
-export { findUnsupportedOcrParameters, inspectDefaultOcrModel, runEnvironmentCheck };
+export {
+    MIN_USABLE_CARD_NAMES,
+    evaluateCardNameIndex,
+    findUnsupportedOcrParameters,
+    inspectDefaultOcrModel,
+    runEnvironmentCheck
+};
 
 export default { runEnvironmentCheck };

--- a/src/diagnostics/index.mjs
+++ b/src/diagnostics/index.mjs
@@ -11,7 +11,7 @@ const appVersion = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")).version;
 // and recent scan activity. Nothing sensitive in here -- secrets live only in
 // secure.config.cjs, which this never reads. `node index.mjs diagnostics`.
 async function gatherDiagnostics({ limit = 20, withMysql = false } = {}) {
-    const { checks, requiredFailures, warnings } = await runEnvironmentCheck({ withMysql });
+    const environment = await runEnvironmentCheck({ withMysql });
     const config = getConfig();
 
     const recentOperations = (await storage.log.dump({ limit })) || [];
@@ -24,7 +24,7 @@ async function gatherDiagnostics({ limit = 20, withMysql = false } = {}) {
             platform: process.platform,
             arch: process.arch
         },
-        environment: { checks, requiredFailures, warnings },
+        environment,
         // Everything in the resolved config is safe to share -- MySQL credentials live in
         // secure.config.cjs, a separate file this module never touches.
         config: {

--- a/src/fuzzy-matching/name-index.mjs
+++ b/src/fuzzy-matching/name-index.mjs
@@ -10,29 +10,56 @@ function nameAliases(name) {
     return [...new Set([name, ...String(name || "").split(/\s+\/\/\s+/g)])].filter(Boolean);
 }
 
-function assertNameRecords(names) {
+function assertNameRecordsArray(names) {
     if (!Array.isArray(names)) {
         throw new Error("Stored card names must be an array");
     }
-    names.forEach((record, index) => {
-        if (typeof record?.name !== "string" || !normalizeForMatch(record.name)) {
-            throw new Error(`Stored card name at index ${index} must contain a non-empty name`);
+}
+
+function analyzeNameRecords(names) {
+    assertNameRecordsArray(names);
+    const countsByNormalized = new Map();
+    let invalidRows = 0;
+
+    for (const record of names) {
+        const normalized = typeof record?.name === "string" ? normalizeForMatch(record.name) : "";
+        if (!normalized) {
+            invalidRows += 1;
+            continue;
         }
-    });
+        countsByNormalized.set(normalized, (countsByNormalized.get(normalized) || 0) + 1);
+    }
+
+    const duplicateRows = [...countsByNormalized.values()].reduce(
+        (total, count) => total + Math.max(0, count - 1),
+        0
+    );
+    return {
+        totalRows: names.length,
+        validRows: names.length - invalidRows,
+        uniqueNames: countsByNormalized.size,
+        invalidRows,
+        duplicateRows
+    };
 }
 
 function buildNameIndex(names) {
-    assertNameRecords(names);
+    assertNameRecordsArray(names);
+    const validRecords = names.filter(
+        (record) => typeof record?.name === "string" && normalizeForMatch(record.name)
+    );
     const canonicalNameByNormalized = new Map();
     const canonicalNames = new Set();
-    for (const record of names) {
+    for (const record of validRecords) {
         const normalized = normalizeForMatch(record.name);
         canonicalNames.add(normalized);
-        canonicalNameByNormalized.set(normalized, record.name);
+        if (!canonicalNameByNormalized.has(normalized)) {
+            canonicalNameByNormalized.set(normalized, record.name);
+        }
     }
 
     const aliasOwners = new Map();
-    for (const record of names) {
+    for (const record of validRecords) {
         for (const alias of nameAliases(record.name).slice(1)) {
             const normalizedAlias = normalizeForMatch(alias);
             const owners = aliasOwners.get(normalizedAlias) || new Set();
@@ -58,6 +85,6 @@ function uniqueNormalized(values) {
     return [...new Set(values.map(normalizeForMatch).filter(Boolean))];
 }
 
-export { buildNameIndex, normalizeForMatch, uniqueNormalized };
+export { analyzeNameRecords, buildNameIndex, normalizeForMatch, uniqueNormalized };
 
-export default { buildNameIndex, normalizeForMatch, uniqueNormalized };
+export default { analyzeNameRecords, buildNameIndex, normalizeForMatch, uniqueNormalized };

--- a/test/db-local/bulk-insert.spec.mjs
+++ b/test/db-local/bulk-insert.spec.mjs
@@ -1,23 +1,51 @@
 import { assert } from "chai";
 import sinon from "sinon";
-import { executeBulkInsert } from "../../src/db-local/bulk-insert.mjs";
+import { executeBulkInsert, runBulkInsertCli } from "../../src/db-local/bulk-insert.mjs";
 
 describe("db-local::bulk-insert", () => {
     it("seeds names through injected boundaries", async () => {
-        const insertName = sinon.stub().resolves();
+        const upsertName = sinon.stub().resolves();
         const logger = { log: sinon.stub() };
 
         const result = await executeBulkInsert({
             getCardNames: async () => ["Pacifism", "Fireball"],
-            insertName,
+            getStoredNames: async () => [],
+            upsertName,
+            removeName: sinon.stub().resolves(),
             logger,
             concurrency: 1
         });
 
-        assert.deepEqual(result, { inserted: 2 });
+        assert.deepEqual(result, {
+            fetched: 2,
+            accepted: 2,
+            rejected: 0,
+            catalogDuplicates: 0,
+            inserted: 2,
+            updated: 0,
+            removed: 0,
+            unchanged: 0
+        });
         assert.deepEqual(
-            insertName.getCalls().map((call) => call.args[0]),
-            ["Pacifism", "Fireball"]
+            upsertName.getCalls().map((call) => call.args[0]),
+            [
+                { name: "Pacifism", normalizedName: "PACIFISM", kind: "inserted" },
+                { name: "Fireball", normalizedName: "FIREBALL", kind: "inserted" }
+            ]
+        );
+    });
+
+    it("returns nonzero and reports catalog failures from the CLI boundary", async () => {
+        const logger = { error: sinon.stub() };
+
+        const exitCode = await runBulkInsertCli({
+            execute: sinon.stub().rejects(new Error("catalog unavailable")),
+            logger
+        });
+
+        assert.equal(exitCode, 1);
+        assert.isTrue(
+            logger.error.calledOnceWithExactly("Card-name seed failed: catalog unavailable")
         );
     });
 });

--- a/test/db-local/seed-card-names.spec.mjs
+++ b/test/db-local/seed-card-names.spec.mjs
@@ -2,49 +2,144 @@ import { assert } from "chai";
 import sinon from "sinon";
 import { seedCardNames } from "../../src/db-local/seed-card-names.mjs";
 
+function createMemoryStore(initialRows = []) {
+    let nextId = 100;
+    const rows = initialRows.map((row) => ({ ...row }));
+    return {
+        rows,
+        getStoredNames: async () => rows.map((row) => ({ ...row })),
+        upsertName: async ({ name, normalizedName, existingRecord }) => {
+            const existing = existingRecord
+                ? rows.find((row) => row._id === existingRecord._id)
+                : rows.find((row) => row.normalizedName === normalizedName);
+            if (existing) {
+                Object.assign(existing, { name, normalizedName });
+            } else {
+                rows.push({ _id: String(nextId++), name, normalizedName });
+            }
+        },
+        removeName: async (record) => {
+            const index = rows.findIndex((row) => row._id === record._id);
+            if (index >= 0) rows.splice(index, 1);
+        }
+    };
+}
+
 describe("db-local::seed-card-names", () => {
-    it("inserts every name with bounded concurrency and summary output", async () => {
+    it("upserts every matchable name with bounded concurrency and summary output", async () => {
         let active = 0;
         let maxActive = 0;
-        const inserted = [];
+        const writes = [];
         const logger = { log: sinon.stub() };
-        const insertName = async (name) => {
+        const upsertName = async (write) => {
             active += 1;
             maxActive = Math.max(maxActive, active);
             await new Promise((resolve) => setImmediate(resolve));
-            inserted.push(name);
+            writes.push(write);
             active -= 1;
         };
 
         const result = await seedCardNames({
             getCardNames: async () => ["Pacifism", "Fireball", "Unsummon", "Shivan Dragon"],
-            insertName,
+            getStoredNames: async () => [],
+            upsertName,
+            removeName: sinon.stub().resolves(),
             logger,
             concurrency: 2
         });
 
-        assert.sameMembers(inserted, ["Pacifism", "Fireball", "Unsummon", "Shivan Dragon"]);
+        assert.sameMembers(
+            writes.map((write) => write.name),
+            ["Pacifism", "Fireball", "Unsummon", "Shivan Dragon"]
+        );
         assert.equal(maxActive, 2);
-        assert.deepEqual(result, { inserted: 4 });
+        assert.deepEqual(result, {
+            fetched: 4,
+            accepted: 4,
+            rejected: 0,
+            catalogDuplicates: 0,
+            inserted: 4,
+            updated: 0,
+            removed: 0,
+            unchanged: 0
+        });
+        assert.match(logger.log.firstCall.args[0], /^Seeding 4 matchable card names/);
+        assert.match(logger.log.secondCall.args[0], /^Card-name seed complete: 4 inserted/);
+    });
+
+    it("rejects underscore-only names with the matching normalization contract", async () => {
+        const store = createMemoryStore();
+
+        const result = await seedCardNames({
+            getCardNames: async () => ["Pacifism", "_____ // ______", "Pacifism"],
+            ...store,
+            logger: { log: sinon.stub() }
+        });
+
+        assert.deepInclude(result, {
+            fetched: 3,
+            accepted: 1,
+            rejected: 1,
+            catalogDuplicates: 1,
+            inserted: 1
+        });
         assert.deepEqual(
-            logger.log.getCalls().map((call) => call.args[0]),
-            ["Seeding 4 card names...", "Seeded 4 card names."]
+            store.rows.map((row) => row.name),
+            ["Pacifism"]
         );
     });
 
-    it("handles an empty Scryfall response without starting inserts", async () => {
-        const insertName = sinon.stub();
-        const logger = { log: sinon.stub() };
+    it("repairs invalid and duplicate stored rows and is unchanged on a second seed", async () => {
+        const store = createMemoryStore([
+            { _id: "1", name: "_____ // ______" },
+            { _id: "2", name: "Pacifism" },
+            { _id: "3", name: "Pacifism", normalizedName: "PACIFISM" }
+        ]);
+        const options = {
+            getCardNames: async () => ["Pacifism", "Fireball"],
+            ...store,
+            logger: { log: sinon.stub() },
+            concurrency: 1
+        };
 
-        const result = await seedCardNames({
-            getCardNames: async () => [],
-            insertName,
-            logger
-        });
+        const first = await seedCardNames(options);
+        const second = await seedCardNames(options);
 
-        assert.deepEqual(result, { inserted: 0 });
-        assert.isFalse(insertName.called);
-        assert.isTrue(logger.log.calledOnceWithExactly("No card names returned; nothing to seed."));
+        assert.deepInclude(first, { inserted: 1, updated: 1, removed: 2, unchanged: 0 });
+        assert.deepInclude(second, { inserted: 0, updated: 0, removed: 0, unchanged: 2 });
+        assert.deepEqual(
+            store.rows.map(({ name, normalizedName }) => ({ name, normalizedName })),
+            [
+                { name: "Pacifism", normalizedName: "PACIFISM" },
+                { name: "Fireball", normalizedName: "FIREBALL" }
+            ]
+        );
+    });
+
+    it("fails an empty or entirely unmatchable catalog before mutating storage", async () => {
+        const upsertName = sinon.stub();
+        const removeName = sinon.stub();
+
+        for (const names of [[], ["_____", null]]) {
+            let caughtError;
+            try {
+                await seedCardNames({
+                    getCardNames: async () => names,
+                    getStoredNames: async () => [{ _id: "1", name: "Pacifism" }],
+                    upsertName,
+                    removeName,
+                    logger: { log: sinon.stub() }
+                });
+            } catch (error) {
+                caughtError = error;
+            }
+            assert.equal(
+                caughtError?.message,
+                "Scryfall card-name catalog contains no matchable names"
+            );
+        }
+        assert.isFalse(upsertName.called);
+        assert.isFalse(removeName.called);
     });
 
     it("rejects a malformed Scryfall response", async () => {
@@ -53,7 +148,9 @@ describe("db-local::seed-card-names", () => {
         try {
             await seedCardNames({
                 getCardNames: async () => null,
-                insertName: sinon.stub(),
+                getStoredNames: sinon.stub(),
+                upsertName: sinon.stub(),
+                removeName: sinon.stub(),
                 logger: { log: sinon.stub() }
             });
         } catch (error) {
@@ -62,23 +159,5 @@ describe("db-local::seed-card-names", () => {
 
         assert.instanceOf(caughtError, Error);
         assert.equal(caughtError.message, "Scryfall card-name response must be an array");
-    });
-
-    it("rejects malformed card names before writing", async () => {
-        const insertName = sinon.stub();
-        let caughtError;
-
-        try {
-            await seedCardNames({
-                getCardNames: async () => ["Pacifism", ""],
-                insertName,
-                logger: { log: sinon.stub() }
-            });
-        } catch (error) {
-            caughtError = error;
-        }
-
-        assert.equal(caughtError.message, "Scryfall card names must be non-empty strings");
-        assert.isFalse(insertName.called);
     });
 });

--- a/test/diagnostics/env-check.spec.mjs
+++ b/test/diagnostics/env-check.spec.mjs
@@ -1,5 +1,7 @@
 import { assert } from "chai";
 import {
+    MIN_USABLE_CARD_NAMES,
+    evaluateCardNameIndex,
     findUnsupportedOcrParameters,
     inspectDefaultOcrModel,
     runEnvironmentCheck
@@ -11,6 +13,46 @@ import { DEFAULT_OCR_MODEL_SHA256 } from "../../src/image-analysis/ocr-model.mjs
 // usable", so a real repo checkout with a seeded local cache is the meaningful thing to assert
 // against. See test/diagnostics/index.spec.mjs for gatherDiagnostics()'s own wiring.
 describe("diagnostics::env-check", () => {
+    it("reports a normalized, deduplicated card-name index as healthy", () => {
+        const records = Array.from({ length: MIN_USABLE_CARD_NAMES }, (_, index) => ({
+            name: `Card ${index}`
+        }));
+
+        const result = evaluateCardNameIndex(records);
+
+        assert.equal(result.status, "pass");
+        assert.isTrue(result.required);
+        assert.deepEqual(result.health, {
+            totalRows: MIN_USABLE_CARD_NAMES,
+            validRows: MIN_USABLE_CARD_NAMES,
+            uniqueNames: MIN_USABLE_CARD_NAMES,
+            invalidRows: 0,
+            duplicateRows: 0
+        });
+    });
+
+    it("fails an underscore-only index even though it contains rows", () => {
+        const result = evaluateCardNameIndex([{ name: "_____ // ______" }]);
+
+        assert.equal(result.status, "fail");
+        assert.isTrue(result.required);
+        assert.include(result.label, "0 unique matchable names");
+        assert.equal(result.health.invalidRows, 1);
+    });
+
+    it("warns when an otherwise usable index contains invalid or duplicate rows", () => {
+        const records = Array.from({ length: MIN_USABLE_CARD_NAMES }, (_, index) => ({
+            name: `Card ${index}`
+        }));
+        records.push({ name: "Card 0" }, { name: "_____" });
+
+        const result = evaluateCardNameIndex(records);
+
+        assert.equal(result.status, "fail");
+        assert.isFalse(result.required);
+        assert.include(result.label, "1 invalid rows, 1 duplicate rows");
+    });
+
     it("returns checks/requiredFailures/warnings with no unhandled rejection", async () => {
         const result = await runEnvironmentCheck();
 
@@ -18,6 +60,15 @@ describe("diagnostics::env-check", () => {
         assert.isNotEmpty(result.checks);
         assert.isNumber(result.requiredFailures);
         assert.isArray(result.warnings);
+        if (result.cardNameIndex) {
+            assert.hasAllKeys(result.cardNameIndex, [
+                "totalRows",
+                "validRows",
+                "uniqueNames",
+                "invalidRows",
+                "duplicateRows"
+            ]);
+        }
         result.checks.forEach((check) => {
             assert.hasAllKeys(check, ["label", "status"]);
             assert.include(["pass", "fail"], check.status);

--- a/test/diagnostics/index.spec.mjs
+++ b/test/diagnostics/index.spec.mjs
@@ -43,6 +43,15 @@ describe("diagnostics::index", () => {
         assert.isNotEmpty(bundle.environment.checks);
         assert.isNumber(bundle.environment.requiredFailures);
         assert.isArray(bundle.environment.warnings);
+        if (bundle.environment.cardNameIndex) {
+            assert.hasAllKeys(bundle.environment.cardNameIndex, [
+                "totalRows",
+                "validRows",
+                "uniqueNames",
+                "invalidRows",
+                "duplicateRows"
+            ]);
+        }
     });
 
     it("includes only the safe-to-share config fields (no secrets)", async () => {

--- a/test/fuzzy/name-match.spec.mjs
+++ b/test/fuzzy/name-match.spec.mjs
@@ -168,6 +168,19 @@ describe("FuzzyMatching::", () => {
             assert.equal(matches.length, 0);
         });
 
+        it("ignores invalid and duplicate legacy rows instead of failing every match", async () => {
+            stubs.BulkNamesStub.resolves([
+                { name: "_____ // ______" },
+                { name: "Pacifism" },
+                { name: "Pacifism", normalizedName: "PACIFISM" }
+            ]);
+
+            const matches = await create({ cleanText: "Pacifism" }).match();
+
+            assert.equal(matches[0]?.name, "Pacifism");
+            assert.equal(matches[0]?.percentage, 1);
+        });
+
         it("should narrow name-style families to the strongest first-token match", async () => {
             const matches = await create({
                 cleanText: "Thought Reflection"


### PR DESCRIPTION
## Summary

- Make the live Scryfall card-name seed workflow safe, idempotent, and diagnosable.
- Prevent unmatchable catalog names and legacy corrupt rows from breaking every scan.
- Make required seed and index-health failures visible to setup, diagnostics, and automation.

## Root cause

Scryfall's live catalog includes underscore-only names whose shared match normalization is empty.
The seeder accepted those rows, repeated runs appended the entire catalog, and matching rejected the
resulting index. The Scryfall boundary also translated request failures into an empty catalog that
the seeder treated as success, while diagnostics considered any non-empty database healthy.

## What changed

- Validate catalog entries with the same normalization contract used by matching.
- Deduplicate catalog names by normalized key and upsert persisted normalized records.
- Remove invalid and duplicate legacy rows safely while preserving valid existing names.
- Tolerate legacy poison rows during matching so one bad record cannot fail every scan.
- Return nonzero for unavailable, empty, or entirely unmatchable required catalogs.
- Propagate required seed failures through setup and clarify skip-seed guidance.
- Report total, valid, unique, invalid, and duplicate name-index counts in diagnostics.
- Add focused offline tests and update setup, CLI, configuration, and README documentation.

## Validation

- `fnm exec --using=22.22.1 -- pnpm check:fast`
- `fnm exec --using=22.22.1 -- pnpm coverage:check` — 413 tests passed; 92.75% statements,
  78.76% branches.
- `fnm exec --using=22.22.1 -- pnpm test:regression` — 151/151 blocking fixtures passed;
  156/158 overall with the two existing non-blocking misses unchanged.
- Isolated live Scryfall seed stored 35,059 names, rejected two unmatchable entries, and
  deduplicated seven normalized collisions.
- Isolated live reseed performed zero inserts, updates, or removals and reported 35,059 unchanged.
- A transient live Scryfall HTTP 503 exited 1 without damaging the existing index.
- Isolated diagnostics reported 35,059 healthy unique names with zero invalid or duplicate rows.
- Isolated Platinum Angel CLI scan exited 0 and matched `Platinum Angel` at 100%.

## Scope notes

- Based on `origin/master` at `e39009e`.
- All smoke-test databases were confined to temporary directories and removed afterward.
- No user databases, regression expectations, dependencies, tags, or releases were changed.
