### PR TITLE
fix: eliminate production dependency audit findings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,10 @@ data are stored on your machine by default. No MySQL server is needed for the no
 Scans are dry runs by default: they print results without adding anything to your collection. The
 local caches and operations log still update unless you disable the local cache.
 
+Local scan inputs must be JPEG, PNG, GIF, or BMP files no larger than 32 MiB, 12,000 pixels on
+either axis, or 40 megapixels decoded. The scanner validates the file signature and dimensions
+before decoding it; TIFF, ICNS, JXL, HEIF, and other container formats are rejected.
+
 ## Quick start
 
 You need:
@@ -127,6 +131,7 @@ local-first rather than fully offline.
 | Look up commands, flags, logging, migration, or collection edits | [CLI reference](docs/cli-reference.md)                |
 | Change settings or understand local database files               | [Configuration and local data](docs/configuration.md) |
 | Understand the scan pipeline and module boundaries               | [Architecture](docs/architecture.md)                  |
+| Review production dependency and image-input security controls   | [Dependency security](docs/dependency-security.md)    |
 | Add or evaluate OCR and matching fixtures                        | [Regression testing](docs/regression-testing.md)      |
 | Build a reviewed custom OCR fine-tuning corpus                   | [OCR training data](docs/ocr-training-data.md)        |
 | Prepare a change or pull request                                 | [Contributing](CONTRIBUTING.md)                       |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,9 @@ matching and an optional legacy MySQL backend.
 ## Scan pipeline
 
 1. `index.mjs` parses the command and resolves configuration.
-2. `src/image-processing/` validates the input and produces bounded hard title crops.
+2. `src/image-processing/` reads the local file once into a capped buffer, allowlists its magic
+   signature, validates dimensions and decoded pixels, and only then passes those same bytes to
+   Jimp to produce bounded hard title crops.
 3. `src/image-analysis/` runs Tesseract with each crop's declared segmentation mode and preserves
    plausible region and line candidates.
 4. `src/fuzzy-matching/` ranks all title candidates from the local card-name index and maps
@@ -21,6 +23,13 @@ matching and an optional legacy MySQL backend.
 
 The image, network, filesystem, and database boundaries remain outside the pure name-normalization
 and matching decisions so those decisions can be tested deterministically.
+
+Local image input is capped at 32 MiB, 12,000 pixels per axis, and 40 megapixels. JPEG decoding also
+uses a 256 MiB decoder allocation ceiling. Remote set-symbol images are limited to the approved
+Scryfall image origins, HTTPS, three same-origin redirects, a 15-second request deadline, and a
+16 MiB streamed body. Redirects are handled manually so request headers are never forwarded to a
+different origin. Accepted decoded formats are JPEG, PNG, GIF, and BMP; generic multi-format
+metadata probing and TIFF decoding are intentionally outside the scan boundary.
 
 ## Storage boundaries
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -30,6 +30,11 @@ A bare image path is accepted as a backward-compatible shorthand:
 node index.mjs ./path/to/card.jpg
 ```
 
+Scan inputs are limited to JPEG, PNG, GIF, and BMP files. Local files may be at most 32 MiB,
+12,000 pixels on either axis, and 40 megapixels decoded. Signature and dimension validation runs
+before image decoding, so renaming an unsupported file to a supported extension does not bypass
+the check.
+
 ### Scan options
 
 | Option                          | Effect                                                                                    |

--- a/docs/dependency-security.md
+++ b/docs/dependency-security.md
@@ -1,0 +1,60 @@
+# Production dependency security
+
+This note records the release-readiness remediation for the production dependency audit run on
+2026-08-09. It is evidence for dependency choices and input controls, not an advisory ignore list.
+
+## Audit baseline and disposition
+
+The baseline `pnpm audit --prod` reported nine advisories: six high, two moderate, and one low.
+The remediated lockfile reports no known production vulnerabilities.
+
+| Dependency path                                                      | Runtime reachability                                                                                                                                                                 | Disposition                                                                                                                                                                                                             |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Direct `image-size` ICNS/JXL/HEIF parsers                            | Reachable from the untrusted local path supplied to `scan`, before OCR                                                                                                               | Removed. `src/image-processing/util.mjs` now recognizes only JPEG, PNG, GIF, and BMP with bounded parsers whose loops advance monotonically over a capped buffer. Unsupported signatures are rejected before Jimp runs. |
+| `tesseract.js > babel-eslint > eslint > ... > flatted`               | Not reachable from OCR. `src/image-analysis/extract-text.mjs` imports the Tesseract worker API; it never imports or invokes Babel ESLint, ESLint caches, `flat-cache`, or `flatted`. | The regression-qualified Tesseract 3.0.3 engine/model pair remains exactly pinned. A version-scoped pnpm override forces vulnerable `flatted` releases to 3.4.2 without changing OCR code or the WASM engine.           |
+| `tesseract.js > babel-eslint > eslint > minimatch > brace-expansion` | Not reachable from OCR for the same reason; the subtree is legacy package tooling.                                                                                                   | A version-scoped override replaces only vulnerable 4.x/5.0.0-5.0.8 releases with 5.0.9. OCR behavior remains covered by the cold-cache regression gate.                                                                 |
+| `jimp > @jimp/core > file-type`                                      | Reachable when local or remote images are decoded.                                                                                                                                   | Jimp moved from 0.22.12 to 1.6.1, which resolves `file-type` 21.3.4. Application preflight additionally rejects non-allowlisted image signatures and validates dimensions before `Jimp.fromBuffer`.                     |
+| `jimp > plugin-print > ... > follow-redirects`                       | The application never invokes Jimp font or print APIs, but the vulnerable package was present in the production graph.                                                               | Jimp 1.6.1 removes this dependency path. Remote set-symbol downloads now use native fetch with manual same-origin redirects, capped bodies, HTTPS, approved origins, and a deadline.                                    |
+| `jimp > plugin-print > ... > min-document`                           | The application never invokes the browser font/DOM helpers, but the vulnerable package was present in the production graph.                                                          | Jimp 1.6.1 removes this dependency path.                                                                                                                                                                                |
+
+## Image-input invariants
+
+All production local image decoding used by OCR and set-symbol cropping goes through one boundary:
+
+- read from one open file descriptor into at most 32 MiB, rejecting files that change size during
+  the read;
+- recognize JPEG, PNG, GIF, or BMP from magic bytes, not filename extensions;
+- reject dimensions over 12,000 pixels on either axis or 40 megapixels before decoding;
+- apply Jimp's JPEG limits of 40 megapixels and 256 MiB in addition to the preflight;
+- verify decoded dimensions exactly match the validated header.
+
+Remote set-symbol images additionally require HTTPS on `cards.scryfall.io` or
+`img.scryfall.com`, remain on the original origin across at most three manual redirects, time out
+after 15 seconds, and stream at most 16 MiB. These controls prevent cross-origin forwarding of the
+Scryfall request headers and bound work even when `Content-Length` is absent or false.
+
+Perceptual hashing receives only the already-validated buffer form, so `image-hash` cannot reopen a
+user-controlled path or perform its own unbounded fetch. Direct library users should use
+`imageProcessing.util.readImage` or `readImageInput` before handing image data to any lower-level
+decoder.
+
+## Residual risk
+
+There are no residual npm advisories in the production lockfile. Tesseract.js 3.0.3 is older than
+the current upstream major, but it remains intentionally pinned because the bundled OCR model and
+158-case cold-cache regression corpus were qualified against that engine. Its audited legacy
+tooling nodes are patched by version-scoped overrides and are not imported by the OCR execution
+path. A future Tesseract major upgrade should be treated as an OCR-model promotion and must pass
+the full regression comparison policy in `docs/regression-testing.md`.
+
+The expanded regression corpus also exposed a deterministic Tesseract 3 WASM abort when one worker
+was reused beyond the first large case cohort. The fixtures immediately after the abort passed with
+a fresh worker, so the regression runner now terminates and recreates its worker after at most 40
+cases. Recognition remains sequential, cache-free, and adaptively reset before every crop; the
+fixed lifecycle adds an explicit heap/work budget without changing the production engine or model.
+
+Jimp still ships format codecs the application does not accept, including TIFF. That code remains
+installed but is not reachable through the application image boundary because validation rejects
+its signature before `Jimp.fromBuffer` is called. The focused tests lock in rejection of the
+ICNS, JXL, and HEIF advisory signatures, excessive dimensions, excessive local and remote byte
+counts, and cross-origin redirects.

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -35,10 +35,11 @@ Every regression case is evaluated with cold application state. Image hashes are
 both the fixture and every candidate reference image; the runner has no in-memory or persistent
 hash cache. Fixture names are injected before the fuzzy matcher can initialize NeDB. Tesseract
 runs with `cacheMethod: none` and reads the bundled `eng.traineddata`, so it neither reads nor writes
-an OCR cache. One initialized Tesseract worker is shared sequentially by all selected cases and
-terminated after the run. This avoids loading the OCR engine and language model for every crop. The
-worker's adaptive recognition state is reset before each crop. OCR results remain independent of
-earlier fixtures, and the persistent language-data cache stays off.
+an OCR cache. One initialized Tesseract worker is shared sequentially for at most 40 selected cases,
+then terminated and replaced before the next case. This bounds the Tesseract 3 WASM heap during the
+expanded corpus without loading the OCR engine and language model for every crop. Each worker's
+adaptive recognition state is reset before every crop. OCR results remain independent of earlier
+fixtures, and the persistent language-data cache stays off.
 Unnecessary OCR previews are disabled. Synthetic transformations use a per-case temporary
 directory only when needed, and that directory is deleted after the case. The Markdown and JSON
 benchmark reports are the only durable files written by the runner.
@@ -74,7 +75,9 @@ pnpm test:regression \
     --ocr-model official-eng-fast
 ```
 
-Execution stays sequential to keep OCR timings and CPU contention comparable.
+Execution stays sequential to keep OCR timings and CPU contention comparable. Runs over 40 cases
+pay a worker initialization cost between case batches; per-case runtime thresholds exclude that
+between-case initialization.
 
 Run multiple fixture IDs or quality groups in one command to reuse its worker.
 Each separate command starts a new worker.

--- a/package.json
+++ b/package.json
@@ -89,13 +89,12 @@
         "commander": "^15.0.0",
         "fuzzyset.js": "1.0.7",
         "image-hash": "^7.0.1",
-        "image-size": "^1.2.1",
-        "jimp": "0.22.12",
+        "jimp": "1.6.1",
         "joi": "^18.2.3",
         "lodash": "^4.18.1",
         "mysql2": "^3.16.0",
         "string-similarity": "^4.0.4",
-        "tesseract.js": "^3.0.3"
+        "tesseract.js": "3.0.3"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -111,5 +110,11 @@
         "prettier": "^3.9.4",
         "sinon": "^21.1.2",
         "typescript": "^5.9.3"
+    },
+    "pnpm": {
+        "overrides": {
+            "brace-expansion@>=4.0.0 <5.0.9": "5.0.9",
+            "flatted@<3.4.2": "3.4.2"
+        }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@>=4.0.0 <5.0.9: 5.0.9
+  flatted@<3.4.2: 3.4.2
+
 importers:
 
   .:
@@ -23,12 +27,9 @@ importers:
       image-hash:
         specifier: ^7.0.1
         version: 7.0.1
-      image-size:
-        specifier: ^1.2.1
-        version: 1.2.1
       jimp:
-        specifier: 0.22.12
-        version: 0.22.12
+        specifier: 1.6.1
+        version: 1.6.1
       joi:
         specifier: ^18.2.3
         version: 18.2.3
@@ -42,7 +43,7 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
       tesseract.js:
-        specifier: ^3.0.3
+        specifier: 3.0.3
         version: 3.0.3(eslint@10.8.1)
     devDependencies:
       '@eslint/js':
@@ -101,10 +102,6 @@ packages:
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -222,170 +219,117 @@ packages:
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
 
-  '@jimp/bmp@0.22.12':
-    resolution: {integrity: sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/core@1.6.1':
+    resolution: {integrity: sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==}
+    engines: {node: '>=18'}
 
-  '@jimp/core@0.22.12':
-    resolution: {integrity: sha512-l0RR0dOPyzMKfjUW1uebzueFEDtCOj9fN6pyTYWWOM/VS4BciXQ1VVrJs8pO3kycGYZxncRKhCoygbNr8eEZQA==}
+  '@jimp/diff@1.6.1':
+    resolution: {integrity: sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==}
+    engines: {node: '>=18'}
 
-  '@jimp/custom@0.22.12':
-    resolution: {integrity: sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==}
+  '@jimp/file-ops@1.6.1':
+    resolution: {integrity: sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==}
+    engines: {node: '>=18'}
 
-  '@jimp/gif@0.22.12':
-    resolution: {integrity: sha512-y6BFTJgch9mbor2H234VSjd9iwAhaNf/t3US5qpYIs0TSbAvM02Fbc28IaDETj9+4YB4676sz4RcN/zwhfu1pg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/js-bmp@1.6.1':
+    resolution: {integrity: sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==}
+    engines: {node: '>=18'}
 
-  '@jimp/jpeg@0.22.12':
-    resolution: {integrity: sha512-Rq26XC/uQWaQKyb/5lksCTCxXhtY01NJeBN+dQv5yNYedN0i7iYu+fXEoRsfaJ8xZzjoANH8sns7rVP4GE7d/Q==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/js-gif@1.6.1':
+    resolution: {integrity: sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-blit@0.22.12':
-    resolution: {integrity: sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/js-jpeg@1.6.1':
+    resolution: {integrity: sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-blur@0.22.12':
-    resolution: {integrity: sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/js-png@1.6.1':
+    resolution: {integrity: sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-circle@0.22.12':
-    resolution: {integrity: sha512-SWVXx1yiuj5jZtMijqUfvVOJBwOifFn0918ou4ftoHgegc5aHWW5dZbYPjvC9fLpvz7oSlptNl2Sxr1zwofjTg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/js-tiff@1.6.1':
+    resolution: {integrity: sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-color@0.22.12':
-    resolution: {integrity: sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-blit@1.6.1':
+    resolution: {integrity: sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-contain@0.22.12':
-    resolution: {integrity: sha512-Eo3DmfixJw3N79lWk8q/0SDYbqmKt1xSTJ69yy8XLYQj9svoBbyRpSnHR+n9hOw5pKXytHwUW6nU4u1wegHNoQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blit': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
-      '@jimp/plugin-scale': '>=0.3.5'
+  '@jimp/plugin-blur@1.6.1':
+    resolution: {integrity: sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-cover@0.22.12':
-    resolution: {integrity: sha512-z0w/1xH/v/knZkpTNx+E8a7fnasQ2wHG5ze6y5oL2dhH1UufNua8gLQXlv8/W56+4nJ1brhSd233HBJCo01BXA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-crop': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
-      '@jimp/plugin-scale': '>=0.3.5'
+  '@jimp/plugin-circle@1.6.1':
+    resolution: {integrity: sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-crop@0.22.12':
-    resolution: {integrity: sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-color@1.6.1':
+    resolution: {integrity: sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-displace@0.22.12':
-    resolution: {integrity: sha512-qpRM8JRicxfK6aPPqKZA6+GzBwUIitiHaZw0QrJ64Ygd3+AsTc7BXr+37k2x7QcyCvmKXY4haUrSIsBug4S3CA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-contain@1.6.1':
+    resolution: {integrity: sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-dither@0.22.12':
-    resolution: {integrity: sha512-jYgGdSdSKl1UUEanX8A85v4+QUm+PE8vHFwlamaKk89s+PXQe7eVE3eNeSZX4inCq63EHL7cX580dMqkoC3ZLw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-cover@1.6.1':
+    resolution: {integrity: sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-fisheye@0.22.12':
-    resolution: {integrity: sha512-LGuUTsFg+fOp6KBKrmLkX4LfyCy8IIsROwoUvsUPKzutSqMJnsm3JGDW2eOmWIS/jJpPaeaishjlxvczjgII+Q==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-crop@1.6.1':
+    resolution: {integrity: sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-flip@0.22.12':
-    resolution: {integrity: sha512-m251Rop7GN8W0Yo/rF9LWk6kNclngyjIJs/VXHToGQ6EGveOSTSQaX2Isi9f9lCDLxt+inBIb7nlaLLxnvHX8Q==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-rotate': '>=0.3.5'
+  '@jimp/plugin-displace@1.6.1':
+    resolution: {integrity: sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-gaussian@0.22.12':
-    resolution: {integrity: sha512-sBfbzoOmJ6FczfG2PquiK84NtVGeScw97JsCC3rpQv1PHVWyW+uqWFF53+n3c8Y0P2HWlUjflEla2h/vWShvhg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-dither@1.6.1':
+    resolution: {integrity: sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-invert@0.22.12':
-    resolution: {integrity: sha512-N+6rwxdB+7OCR6PYijaA/iizXXodpxOGvT/smd/lxeXsZ/empHmFFFJ/FaXcYh19Tm04dGDaXcNF/dN5nm6+xQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-fisheye@1.6.1':
+    resolution: {integrity: sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-mask@0.22.12':
-    resolution: {integrity: sha512-4AWZg+DomtpUA099jRV8IEZUfn1wLv6+nem4NRJC7L/82vxzLCgXKTxvNvBcNmJjT9yS1LAAmiJGdWKXG63/NA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-flip@1.6.1':
+    resolution: {integrity: sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-normalize@0.22.12':
-    resolution: {integrity: sha512-0So0rexQivnWgnhacX4cfkM2223YdExnJTTy6d06WbkfZk5alHUx8MM3yEzwoCN0ErO7oyqEWRnEkGC+As1FtA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-hash@1.6.1':
+    resolution: {integrity: sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-print@0.22.12':
-    resolution: {integrity: sha512-c7TnhHlxm87DJeSnwr/XOLjJU/whoiKYY7r21SbuJ5nuH+7a78EW1teOaj5gEr2wYEd7QtkFqGlmyGXY/YclyQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blit': '>=0.3.5'
+  '@jimp/plugin-mask@1.6.1':
+    resolution: {integrity: sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-resize@0.22.12':
-    resolution: {integrity: sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/plugin-print@1.6.1':
+    resolution: {integrity: sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-rotate@0.22.12':
-    resolution: {integrity: sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blit': '>=0.3.5'
-      '@jimp/plugin-crop': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
+  '@jimp/plugin-quantize@1.6.1':
+    resolution: {integrity: sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-scale@0.22.12':
-    resolution: {integrity: sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
+  '@jimp/plugin-resize@1.6.1':
+    resolution: {integrity: sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-shadow@0.22.12':
-    resolution: {integrity: sha512-FX8mTJuCt7/3zXVoeD/qHlm4YH2bVqBuWQHXSuBK054e7wFRnRnbSLPUqAwSeYP3lWqpuQzJtgiiBxV3+WWwTg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blur': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
+  '@jimp/plugin-rotate@1.6.1':
+    resolution: {integrity: sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugin-threshold@0.22.12':
-    resolution: {integrity: sha512-4x5GrQr1a/9L0paBC/MZZJjjgjxLYrqSmWd+e+QfAEPvmRxdRoQ5uKEuNgXnm9/weHQBTnQBQsOY2iFja+XGAw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-color': '>=0.8.0'
-      '@jimp/plugin-resize': '>=0.8.0'
+  '@jimp/plugin-threshold@1.6.1':
+    resolution: {integrity: sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==}
+    engines: {node: '>=18'}
 
-  '@jimp/plugins@0.22.12':
-    resolution: {integrity: sha512-yBJ8vQrDkBbTgQZLty9k4+KtUQdRjsIDJSPjuI21YdVeqZxYywifHl4/XWILoTZsjTUASQcGoH0TuC0N7xm3ww==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
+  '@jimp/types@1.6.1':
+    resolution: {integrity: sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==}
+    engines: {node: '>=18'}
 
-  '@jimp/png@0.22.12':
-    resolution: {integrity: sha512-Mrp6dr3UTn+aLK8ty/dSKELz+Otdz1v4aAXzV5q53UDD2rbB5joKVJ/ChY310B+eRzNxIovbUF1KVrUsYdE8Hg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/tiff@0.22.12':
-    resolution: {integrity: sha512-E1LtMh4RyJsoCAfAkBRVSYyZDTtLq9p9LUiiYP0vPtXyxX4BiYBUYihTLSBlCQg5nF2e4OpQg7SPrLdJ66u7jg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/types@0.22.12':
-    resolution: {integrity: sha512-wwKYzRdElE1MBXFREvCto5s699izFHNVvALUv79GXNbsOVqlwlOxlWJ8DuyOGIXoLP4JW/m30YyuTtfUJgMRMA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/utils@0.22.12':
-    resolution: {integrity: sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q==}
+  '@jimp/utils@1.6.1':
+    resolution: {integrity: sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==}
+    engines: {node: '>=18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -444,10 +388,6 @@ packages:
   '@yetzt/binary-search-tree@0.2.6':
     resolution: {integrity: sha512-e/8wt8AAumI8VK5sv09b3IgWuRoblXJ5z0SQYfrL2nap89oKihvVaP1zy3FzD5NaeRi1X0gdXZA9lB3QAZILBg==}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -486,6 +426,10 @@ packages:
   async@0.2.10:
     resolution: {integrity: sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==}
 
+  await-to-js@3.0.0:
+    resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
+    engines: {node: '>=6.0.0'}
+
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
@@ -504,31 +448,21 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   bmp-js@0.1.0:
     resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
+
+  bmp-ts@1.0.9:
+    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
-
-  buffer-equal@0.0.1:
-    resolution: {integrity: sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==}
-    engines: {node: '>=0.4.0'}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   c8@12.0.0:
     resolution: {integrity: sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==}
@@ -543,9 +477,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  centra@2.7.0:
-    resolution: {integrity: sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -616,9 +547,6 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
-
-  dom-walk@0.1.2:
-    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -692,14 +620,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
-
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
@@ -720,10 +640,6 @@ packages:
     resolution: {integrity: sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==}
     engines: {node: '>=8'}
 
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
-
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
@@ -740,17 +656,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -789,9 +696,6 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
-
-  global@4.4.0:
-    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
 
   globals@17.7.0:
     resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
@@ -832,20 +736,12 @@ packages:
   image-q@4.0.0:
     resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
-    engines: {node: '>=16.x'}
-    hasBin: true
-
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -861,9 +757,6 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  is-function@1.0.2:
-    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -890,9 +783,6 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isomorphic-fetch@3.0.0:
-    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
-
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -908,8 +798,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jimp@0.22.12:
-    resolution: {integrity: sha512-R5jZaYDnfkxKJy1dwLpj/7cvyjxiclxU3F4TrI/J4j2rS0niq6YDUMoPn5hs8GDpO+OZGo7Ky057CRtWesyhfg==}
+  jimp@1.6.1:
+    resolution: {integrity: sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==}
+    engines: {node: '>=18'}
 
   joi@18.2.3:
     resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
@@ -1008,9 +899,6 @@ packages:
     engines: {node: '>=22.22.1'}
     hasBin: true
 
-  load-bmfont@1.4.2:
-    resolution: {integrity: sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==}
-
   localforage@1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
@@ -1043,13 +931,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  mime@1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
-    engines: {node: '>=4'}
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
     hasBin: true
-
-  min-document@2.19.0:
-    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1125,9 +1010,6 @@ packages:
   parse-bmfont-xml@1.1.6:
     resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
 
-  parse-headers@2.0.6:
-    resolution: {integrity: sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1147,15 +1029,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
-
-  phin@3.7.1:
-    resolution: {integrity: sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==}
-    engines: {node: '>= 8'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1163,13 +1036,9 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  pixelmatch@4.0.2:
-    resolution: {integrity: sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==}
+  pixelmatch@5.3.0:
+    resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
     hasBin: true
-
-  pngjs@3.4.0:
-    resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
-    engines: {node: '>=4.0.0'}
 
   pngjs@6.0.0:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
@@ -1188,27 +1057,12 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
-
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
-  readable-stream@4.7.0:
-    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  readable-web-to-node-stream@3.0.4:
-    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
-    engines: {node: '>=8'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1262,6 +1116,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-xml-to-json@1.2.7:
+    resolution: {integrity: sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==}
+    engines: {node: '>=20.12.2'}
+
   sinon@21.1.2:
     resolution: {integrity: sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==}
 
@@ -1293,9 +1151,6 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1311,10 +1166,6 @@ packages:
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
-
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1338,19 +1189,12 @@ packages:
     resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
     engines: {node: 20 || >=22}
 
-  timm@1.7.1:
-    resolution: {integrity: sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==}
-
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
-
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -1399,9 +1243,6 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
-  whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
-
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -1429,9 +1270,6 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  xhr@2.6.0:
-    resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
-
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
 
@@ -1442,10 +1280,6 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
-
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -1483,11 +1317,14 @@ packages:
   zlibjs@0.3.1:
     resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -1502,8 +1339,6 @@ snapshots:
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
@@ -1621,221 +1456,228 @@ snapshots:
 
   '@istanbuljs/schema@0.1.6': {}
 
-  '@jimp/bmp@0.22.12(@jimp/custom@0.22.12)':
+  '@jimp/core@1.6.1':
     dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-      bmp-js: 0.1.0
-
-  '@jimp/core@0.22.12':
-    dependencies:
-      '@jimp/utils': 0.22.12
-      any-base: 1.1.0
-      buffer: 5.7.1
+      '@jimp/file-ops': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      await-to-js: 3.0.0
       exif-parser: 0.1.12
-      file-type: 16.5.4
-      isomorphic-fetch: 3.0.0
-      pixelmatch: 4.0.2
-      tinycolor2: 1.6.0
+      file-type: 21.3.4
+      mime: 3.0.0
     transitivePeerDependencies:
-      - encoding
+      - supports-color
 
-  '@jimp/custom@0.22.12':
+  '@jimp/diff@1.6.1':
     dependencies:
-      '@jimp/core': 0.22.12
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      pixelmatch: 5.3.0
     transitivePeerDependencies:
-      - encoding
+      - supports-color
 
-  '@jimp/gif@0.22.12(@jimp/custom@0.22.12)':
+  '@jimp/file-ops@1.6.1': {}
+
+  '@jimp/js-bmp@1.6.1':
     dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      bmp-ts: 1.0.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-gif@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
       gifwrap: 0.10.1
       omggif: 1.0.10
+    transitivePeerDependencies:
+      - supports-color
 
-  '@jimp/jpeg@0.22.12(@jimp/custom@0.22.12)':
+  '@jimp/js-jpeg@1.6.1':
     dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
       jpeg-js: 0.4.4
-
-  '@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-blur@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-circle@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-color@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-      tinycolor2: 1.6.0
-
-  '@jimp/plugin-contain@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-scale@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-blit': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-scale': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-cover@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-scale@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-crop': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-scale': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-displace@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-dither@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-fisheye@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-flip@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-rotate@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-rotate': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-gaussian@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-invert@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-mask@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-normalize@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-print@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-blit': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/utils': 0.22.12
-      load-bmfont: 1.4.2
     transitivePeerDependencies:
-      - debug
+      - supports-color
 
-  '@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)':
+  '@jimp/js-png@1.6.1':
     dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-rotate@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-blit': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-crop': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-scale@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-shadow@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blur@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-blur': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugin-threshold@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-color@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-color': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/utils': 0.22.12
-
-  '@jimp/plugins@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugin-blit': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-blur': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-circle': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-color': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-contain': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-scale@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)))
-      '@jimp/plugin-cover': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-scale@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)))
-      '@jimp/plugin-crop': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-displace': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-dither': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-fisheye': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-flip': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-rotate@0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)))
-      '@jimp/plugin-gaussian': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-invert': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-mask': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-normalize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-print': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))
-      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/plugin-rotate': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blit@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-crop@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))
-      '@jimp/plugin-scale': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))
-      '@jimp/plugin-shadow': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-blur@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))
-      '@jimp/plugin-threshold': 0.22.12(@jimp/custom@0.22.12)(@jimp/plugin-color@0.22.12(@jimp/custom@0.22.12))(@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12))
-      timm: 1.7.1
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      pngjs: 7.0.0
     transitivePeerDependencies:
-      - debug
+      - supports-color
 
-  '@jimp/png@0.22.12(@jimp/custom@0.22.12)':
+  '@jimp/js-tiff@1.6.1':
     dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/utils': 0.22.12
-      pngjs: 6.0.0
-
-  '@jimp/tiff@0.22.12(@jimp/custom@0.22.12)':
-    dependencies:
-      '@jimp/custom': 0.22.12
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
       utif2: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
 
-  '@jimp/types@0.22.12(@jimp/custom@0.22.12)':
+  '@jimp/plugin-blit@1.6.1':
     dependencies:
-      '@jimp/bmp': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/custom': 0.22.12
-      '@jimp/gif': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/jpeg': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/png': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/tiff': 0.22.12(@jimp/custom@0.22.12)
-      timm: 1.7.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
 
-  '@jimp/utils@0.22.12':
+  '@jimp/plugin-blur@1.6.1':
     dependencies:
-      regenerator-runtime: 0.13.11
+      '@jimp/core': 1.6.1
+      '@jimp/utils': 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-circle@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-color@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      tinycolor2: 1.6.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-contain@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-cover@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-crop@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-displace@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-dither@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+
+  '@jimp/plugin-fisheye@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-flip@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-hash@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/js-bmp': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/js-tiff': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      any-base: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-mask@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-print@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/types': 1.6.1
+      parse-bmfont-ascii: 1.0.6
+      parse-bmfont-binary: 1.0.6
+      parse-bmfont-xml: 1.1.6
+      simple-xml-to-json: 1.2.7
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-quantize@1.6.1':
+    dependencies:
+      image-q: 4.0.0
+      zod: 3.25.76
+
+  '@jimp/plugin-resize@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-rotate@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-threshold@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-hash': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/types@1.6.1':
+    dependencies:
+      zod: 3.25.76
+
+  '@jimp/utils@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      tinycolor2: 1.6.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1894,10 +1736,6 @@ snapshots:
 
   '@yetzt/binary-search-tree@0.2.6': {}
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -1927,6 +1765,8 @@ snapshots:
 
   async@0.2.10: {}
 
+  await-to-js@3.0.0: {}
+
   aws-ssl-profiles@1.1.2: {}
 
   babel-eslint@10.1.0(eslint@10.8.1):
@@ -1945,31 +1785,19 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1: {}
-
   bmp-js@0.1.0: {}
+
+  bmp-ts@1.0.9: {}
 
   brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
   browser-stdout@1.3.1: {}
-
-  buffer-equal@0.0.1: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   c8@12.0.0:
     dependencies:
@@ -1986,12 +1814,6 @@ snapshots:
       yargs-parser: 21.1.1
 
   camelcase@6.3.0: {}
-
-  centra@2.7.0:
-    dependencies:
-      follow-redirects: 1.15.9
-    transitivePeerDependencies:
-      - debug
 
   chai@6.2.2: {}
 
@@ -2051,8 +1873,6 @@ snapshots:
   diff@7.0.0: {}
 
   diff@8.0.4: {}
-
-  dom-walk@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -2136,10 +1956,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  event-target-shim@5.0.1: {}
-
-  events@3.3.0: {}
-
   exif-parser@0.1.12: {}
 
   fast-deep-equal@3.1.3: {}
@@ -2153,12 +1969,6 @@ snapshots:
       flat-cache: 4.0.1
 
   file-type@12.4.2: {}
-
-  file-type@16.5.4:
-    dependencies:
-      readable-web-to-node-stream: 3.0.4
-      strtok3: 6.3.0
-      token-types: 4.2.1
 
   file-type@21.3.4:
     dependencies:
@@ -2176,14 +1986,12 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
-  flatted@3.3.3: {}
-
-  follow-redirects@1.15.9: {}
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -2226,11 +2034,6 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  global@4.4.0:
-    dependencies:
-      min-document: 2.19.0
-      process: 0.11.10
-
   globals@17.7.0: {}
 
   has-flag@4.0.0: {}
@@ -2266,15 +2069,9 @@ snapshots:
     dependencies:
       '@types/node': 16.9.1
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
-
   immediate@3.0.6: {}
 
   imurmurhash@0.1.4: {}
-
-  inherits@2.0.4: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -2285,8 +2082,6 @@ snapshots:
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
-
-  is-function@1.0.2: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -2303,13 +2098,6 @@ snapshots:
   is-url@1.2.4: {}
 
   isexe@2.0.0: {}
-
-  isomorphic-fetch@3.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-      whatwg-fetch: 3.6.20
-    transitivePeerDependencies:
-      - encoding
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2330,15 +2118,37 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jimp@0.22.12:
+  jimp@1.6.1:
     dependencies:
-      '@jimp/custom': 0.22.12
-      '@jimp/plugins': 0.22.12(@jimp/custom@0.22.12)
-      '@jimp/types': 0.22.12(@jimp/custom@0.22.12)
-      regenerator-runtime: 0.13.11
+      '@jimp/core': 1.6.1
+      '@jimp/diff': 1.6.1
+      '@jimp/js-bmp': 1.6.1
+      '@jimp/js-gif': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/js-tiff': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/plugin-blur': 1.6.1
+      '@jimp/plugin-circle': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-contain': 1.6.1
+      '@jimp/plugin-cover': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-displace': 1.6.1
+      '@jimp/plugin-dither': 1.6.1
+      '@jimp/plugin-fisheye': 1.6.1
+      '@jimp/plugin-flip': 1.6.1
+      '@jimp/plugin-hash': 1.6.1
+      '@jimp/plugin-mask': 1.6.1
+      '@jimp/plugin-print': 1.6.1
+      '@jimp/plugin-quantize': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/plugin-rotate': 1.6.1
+      '@jimp/plugin-threshold': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
     transitivePeerDependencies:
-      - debug
-      - encoding
+      - supports-color
 
   joi@18.2.3:
     dependencies:
@@ -2430,19 +2240,6 @@ snapshots:
     optionalDependencies:
       yaml: 2.9.0
 
-  load-bmfont@1.4.2:
-    dependencies:
-      buffer-equal: 0.0.1
-      mime: 1.6.0
-      parse-bmfont-ascii: 1.0.6
-      parse-bmfont-binary: 1.0.6
-      parse-bmfont-xml: 1.1.6
-      phin: 3.7.1
-      xhr: 2.6.0
-      xtend: 4.0.2
-    transitivePeerDependencies:
-      - debug
-
   localforage@1.10.0:
     dependencies:
       lie: 3.1.1
@@ -2470,15 +2267,11 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  mime@1.6.0: {}
-
-  min-document@2.19.0:
-    dependencies:
-      dom-walk: 0.1.2
+  mime@3.0.0: {}
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
@@ -2568,8 +2361,6 @@ snapshots:
       xml-parse-from-string: 1.0.1
       xml2js: 0.5.0
 
-  parse-headers@2.0.6: {}
-
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -2586,23 +2377,13 @@ snapshots:
       lru-cache: 11.5.1
       minipass: 7.1.3
 
-  peek-readable@4.1.0: {}
-
-  phin@3.7.1:
-    dependencies:
-      centra: 2.7.0
-    transitivePeerDependencies:
-      - debug
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
 
-  pixelmatch@4.0.2:
+  pixelmatch@5.3.0:
     dependencies:
-      pngjs: 3.4.0
-
-  pngjs@3.4.0: {}
+      pngjs: 6.0.0
 
   pngjs@6.0.0: {}
 
@@ -2612,29 +2393,11 @@ snapshots:
 
   prettier@3.9.4: {}
 
-  process@0.11.10: {}
-
   punycode@2.3.1: {}
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
-
-  readable-stream@4.7.0:
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
-
-  readable-web-to-node-stream@3.0.4:
-    dependencies:
-      readable-stream: 4.7.0
 
   readdirp@4.1.2: {}
 
@@ -2672,6 +2435,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-xml-to-json@1.2.7: {}
+
   sinon@21.1.2:
     dependencies:
       '@sinonjs/commons': 3.0.1
@@ -2708,10 +2473,6 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -2725,11 +2486,6 @@ snapshots:
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
-
-  strtok3@6.3.0:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
 
   supports-color@7.2.0:
     dependencies:
@@ -2769,16 +2525,9 @@ snapshots:
       glob: 13.0.6
       minimatch: 10.2.5
 
-  timm@1.7.1: {}
-
   tinycolor2@1.6.0: {}
 
   tinyexec@1.3.0: {}
-
-  token-types@4.2.1:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
 
   token-types@6.1.2:
     dependencies:
@@ -2820,8 +2569,6 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  whatwg-fetch@3.6.20: {}
-
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -2853,13 +2600,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  xhr@2.6.0:
-    dependencies:
-      global: 4.4.0
-      is-function: 1.0.2
-      parse-headers: 2.0.6
-      xtend: 4.0.2
-
   xml-parse-from-string@1.0.1: {}
 
   xml2js@0.5.0:
@@ -2868,8 +2608,6 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
-
-  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 
@@ -2909,3 +2647,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zlibjs@0.3.1: {}
+
+  zod@3.25.76: {}

--- a/scripts/run-regression.mjs
+++ b/scripts/run-regression.mjs
@@ -80,7 +80,7 @@ async function main(argv = process.argv, overrides = {}) {
         `CI gate: ${report.gate.passed}/${report.gate.total} blocking fixtures passed; ${report.gate.nonBlockingFailed}/${report.gate.nonBlocking} non-blocking fixtures failed`
     );
     writeLine("Application persistence, image-hash cache, and OCR cache: disabled");
-    writeLine("Tesseract worker: shared sequentially for this regression run");
+    writeLine(`Tesseract worker: ${report.isolation.ocrWorkerLifecycle}`);
     if (report.pending.cases > 0) {
         writeLine(`Disabled fixtures: ${report.pending.cases}`);
     }

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import jimp from "jimp";
 import logger from "../logger/log.mjs";
 import joi from "joi";
 import storage from "../storage/index.mjs";
@@ -31,7 +30,8 @@ const defaultDependencies = {
     Hash: imageHashing.Hash,
     createDirectory: FileIO.createDirectory,
     cleanUpFiles: FileIO.cleanUpFiles,
-    CropSetSymbol: imageProcessing.smartCrop.cropSetSymbolFromImage
+    CropSetSymbol: imageProcessing.smartCrop.cropSetSymbolFromImage,
+    readImage: imageProcessing.util.readImage
 };
 
 const schema = joi.object().keys({
@@ -241,19 +241,18 @@ class ProcessHashes {
     }
 
     async _hashRemoteSetSymbol(url, tempDirectory) {
-        // Scryfall's image CDN 400s a header-less request -- jimp's own URL loader sends none by
-        // default. Same fix/header as image-hashing/hash-image.mjs's remote imageHash() calls.
-        // Only a real http(s) URL takes jimp's {url, headers} request-object form; a local test
-        // fixture path must stay a plain string so it still takes jimp's fs-read branch.
-        const image = imageHashing.isRemoteUrl(url)
-            ? await jimp.read({ url, headers: imageHashing.REMOTE_IMAGE_REQUEST_HEADERS })
-            : await jimp.read(url);
+        const image = await this.dependencies.readImage(
+            url,
+            imageHashing.isRemoteUrl(url)
+                ? { headers: imageHashing.REMOTE_IMAGE_REQUEST_HEADERS }
+                : undefined
+        );
         const cropped = this.dependencies.CropSetSymbol(image);
         if (cropped.lowConfidence) {
             throw new Error(`Set symbol crop is low confidence: ${cropped.reason}`);
         }
         const tmpFilePath = path.join(tempDirectory, `${randomUUID()}.png`);
-        await cropped.image.writeAsync(tmpFilePath);
+        await cropped.image.write(tmpFilePath);
         return this._hashImage(tmpFilePath);
     }
 

--- a/src/image-hashing/hash-image.mjs
+++ b/src/image-hashing/hash-image.mjs
@@ -1,7 +1,9 @@
 import stringSimilarity from "string-similarity";
 import { imageHash } from "image-hash";
+import { JimpMime } from "jimp";
 import log from "../logger/log.mjs";
 import { round } from "../util.mjs";
+import { decodeImageInput, readImageInput } from "../image-processing/util.mjs";
 
 const defaultLogger = log.create({
     isPretty: true
@@ -23,22 +25,42 @@ export function isRemoteUrl(value) {
 
 export function createHashing({
     imageHash: hashImageSource = imageHash,
+    loadImageInput = readImageInput,
+    decodeImage = decodeImageInput,
     logger = defaultLogger
 } = {}) {
+    async function prepareHashSource(imgUrl, options) {
+        const input = await loadImageInput(imgUrl, options);
+        if (input.dimensions.format === "jpeg" || input.dimensions.format === "png") {
+            return {
+                data: input.buffer,
+                ext: input.dimensions.format === "jpeg" ? JimpMime.jpeg : JimpMime.png
+            };
+        }
+
+        // image-hash only decodes JPEG/PNG/WebP. Preserve the scanner's bounded GIF/BMP input
+        // contract by decoding the already-validated bytes and normalizing them to PNG first.
+        const image = await decodeImage(input);
+        return { data: await image.getBuffer(JimpMime.png), ext: JimpMime.png };
+    }
+
     function hashImage(imgUrl, cb) {
         logger.info(`Hashing image: ${formatImageSource(imgUrl)}`);
-        // image-hash accepts either a plain path/URL string or a {url, ...fetchInit} request object;
-        // only remote URLs need the header -- a local file path must stay a plain string so it still
-        // takes the fs.readFile branch instead of being treated as a request object.
-        const source = isRemoteUrl(imgUrl)
-            ? { url: imgUrl, headers: REMOTE_IMAGE_REQUEST_HEADERS }
-            : imgUrl;
-        hashImageSource(source, 16, true, (error, data) => {
-            if (error) {
-                return cb(error);
-            }
-            return cb(null, data);
-        });
+        const options = isRemoteUrl(imgUrl) ? { headers: REMOTE_IMAGE_REQUEST_HEADERS } : {};
+        prepareHashSource(imgUrl, options).then(
+            (source) => {
+                // Never let image-hash reopen a user path or perform its own unbounded fetch. Its
+                // buffer form receives bytes already capped, signature-checked, and dimension-checked
+                // by the shared image-input boundary.
+                hashImageSource(source, 16, true, (error, data) => {
+                    if (error) {
+                        return cb(error);
+                    }
+                    return cb(null, data);
+                });
+            },
+            (error) => cb(error)
+        );
     }
 
     function compareHash(hashOne, hashTwo) {

--- a/src/image-processing/binarize.mjs
+++ b/src/image-processing/binarize.mjs
@@ -1,4 +1,4 @@
-import jimp from "jimp";
+import { Jimp } from "jimp";
 
 // Shared jimp binarization/preprocessing helpers for ocr-preprocessing.mjs -- previously
 // duplicated byte-identical across multiple preprocessing modules. One implementation now.
@@ -76,14 +76,14 @@ function sharpen(img) {
 }
 
 async function padAndScale(img, padding, scaleFactor, minWidth) {
-    const padded = await new jimp(
-        img.bitmap.width + padding * 2,
-        img.bitmap.height + padding * 2,
-        0xffffffff
-    );
+    const padded = new Jimp({
+        width: img.bitmap.width + padding * 2,
+        height: img.bitmap.height + padding * 2,
+        color: 0xffffffff
+    });
     padded.composite(img, padding, padding);
     const targetWidth = Math.max(minWidth, Math.round(padded.bitmap.width * scaleFactor));
-    padded.resize(targetWidth, jimp.AUTO);
+    padded.resize({ w: targetWidth });
     return padded;
 }
 

--- a/src/image-processing/color-adjustments.mjs
+++ b/src/image-processing/color-adjustments.mjs
@@ -1,0 +1,35 @@
+function clampChannel(value) {
+    return Math.max(0, Math.min(255, value));
+}
+
+/**
+ * Apply the additive brightness semantics used by the project's original Jimp release.
+ *
+ * Jimp 1.x interprets brightness as a channel multiplier. The OCR tuning and regression
+ * transform values are intentionally additive fractions of the full channel range, so keep
+ * that contract explicit and independent of future image-library changes.
+ *
+ * @param {{bitmap: {data: Buffer|Uint8Array}}} image
+ * @param {number} amount additive fraction in the inclusive range [-1, 1]
+ * @returns {typeof image}
+ */
+function adjustBrightness(image, amount) {
+    if (!Number.isFinite(amount) || amount < -1 || amount > 1) {
+        throw new RangeError("Brightness amount must be a finite number between -1 and 1");
+    }
+
+    const { data } = image.bitmap;
+    const offset = 255 * amount;
+    for (let index = 0; index < data.length; index += 4) {
+        data[index] = clampChannel(data[index] + offset);
+        data[index + 1] = clampChannel(data[index + 1] + offset);
+        data[index + 2] = clampChannel(data[index + 2] + offset);
+    }
+    return image;
+}
+
+export { adjustBrightness };
+
+export default {
+    adjustBrightness
+};

--- a/src/image-processing/ocr-preprocessing.mjs
+++ b/src/image-processing/ocr-preprocessing.mjs
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import jimp from "jimp";
-import { getImageDimensions } from "./util.mjs";
+import { JimpMime } from "jimp";
+import { readImage } from "./util.mjs";
+import { adjustBrightness } from "./color-adjustments.mjs";
 import smartCrop from "./smart-crop.mjs";
 import {
     computeOtsuThreshold,
@@ -39,7 +40,8 @@ const titleNameTypes = new Set(["name", "soft-name", "rotated-name"]);
  */
 async function prepareOcrVariants(imgPath, type, options = {}) {
     const { directory, logger = defaultLogger } = options;
-    const dimensions = await getImageDimensions(imgPath);
+    const baseImage = await readImage(imgPath);
+    const dimensions = baseImage.bitmap;
     const sourceSizing = smartCrop.assertOcrSourceSizeOk(dimensions);
     if (sourceSizing.upscaled) {
         logger.warn(
@@ -48,7 +50,6 @@ async function prepareOcrVariants(imgPath, type, options = {}) {
         );
     }
 
-    const baseImage = await jimp.read(imgPath);
     if (type === "rotated-name") {
         return {
             variants: await buildRotatedNameVariants(baseImage, {
@@ -69,7 +70,7 @@ async function prepareOcrVariants(imgPath, type, options = {}) {
             // no threshold) reads noticeably better on undersized sources -- see issue #156.
             lowResolutionSource: sourceSizing.upscaled
         });
-        const buffer = await processed.getBufferAsync(jimp.MIME_PNG);
+        const buffer = await processed.getBuffer(JimpMime.png);
         variants.push({
             region: template.key,
             psm: template.psm,
@@ -112,7 +113,7 @@ async function buildRotatedNameVariants(baseImage, options = {}) {
                 region: `rotated-name-${rotation === 90 ? "cw" : "ccw"}-${mode}`,
                 psm: template.psm,
                 characterWhitelist: nameCharacterWhitelist,
-                buffer: await processed.getBufferAsync(jimp.MIME_PNG),
+                buffer: await processed.getBuffer(JimpMime.png),
                 image: processed
             });
         }
@@ -133,12 +134,8 @@ async function cropAndPreprocess(baseImage, template, options = {}) {
  * OCR-friendly preprocessing: grayscale -> normalize -> blur -> upscale -> threshold -> invert -> sharpen.
  */
 async function buildOcrImage(img) {
-    let working = img
-        .clone()
-        .greyscale()
-        .normalize()
-        .contrast(preprocessConfig.contrast)
-        .brightness(preprocessConfig.brightness);
+    let working = img.clone().greyscale().normalize().contrast(preprocessConfig.contrast);
+    adjustBrightness(working, preprocessConfig.brightness);
     working = working.gaussian(preprocessConfig.blur);
     working = await padAndScale(
         working,
@@ -173,7 +170,7 @@ async function buildSoftOcrImage(img, invert = false) {
 
 async function writePreview(image, directory, type, regionKey) {
     const filePath = path.join(directory, `${type || "ocr"}-${regionKey}-${randomUUID()}.png`);
-    await image.writeAsync(filePath);
+    await image.write(filePath);
     return filePath;
 }
 

--- a/src/image-processing/smart-crop.mjs
+++ b/src/image-processing/smart-crop.mjs
@@ -1,7 +1,6 @@
-import jimp from "jimp";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import { getImageDimensions } from "./util.mjs";
+import { readImage } from "./util.mjs";
 import { round, clamp } from "../util.mjs";
 
 // Reusable region registry -- the shared "layer" every crop spot plugs into. setSymbol feeds the
@@ -183,7 +182,12 @@ function cropRegion(img, percents) {
     const cropHeight = clamp(round(height * percents.heightPercent), 1, height - top);
     const region = { left, top, width: cropWidth, height: cropHeight };
     return {
-        image: img.clone().crop(region.left, region.top, region.width, region.height),
+        image: img.clone().crop({
+            x: region.left,
+            y: region.top,
+            w: region.width,
+            h: region.height
+        }),
         region
     };
 }
@@ -235,16 +239,16 @@ function cropSetSymbolFromImage(img) {
  * on low-confidence crops -- both cases should fall back to full-card hashing at the call site.
  */
 async function writeSetSymbolSnippet(imgPath, directory) {
-    const dimensions = await getImageDimensions(imgPath);
+    const img = await readImage(imgPath);
+    const dimensions = img.bitmap;
     assertSourceSizeOk(dimensions);
-    const img = await jimp.read(imgPath);
     const result = cropSetSymbolFromImage(img);
     if (result.lowConfidence) {
         throw new Error(`Set symbol crop is low confidence: ${result.reason}`);
     }
     const ext = path.extname(imgPath) || ".jpg";
     const filePath = path.join(directory, `${randomUUID()}${ext}`);
-    await result.image.writeAsync(filePath);
+    await result.image.write(filePath);
     return filePath;
 }
 

--- a/src/image-processing/util.mjs
+++ b/src/image-processing/util.mjs
@@ -1,14 +1,305 @@
-import { promisify } from "node:util";
-import imageSize from "image-size";
+import { open } from "node:fs/promises";
+import { Jimp, JimpMime } from "jimp";
 
-const sizeOf = promisify(imageSize);
+const limits = Object.freeze({
+    maximumFileBytes: 32 * 1024 * 1024,
+    maximumRemoteBytes: 16 * 1024 * 1024,
+    maximumWidth: 12_000,
+    maximumHeight: 12_000,
+    maximumPixels: 40_000_000,
+    maximumRedirects: 3,
+    requestTimeoutMs: 15_000
+});
 
-async function getImageDimensions(imagePath) {
-    return sizeOf(imagePath);
+const allowedRemoteImageOrigins = new Set([
+    "https://cards.scryfall.io",
+    "https://img.scryfall.com"
+]);
+
+const jpegStartOfFrameMarkers = new Set([
+    0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf
+]);
+
+function invalidImage(reason) {
+    return new Error(`Invalid or unsupported image: ${reason}`);
 }
 
-export { getImageDimensions };
+function assertDimensionsWithinLimits({ width, height, format }) {
+    if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width < 1 || height < 1) {
+        throw invalidImage("dimensions must be positive integers");
+    }
+    if (width > limits.maximumWidth || height > limits.maximumHeight) {
+        throw invalidImage(
+            `dimensions exceed ${limits.maximumWidth}x${limits.maximumHeight} pixels`
+        );
+    }
+    if (width * height > limits.maximumPixels) {
+        throw invalidImage(`decoded size exceeds ${limits.maximumPixels} pixels`);
+    }
+    return { width, height, format };
+}
+
+function parsePngDimensions(buffer) {
+    const pngSignature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    if (buffer.length < 24 || !buffer.subarray(0, 8).equals(pngSignature)) {
+        return undefined;
+    }
+    if (buffer.readUInt32BE(8) !== 13 || buffer.toString("ascii", 12, 16) !== "IHDR") {
+        throw invalidImage("PNG does not start with a valid IHDR chunk");
+    }
+    return {
+        width: buffer.readUInt32BE(16),
+        height: buffer.readUInt32BE(20),
+        format: "png"
+    };
+}
+
+function parseGifDimensions(buffer) {
+    if (buffer.length < 10) return undefined;
+    const signature = buffer.toString("ascii", 0, 6);
+    if (signature !== "GIF87a" && signature !== "GIF89a") return undefined;
+    return {
+        width: buffer.readUInt16LE(6),
+        height: buffer.readUInt16LE(8),
+        format: "gif"
+    };
+}
+
+function parseBmpDimensions(buffer) {
+    if (buffer.length < 26 || buffer.toString("ascii", 0, 2) !== "BM") return undefined;
+    const dibHeaderSize = buffer.readUInt32LE(14);
+    if (dibHeaderSize === 12) {
+        return {
+            width: buffer.readUInt16LE(18),
+            height: buffer.readUInt16LE(20),
+            format: "bmp"
+        };
+    }
+    if (dibHeaderSize < 40 || buffer.length < 26) {
+        throw invalidImage("BMP has an unsupported DIB header");
+    }
+    return {
+        width: Math.abs(buffer.readInt32LE(18)),
+        height: Math.abs(buffer.readInt32LE(22)),
+        format: "bmp"
+    };
+}
+
+function parseJpegDimensions(buffer) {
+    if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) return undefined;
+
+    let offset = 2;
+    while (offset + 1 < buffer.length) {
+        if (buffer[offset] !== 0xff) {
+            throw invalidImage("JPEG marker stream is malformed");
+        }
+        while (offset < buffer.length && buffer[offset] === 0xff) offset += 1;
+        if (offset >= buffer.length) break;
+
+        const marker = buffer[offset];
+        offset += 1;
+        if (marker === 0xd9 || marker === 0xda) break;
+        if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+        if (offset + 2 > buffer.length) break;
+
+        const segmentLength = buffer.readUInt16BE(offset);
+        if (segmentLength < 2 || offset + segmentLength > buffer.length) {
+            throw invalidImage("JPEG segment length is invalid");
+        }
+        if (jpegStartOfFrameMarkers.has(marker)) {
+            if (segmentLength < 7) throw invalidImage("JPEG frame header is truncated");
+            return {
+                width: buffer.readUInt16BE(offset + 5),
+                height: buffer.readUInt16BE(offset + 3),
+                format: "jpeg"
+            };
+        }
+        offset += segmentLength;
+    }
+    throw invalidImage("JPEG dimensions were not found before image data");
+}
+
+function getImageDimensionsFromBuffer(value) {
+    const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value);
+    if (buffer.length < 1 || buffer.length > limits.maximumFileBytes) {
+        throw invalidImage(`file must be between 1 and ${limits.maximumFileBytes} bytes`);
+    }
+
+    const dimensions =
+        parsePngDimensions(buffer) ||
+        parseJpegDimensions(buffer) ||
+        parseGifDimensions(buffer) ||
+        parseBmpDimensions(buffer);
+    if (!dimensions) {
+        throw invalidImage("expected JPEG, PNG, GIF, or BMP data");
+    }
+    return assertDimensionsWithinLimits(dimensions);
+}
+
+async function readBoundedFile(imagePath) {
+    const handle = await open(imagePath, "r");
+    try {
+        const initialStats = await handle.stat();
+        if (
+            !initialStats.isFile() ||
+            initialStats.size < 1 ||
+            initialStats.size > limits.maximumFileBytes
+        ) {
+            throw invalidImage(`file must be between 1 and ${limits.maximumFileBytes} bytes`);
+        }
+
+        const buffer = Buffer.allocUnsafe(initialStats.size);
+        let offset = 0;
+        while (offset < buffer.length) {
+            const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+            if (bytesRead === 0) break;
+            offset += bytesRead;
+        }
+        const finalStats = await handle.stat();
+        if (offset !== buffer.length || finalStats.size !== initialStats.size) {
+            throw invalidImage("file changed while it was being read");
+        }
+        return buffer;
+    } finally {
+        await handle.close();
+    }
+}
+
+function parseAllowedRemoteUrl(value, expectedOrigin) {
+    let url;
+    try {
+        url = new URL(value);
+    } catch {
+        throw invalidImage("remote URL is invalid");
+    }
+    const allowedOrigin = expectedOrigin || url.origin;
+    if (
+        url.protocol !== "https:" ||
+        !allowedRemoteImageOrigins.has(url.origin) ||
+        url.origin !== allowedOrigin
+    ) {
+        throw invalidImage("remote URL must remain on an approved Scryfall image origin");
+    }
+    return url;
+}
+
+async function readBoundedResponse(response) {
+    const contentLength = Number(response.headers?.get?.("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > limits.maximumRemoteBytes) {
+        await response.body?.cancel?.();
+        throw invalidImage(`remote body exceeds ${limits.maximumRemoteBytes} bytes`);
+    }
+
+    if (!response.body?.getReader) {
+        const buffer = Buffer.from(await response.arrayBuffer());
+        if (buffer.length > limits.maximumRemoteBytes) {
+            throw invalidImage(`remote body exceeds ${limits.maximumRemoteBytes} bytes`);
+        }
+        return buffer;
+    }
+
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > limits.maximumRemoteBytes) {
+            await reader.cancel();
+            throw invalidImage(`remote body exceeds ${limits.maximumRemoteBytes} bytes`);
+        }
+        chunks.push(Buffer.from(value));
+    }
+    return Buffer.concat(chunks, total);
+}
+
+async function downloadBoundedImage(
+    source,
+    { fetchImpl = globalThis.fetch, headers = {}, signal } = {}
+) {
+    let url = parseAllowedRemoteUrl(source);
+    const expectedOrigin = url.origin;
+    const requestSignal = signal || AbortSignal.timeout(limits.requestTimeoutMs);
+
+    for (let redirects = 0; redirects <= limits.maximumRedirects; redirects += 1) {
+        const response = await fetchImpl(url, {
+            headers,
+            redirect: "manual",
+            signal: requestSignal
+        });
+        if (response.status >= 300 && response.status < 400) {
+            const location = response.headers?.get?.("location");
+            await response.body?.cancel?.();
+            if (!location || redirects === limits.maximumRedirects) {
+                throw invalidImage("remote redirect limit exceeded");
+            }
+            url = parseAllowedRemoteUrl(new URL(location, url).href, expectedOrigin);
+            continue;
+        }
+        if (!response.ok) {
+            await response.body?.cancel?.();
+            throw new Error(`Remote image request failed with HTTP ${response.status}`);
+        }
+        return readBoundedResponse(response);
+    }
+    throw invalidImage("remote redirect limit exceeded");
+}
+
+function isRemoteImageSource(source) {
+    return typeof source === "string" && /^https?:\/\//i.test(source);
+}
+
+async function readImageInput(source, options = {}) {
+    const buffer = isRemoteImageSource(source)
+        ? await downloadBoundedImage(source, options)
+        : await readBoundedFile(source);
+    const dimensions = getImageDimensionsFromBuffer(buffer);
+    return { buffer, dimensions };
+}
+
+async function decodeImageInput({ buffer, dimensions }) {
+    const decodeOptions =
+        dimensions.format === "jpeg"
+            ? {
+                  [JimpMime.jpeg]: {
+                      maxResolutionInMP: limits.maximumPixels / 1_000_000,
+                      maxMemoryUsageInMB: 256
+                  }
+              }
+            : undefined;
+    const image = await Jimp.fromBuffer(buffer, decodeOptions);
+    if (image.bitmap.width !== dimensions.width || image.bitmap.height !== dimensions.height) {
+        throw invalidImage("decoded dimensions do not match the validated header");
+    }
+    return image;
+}
+
+async function readImage(source, options = {}) {
+    return decodeImageInput(await readImageInput(source, options));
+}
+
+async function getImageDimensions(imagePath) {
+    return getImageDimensionsFromBuffer(await readBoundedFile(imagePath));
+}
+
+export {
+    allowedRemoteImageOrigins,
+    decodeImageInput,
+    downloadBoundedImage,
+    getImageDimensions,
+    getImageDimensionsFromBuffer,
+    limits,
+    readImage,
+    readImageInput
+};
 
 export default {
-    getImageDimensions
+    decodeImageInput,
+    downloadBoundedImage,
+    getImageDimensions,
+    getImageDimensionsFromBuffer,
+    limits,
+    readImage,
+    readImageInput
 };

--- a/src/regression/image-fixture.mjs
+++ b/src/regression/image-fixture.mjs
@@ -1,5 +1,6 @@
 import path from "node:path";
-import jimp from "jimp";
+import { readImage } from "../image-processing/util.mjs";
+import { adjustBrightness } from "../image-processing/color-adjustments.mjs";
 
 function clampPercent(value = 0) {
     return Math.max(0, Math.min(0.45, value));
@@ -20,7 +21,7 @@ function applyCrop(image, crop) {
         1,
         image.bitmap.height - top - Math.round(image.bitmap.height * bottomPercent)
     );
-    image.crop(left, top, width, height);
+    image.crop({ x: left, y: top, w: width, h: height });
 }
 
 async function materializeFixture(fixture, directory) {
@@ -29,12 +30,12 @@ async function materializeFixture(fixture, directory) {
         return fixture.imagePath;
     }
 
-    const image = await jimp.read(fixture.imagePath);
+    const image = await readImage(fixture.imagePath);
     if (transform.crop) {
         applyCrop(image, transform.crop);
     }
     if (typeof transform.brightness === "number") {
-        image.brightness(transform.brightness);
+        adjustBrightness(image, transform.brightness);
     }
     if (typeof transform.contrast === "number") {
         image.contrast(transform.contrast);
@@ -46,12 +47,12 @@ async function materializeFixture(fixture, directory) {
         image.rotate(transform.rotate, false);
     }
     if (transform.resize) {
-        image.resize(transform.resize.width, transform.resize.height);
+        image.resize({ w: transform.resize.width, h: transform.resize.height });
     }
 
     const safeId = fixture.id.replace(/[^a-z0-9_-]/gi, "-");
     const outputPath = path.join(directory, `${safeId}.png`);
-    await image.writeAsync(outputPath);
+    await image.write(outputPath);
     return outputPath;
 }
 

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -13,6 +13,7 @@ import { resolveCardName } from "../processor/name-resolver.mjs";
 const noCacheOcrOptions = Object.freeze({
     cacheMethod: "none"
 });
+const maximumCasesPerOcrSession = 40;
 
 const silentLogger = {
     info: () => {},
@@ -353,15 +354,20 @@ async function runRegression(manifest, options = {}) {
     const managesOcrSession =
         dependencies.ImageProcessor === imageProcessorModule ||
         typeof options.dependencies?.createOcrSession === "function";
-    const ocrSession = managesOcrSession
-        ? await dependencies.createOcrSession({ ...ocrOptions, logger: silentLogger })
-        : null;
-    if (ocrSession) {
-        dependencies.ocrOptions = { ...dependencies.ocrOptions, session: ocrSession };
+    let ocrSession;
+
+    async function startOcrSession() {
+        await ocrSession?.terminate();
+        ocrSession = undefined;
+        ocrSession = await dependencies.createOcrSession({ ...ocrOptions, logger: silentLogger });
+        dependencies.ocrOptions = { ...ocrOptions, session: ocrSession };
     }
 
     try {
-        for (const fixture of selectedCases) {
+        for (const [index, fixture] of selectedCases.entries()) {
+            if (managesOcrSession && index % maximumCasesPerOcrSession === 0) {
+                await startOcrSession();
+            }
             results.push(await analyzeFixture(fixture, manifest, context, dependencies));
         }
         return {
@@ -377,7 +383,9 @@ async function runRegression(manifest, options = {}) {
                 ocrLanguageSource: options.ocrModel
                     ? `OCR candidate ${options.ocrModel.id}`
                     : "bundled official tessdata_best eng.traineddata",
-                ocrWorkerLifecycle: "shared process; adaptive state reset per crop",
+                ocrWorkerLifecycle:
+                    `shared sequentially for at most ${maximumCasesPerOcrSession} cases; ` +
+                    "adaptive state reset per crop",
                 temporaryArtifacts: "deleted after each case"
             },
             pending: {
@@ -400,6 +408,7 @@ export {
     analyzeFixture,
     comparisonScore,
     evaluateResult,
+    maximumCasesPerOcrSession,
     rankPrintCandidates,
     runRegression,
     summarize,
@@ -410,6 +419,7 @@ export default {
     analyzeFixture,
     comparisonScore,
     evaluateResult,
+    maximumCasesPerOcrSession,
     rankPrintCandidates,
     runRegression,
     summarize,

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -1,6 +1,5 @@
 import os from "os";
 import path from "node:path";
-import jimp from "jimp";
 import { assert } from "chai";
 import sinon from "sinon";
 import exportProcessor from "../../src/export-processor/index.mjs";
@@ -323,12 +322,7 @@ describe("Integration::", () => {
             assert.isTrue(error.calledWithMatch(sinon.match(/cleanup failed/)));
         });
 
-        // Scryfall's image CDN 400s a header-less request; jimp's own URL loader sends none by
-        // default. Lock in that a remote set-symbol crop always carries a User-Agent.
-        it("passes a User-Agent header when jimp reads a remote set-symbol image", async () => {
-            const readStub = sandbox.stub(jimp, "read").resolves({
-                clone: () => ({ crop: () => ({}) })
-            });
+        it("passes a User-Agent header when reading a remote set-symbol image", async () => {
             let hasher = ProcessHashes.create({
                 cards: [
                     {
@@ -342,8 +336,9 @@ describe("Integration::", () => {
                 name: "Test",
                 hashMode: "set-symbol"
             });
+            const readStub = sandbox.stub(hasher.dependencies, "readImage").resolves({});
             sandbox.stub(hasher.dependencies, "CropSetSymbol").returns({
-                image: { writeAsync: sandbox.stub().resolves() },
+                image: { write: sandbox.stub().resolves() },
                 lowConfidence: false
             });
             sandbox.stub(Hash, "hashImage").callsArgWith(1, null, FAKE_HASH);
@@ -354,34 +349,32 @@ describe("Integration::", () => {
             );
 
             assert.isTrue(readStub.calledOnce);
-            const [source] = readStub.firstCall.args;
-            assert.equal(source.url, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
-            assert.property(source.headers, "User-Agent");
-            assert.isNotEmpty(source.headers["User-Agent"]);
+            const [source, options] = readStub.firstCall.args;
+            assert.equal(source, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
+            assert.property(options.headers, "User-Agent");
+            assert.isNotEmpty(options.headers["User-Agent"]);
         });
 
         it("reads a local fixture path as a plain string, not a headers request object", async () => {
             const fixturePath = path.resolve(
                 "test-images/regression/scryfall/fin-570-vivi-ornitier-25ef2d44.jpg"
             );
-            const readStub = sandbox.stub(jimp, "read").resolves({
-                clone: () => ({ crop: () => ({}) })
-            });
             let hasher = ProcessHashes.create({
                 cards: [{ image_uris: { normal: fixturePath }, set_name: "SET_A" }],
                 localHash: CLOSE_DIFF_HASH,
                 name: "Test",
                 hashMode: "set-symbol"
             });
+            const readStub = sandbox.stub(hasher.dependencies, "readImage").resolves({});
             sandbox.stub(hasher.dependencies, "CropSetSymbol").returns({
-                image: { writeAsync: sandbox.stub().resolves() },
+                image: { write: sandbox.stub().resolves() },
                 lowConfidence: false
             });
             sandbox.stub(Hash, "hashImage").callsArgWith(1, null, FAKE_HASH);
 
             await hasher._hashRemoteSetSymbol(fixturePath, "/tmp");
 
-            assert.isTrue(readStub.calledOnceWithExactly(fixturePath));
+            assert.isTrue(readStub.calledOnceWithExactly(fixturePath, undefined));
         });
 
         it("Should fall back to full remote hash when set-symbol crop is low confidence", async () => {

--- a/test/hashing/hashing.spec.mjs
+++ b/test/hashing/hashing.spec.mjs
@@ -7,10 +7,18 @@ describe("Hashing::", () => {
     const fakeHash = "0773063f063f36070e070a070f378e7f1f000fff0fff020103f00ffb0f810ff0";
     let Hashing;
     let imageHashStub;
+    let loadImageInputStub;
     describe("ImageHashing::", () => {
         beforeEach(() => {
             imageHashStub = sinon.stub().callsArgWith(3, null, fakeHash);
-            Hashing = createHashing({ imageHash: imageHashStub });
+            loadImageInputStub = sinon.stub().resolves({
+                buffer: Buffer.from("validated image"),
+                dimensions: { width: 10, height: 10, format: "jpeg" }
+            });
+            Hashing = createHashing({
+                imageHash: imageHashStub,
+                loadImageInput: loadImageInputStub
+            });
         });
         afterEach(() => {
             sinon.restore();
@@ -31,21 +39,24 @@ describe("Hashing::", () => {
         });
 
         it("Should return an error", (done) => {
-            imageHashStub.callsArgWith(3, {}, null);
+            loadImageInputStub.rejects({});
             Hashing.hashImage("", (error, hash) => {
                 assert.deepEqual(error, {});
                 assert.isUndefined(hash);
-                assert.isTrue(imageHashStub.calledOnce, "Image Hash called");
+                assert.isFalse(imageHashStub.called, "Image Hash not called");
                 done();
             });
         });
 
         it("does not let a malformed remote URL break hashing", (done) => {
             const consoleLogStub = sinon.stub(console, "log");
+            loadImageInputStub.rejects(
+                new Error("Invalid or unsupported image: remote URL is invalid")
+            );
 
             Hashing.hashImage("http://%", (error, hash) => {
-                assert.isNull(error);
-                assert.equal(hash, fakeHash);
+                assert.match(error.message, /remote URL is invalid/);
+                assert.isUndefined(hash);
                 assert.isTrue(
                     consoleLogStub.calledOnceWithExactly("INFO  Hashing image: invalid URL")
                 );

--- a/test/image-hashing/hash-image.spec.mjs
+++ b/test/image-hashing/hash-image.spec.mjs
@@ -5,12 +5,23 @@ import { compareHash, createHashing } from "../../src/image-hashing/hash-image.m
 describe("image-hashing::hash-image", () => {
     let sandbox;
     let imageHashStub;
+    let loadImageInputStub;
+    let decodeImageStub;
     let hashImage;
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
         imageHashStub = sandbox.stub();
-        ({ hashImage } = createHashing({ imageHash: imageHashStub }));
+        loadImageInputStub = sandbox.stub().resolves({
+            buffer: Buffer.from("validated image"),
+            dimensions: { width: 10, height: 10, format: "jpeg" }
+        });
+        decodeImageStub = sandbox.stub();
+        ({ hashImage } = createHashing({
+            imageHash: imageHashStub,
+            loadImageInput: loadImageInputStub,
+            decodeImage: decodeImageStub
+        }));
     });
 
     afterEach(() => {
@@ -18,32 +29,55 @@ describe("image-hashing::hash-image", () => {
     });
 
     describe("hashImage::", () => {
-        // Scryfall's image CDN 400s a header-less request (Node's global fetch, which the
-        // image-hash package uses, sends no User-Agent by default) -- every remote hash was
-        // failing outright until this was fixed. Lock in that a remote URL always carries a
-        // User-Agent through image-hash's {url, headers} request-object form.
-        it("passes a User-Agent header for a remote http(s) URL", (done) => {
+        it("loads remote images through the bounded boundary with a User-Agent", (done) => {
             imageHashStub.callsArgWith(3, null, "hash");
 
             hashImage("https://cards.scryfall.io/normal/front/a/b/card.jpg", (err, hash) => {
                 assert.isNull(err);
                 assert.equal(hash, "hash");
+                assert.isTrue(loadImageInputStub.calledOnce);
+                const [url, options] = loadImageInputStub.firstCall.args;
+                assert.equal(url, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
+                assert.property(options.headers, "User-Agent");
                 assert.isTrue(imageHashStub.calledOnce);
                 const [source] = imageHashStub.firstCall.args;
-                assert.equal(source.url, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
-                assert.property(source.headers, "User-Agent");
-                assert.isNotEmpty(source.headers["User-Agent"]);
+                assert.instanceOf(source.data, Buffer);
+                assert.equal(source.ext, "image/jpeg");
                 done(err);
             });
         });
 
-        it("passes a local file path through unchanged (no headers wrapper)", (done) => {
+        it("loads local images through the bounded boundary without request headers", (done) => {
             imageHashStub.callsArgWith(3, null, "hash");
 
             hashImage("/tmp/some/local/card.png", (err) => {
+                assert.isTrue(
+                    loadImageInputStub.calledOnceWithExactly("/tmp/some/local/card.png", {})
+                );
                 assert.isTrue(imageHashStub.calledOnce);
                 const [source] = imageHashStub.firstCall.args;
-                assert.equal(source, "/tmp/some/local/card.png");
+                assert.instanceOf(source.data, Buffer);
+                done(err);
+            });
+        });
+
+        it("normalizes a validated GIF or BMP before hashing", (done) => {
+            loadImageInputStub.resolves({
+                buffer: Buffer.from("validated gif"),
+                dimensions: { width: 10, height: 10, format: "gif" }
+            });
+            decodeImageStub.resolves({
+                getBuffer: sandbox.stub().resolves(Buffer.from("normalized png"))
+            });
+            imageHashStub.callsArgWith(3, null, "hash");
+
+            hashImage("/tmp/card.gif", (err, hash) => {
+                assert.isNull(err);
+                assert.equal(hash, "hash");
+                assert.isTrue(decodeImageStub.calledOnce);
+                const [source] = imageHashStub.firstCall.args;
+                assert.equal(source.ext, "image/png");
+                assert.equal(source.data.toString(), "normalized png");
                 done(err);
             });
         });
@@ -55,6 +89,18 @@ describe("image-hashing::hash-image", () => {
                 assert.instanceOf(err, Error);
                 assert.equal(err.message, "boom");
                 assert.isUndefined(hash);
+                done();
+            });
+        });
+
+        it("does not invoke image-hash when bounded input validation fails", (done) => {
+            loadImageInputStub.rejects(
+                new Error("Invalid or unsupported image: dimensions exceed limit")
+            );
+
+            hashImage("/tmp/hostile.jpg", (err) => {
+                assert.match(err.message, /dimensions exceed limit/);
+                assert.isFalse(imageHashStub.called);
                 done();
             });
         });

--- a/test/image-processing/color-adjustments.spec.mjs
+++ b/test/image-processing/color-adjustments.spec.mjs
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { Jimp } from "jimp";
+import { adjustBrightness } from "../../src/image-processing/color-adjustments.mjs";
+
+function pixelChannels(image) {
+    return Array.from(image.bitmap.data.subarray(0, 4));
+}
+
+describe("color adjustments", () => {
+    it("preserves the additive brightness contract used by OCR tuning", () => {
+        const image = new Jimp({ width: 1, height: 1, color: 0x646464ff });
+
+        expect(adjustBrightness(image, 0.1)).to.equal(image);
+        expect(pixelChannels(image)).to.deep.equal([125, 125, 125, 255]);
+    });
+
+    it("supports negative brightness and clamps channel bounds", () => {
+        const darkened = new Jimp({ width: 1, height: 1, color: 0x646464ff });
+        const clamped = new Jimp({ width: 1, height: 1, color: 0xfa050aff });
+
+        adjustBrightness(darkened, -0.2);
+        adjustBrightness(clamped, 0.1);
+
+        expect(pixelChannels(darkened)).to.deep.equal([49, 49, 49, 255]);
+        expect(pixelChannels(clamped)).to.deep.equal([255, 30, 35, 255]);
+    });
+
+    it("rejects non-finite or out-of-range brightness amounts", () => {
+        const image = new Jimp({ width: 1, height: 1, color: 0x646464ff });
+
+        expect(() => adjustBrightness(image, Number.NaN)).to.throw(RangeError);
+        expect(() => adjustBrightness(image, 1.01)).to.throw(RangeError);
+        expect(() => adjustBrightness(image, -1.01)).to.throw(RangeError);
+    });
+});

--- a/test/image-processing/ocr-preprocessing.spec.mjs
+++ b/test/image-processing/ocr-preprocessing.spec.mjs
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import path from "node:path";
 import sinon from "sinon";
-import jimp from "jimp";
+import { Jimp } from "jimp";
 import os from "node:os";
 import fs from "node:fs/promises";
 import { randomUUID } from "node:crypto";
@@ -53,9 +53,9 @@ describe("OCR preprocessing::", function () {
         it("still rejects a source too degraded to be a recoverable upscale", async () => {
             const tempDir = await makeTempDir();
             try {
-                const tinyImage = await new jimp(100, 100, 0xffffffff);
+                const tinyImage = new Jimp({ width: 100, height: 100, color: 0xffffffff });
                 const tinyPath = path.join(tempDir, "tiny.png");
-                await tinyImage.writeAsync(tinyPath);
+                await tinyImage.write(tinyPath);
 
                 let caughtError;
                 try {

--- a/test/image-processing/smart-crop.spec.mjs
+++ b/test/image-processing/smart-crop.spec.mjs
@@ -2,7 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import jimp from "jimp";
+import { Jimp } from "jimp";
 import { assert } from "chai";
 import {
     regions,
@@ -27,7 +27,7 @@ async function makeTempDir() {
 }
 
 async function checkerboardImage(width, height) {
-    const img = await new jimp(width, height, 0xffffffff);
+    const img = new Jimp({ width, height, color: 0xffffffff });
     const { data } = img.bitmap;
     for (let y = 0; y < height; y++) {
         for (let x = 0; x < width; x++) {
@@ -46,7 +46,7 @@ async function checkerboardImage(width, height) {
 describe("Smart crop::", () => {
     describe("computeGreyscaleStdDev / assessConfidence::", () => {
         it("flags a solid-color image as low confidence", async () => {
-            const img = await new jimp(100, 100, 0x808080ff);
+            const img = new Jimp({ width: 100, height: 100, color: 0x808080ff });
             const stdDev = computeGreyscaleStdDev(img);
             assert.equal(stdDev, 0);
             const result = assessConfidence(img);
@@ -104,7 +104,7 @@ describe("Smart crop::", () => {
         });
 
         it("crops a real card fixture to the expected proportions", async () => {
-            const baseImage = await jimp.read(FIXTURE_PATH);
+            const baseImage = await Jimp.read(FIXTURE_PATH);
             const { width, height } = baseImage.bitmap;
 
             const { image, region } = cropSetSymbolFromImage(baseImage);
@@ -171,9 +171,9 @@ describe("Smart crop::", () => {
         });
 
         it("throws when the source image is too small", async () => {
-            const smallImage = await new jimp(100, 100, 0xffffffff);
+            const smallImage = new Jimp({ width: 100, height: 100, color: 0xffffffff });
             const smallPath = path.join(tempDir, "small.png");
-            await smallImage.writeAsync(smallPath);
+            await smallImage.write(smallPath);
 
             let caughtError;
             try {
@@ -186,9 +186,9 @@ describe("Smart crop::", () => {
         });
 
         it("throws when the crop lands on a low-confidence flat region", async () => {
-            const flatImage = await new jimp(1000, 1400, 0x808080ff);
+            const flatImage = new Jimp({ width: 1000, height: 1400, color: 0x808080ff });
             const flatPath = path.join(tempDir, "flat.png");
-            await flatImage.writeAsync(flatPath);
+            await flatImage.write(flatPath);
 
             let caughtError;
             try {

--- a/test/image-processing/util.spec.mjs
+++ b/test/image-processing/util.spec.mjs
@@ -1,0 +1,192 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { assert } from "chai";
+import { Jimp, JimpMime } from "jimp";
+import {
+    getImageDimensions,
+    getImageDimensionsFromBuffer,
+    limits,
+    readImage
+} from "../../src/image-processing/util.mjs";
+
+const JPEG_FIXTURE = path.resolve(
+    "test-images/regression/scryfall/fin-570-vivi-ornitier-25ef2d44.jpg"
+);
+const PNG_FIXTURE = path.resolve("test-images/QueenMarchesa.png");
+
+function makePngHeader(width, height) {
+    const buffer = Buffer.alloc(24);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer);
+    buffer.writeUInt32BE(13, 8);
+    buffer.write("IHDR", 12, "ascii");
+    buffer.writeUInt32BE(width, 16);
+    buffer.writeUInt32BE(height, 20);
+    return buffer;
+}
+
+async function captureError(operation) {
+    try {
+        await operation();
+    } catch (error) {
+        return error;
+    }
+    return undefined;
+}
+
+describe("Bounded image input::", function () {
+    this.timeout(15000);
+
+    it("reads and decodes supported JPEG and PNG files through the bounded buffer", async () => {
+        const jpegDimensions = await getImageDimensions(JPEG_FIXTURE);
+        const pngDimensions = await getImageDimensions(PNG_FIXTURE);
+        const jpeg = await readImage(JPEG_FIXTURE);
+        const png = await readImage(PNG_FIXTURE);
+
+        assert.deepInclude(jpegDimensions, { width: 488, height: 680, format: "jpeg" });
+        assert.deepInclude(pngDimensions, { width: 745, height: 1040, format: "png" });
+        assert.equal(jpeg.bitmap.width, jpegDimensions.width);
+        assert.equal(jpeg.bitmap.height, jpegDimensions.height);
+        assert.equal(png.bitmap.width, pngDimensions.width);
+        assert.equal(png.bitmap.height, pngDimensions.height);
+    });
+
+    it("reads and decodes bounded GIF and BMP inputs", async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "supported-images-"));
+        try {
+            const source = new Jimp({ width: 20, height: 30, color: 0x123456ff });
+            for (const [extension, mime] of [
+                ["gif", JimpMime.gif],
+                ["bmp", JimpMime.bmp]
+            ]) {
+                const imagePath = path.join(tempDir, `card.${extension}`);
+                await fs.writeFile(imagePath, await source.getBuffer(mime));
+                const image = await readImage(imagePath);
+                assert.deepInclude(image.bitmap, { width: 20, height: 30 });
+            }
+        } finally {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects the ICNS, JXL, and HEIF signatures from the image-size advisories", async () => {
+        const samples = [
+            Buffer.from("icns00000010", "ascii"),
+            Buffer.from([0x00, 0x00, 0x00, 0x0c, 0x4a, 0x58, 0x4c, 0x20, 0x0d, 0x0a, 0x87, 0x0a]),
+            Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63])
+        ];
+
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "unsupported-images-"));
+        try {
+            for (const [index, sample] of samples.entries()) {
+                assert.throws(
+                    () => getImageDimensionsFromBuffer(sample),
+                    /expected JPEG, PNG, GIF, or BMP data/
+                );
+                const imagePath = path.join(tempDir, `advisory-${index}.jpg`);
+                await fs.writeFile(imagePath, sample);
+                const error = await captureError(() => readImage(imagePath));
+                assert.instanceOf(error, Error);
+                assert.match(error.message, /expected JPEG, PNG, GIF, or BMP data/);
+            }
+        } finally {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects excessive dimensions and decoded pixel counts before Jimp runs", () => {
+        assert.throws(
+            () => getImageDimensionsFromBuffer(makePngHeader(limits.maximumWidth + 1, 100)),
+            /dimensions exceed/
+        );
+        assert.throws(
+            () => getImageDimensionsFromBuffer(makePngHeader(10_000, 5_000)),
+            /decoded size exceeds/
+        );
+    });
+
+    it("rejects a source file over the byte limit without allocating its contents", async () => {
+        const tempPath = path.join(os.tmpdir(), `oversized-image-${randomUUID()}.png`);
+        const handle = await fs.open(tempPath, "w");
+        try {
+            await handle.truncate(limits.maximumFileBytes + 1);
+        } finally {
+            await handle.close();
+        }
+
+        try {
+            const error = await captureError(() => getImageDimensions(tempPath));
+            assert.instanceOf(error, Error);
+            assert.match(error.message, /file must be between 1 and/);
+        } finally {
+            await fs.rm(tempPath, { force: true });
+        }
+    });
+
+    it("downloads Scryfall images with manual redirects, request headers, and byte limits", async () => {
+        const fixture = await fs.readFile(JPEG_FIXTURE);
+        const calls = [];
+        const fetchImpl = async (url, init) => {
+            calls.push({ url: String(url), init });
+            if (calls.length === 1) {
+                return new Response(null, {
+                    status: 302,
+                    headers: { location: "/normal/front/a/b/card.jpg" }
+                });
+            }
+            return new Response(fixture, {
+                status: 200,
+                headers: { "content-length": String(fixture.length) }
+            });
+        };
+
+        const image = await readImage("https://cards.scryfall.io/redirect/card.jpg", {
+            fetchImpl,
+            headers: { "User-Agent": "test-agent" }
+        });
+
+        assert.equal(image.bitmap.width, 488);
+        assert.lengthOf(calls, 2);
+        assert.equal(calls[0].init.redirect, "manual");
+        assert.equal(calls[1].init.headers["User-Agent"], "test-agent");
+        assert.equal(calls[1].url, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
+    });
+
+    it("does not forward headers across a cross-origin redirect", async () => {
+        let calls = 0;
+        const fetchImpl = async () => {
+            calls += 1;
+            return new Response(null, {
+                status: 302,
+                headers: { location: "https://example.test/stolen.jpg" }
+            });
+        };
+
+        const error = await captureError(() =>
+            readImage("https://cards.scryfall.io/normal/front/a/b/card.jpg", {
+                fetchImpl,
+                headers: { Authorization: "secret" }
+            })
+        );
+
+        assert.equal(calls, 1);
+        assert.instanceOf(error, Error);
+        assert.match(error.message, /must remain on an approved Scryfall image origin/);
+    });
+
+    it("rejects an oversized remote body from Content-Length before reading it", async () => {
+        const fetchImpl = async () =>
+            new Response(null, {
+                status: 200,
+                headers: { "content-length": String(limits.maximumRemoteBytes + 1) }
+            });
+
+        const error = await captureError(() =>
+            readImage("https://cards.scryfall.io/normal/front/a/b/card.jpg", { fetchImpl })
+        );
+
+        assert.instanceOf(error, Error);
+        assert.match(error.message, /remote body exceeds/);
+    });
+});

--- a/test/regression/regression-runner.spec.mjs
+++ b/test/regression/regression-runner.spec.mjs
@@ -6,6 +6,7 @@ import matchNameModule from "../../src/fuzzy-matching/match-name.mjs";
 import { QUALITY_LEVELS, loadManifest, validateManifest } from "../../src/regression/manifest.mjs";
 import { formatBenchmarkReport } from "../../src/regression/report.mjs";
 import {
+    maximumCasesPerOcrSession,
     runRegression,
     summarize,
     summarizeGate
@@ -355,7 +356,81 @@ describe("Regression framework::", () => {
         assert.equal(report.isolation.ocrLanguageSource, "OCR candidate official-eng-fast");
         assert.equal(
             report.isolation.ocrWorkerLifecycle,
-            "shared process; adaptive state reset per crop"
+            "shared sequentially for at most 40 cases; adaptive state reset per crop"
+        );
+    });
+
+    it("recycles the OCR worker after the fixed case budget", async () => {
+        const manifest = {
+            path: "/fixtures/manifest.json",
+            catalog: [
+                {
+                    name: "Pacifism",
+                    set: "BBD",
+                    collectorNumber: "101",
+                    referenceImagePath: "/fixtures/reference.jpg"
+                }
+            ],
+            cases: Array.from({ length: maximumCasesPerOcrSession + 1 }, (_, index) => ({
+                id: `case-${index}`,
+                image: `case-${index}.jpg`,
+                imagePath: `/fixtures/case-${index}.jpg`,
+                quality: "clean-scan",
+                expected: { name: "Pacifism", set: "BBD", collectorNumber: "101" }
+            }))
+        };
+        const sessions = [];
+        const receivedSessions = [];
+
+        const report = await runRegression(manifest, {
+            dependencies: {
+                ImageProcessor: {
+                    create: ({ ocrOptions }) => {
+                        receivedSessions.push(ocrOptions.session);
+                        return {
+                            extract: (callback) =>
+                                callback(null, {
+                                    cleanText: "PACIFISM",
+                                    dirtyText: "Pacifism",
+                                    confidence: 99,
+                                    bestVariant: { region: "name-core" }
+                                })
+                        };
+                    }
+                },
+                MatchName: matchNameModule,
+                Hash: {
+                    hashImage: (_imagePath, callback) => callback(null, "fresh-hash"),
+                    compareHash: () => ({
+                        twoBitMatches: 1,
+                        fourBitMatches: 1,
+                        stringCompare: 1
+                    })
+                },
+                materializeFixture: async (fixture) => fixture.imagePath,
+                createOcrSession: async () => {
+                    const session = {
+                        terminateCalls: 0,
+                        async terminate() {
+                            this.terminateCalls += 1;
+                        }
+                    };
+                    sessions.push(session);
+                    return session;
+                }
+            }
+        });
+
+        assert.equal(report.summary.passed, maximumCasesPerOcrSession + 1);
+        assert.lengthOf(sessions, 2);
+        assert.deepEqual(
+            receivedSessions.slice(0, maximumCasesPerOcrSession),
+            Array(maximumCasesPerOcrSession).fill(sessions[0])
+        );
+        assert.equal(receivedSessions.at(-1), sessions[1]);
+        assert.deepEqual(
+            sessions.map((session) => session.terminateCalls),
+            [1, 1]
         );
     });
 

--- a/test/scripts/run-regression.spec.mjs
+++ b/test/scripts/run-regression.spec.mjs
@@ -29,6 +29,10 @@ describe("run-regression CLI::", () => {
         const report = {
             summary: { passed: 1, total: 1, passRate: 100 },
             gate: { passed: 1, total: 1, failed: 0, nonBlocking: 0, nonBlockingFailed: 0 },
+            isolation: {
+                ocrWorkerLifecycle:
+                    "shared sequentially for at most 40 cases; adaptive state reset per crop"
+            },
             pending: { cases: 0, placeholderCases: 0 }
         };
 
@@ -59,6 +63,10 @@ describe("run-regression CLI::", () => {
         assert.strictEqual(result, report);
         assert.strictEqual(receivedOptions.ocrModel, selectedCandidate);
         assert.include(lines, "OCR model: official-eng-fast");
+        assert.include(
+            lines,
+            "Tesseract worker: shared sequentially for at most 40 cases; adaptive state reset per crop"
+        );
     });
 
     it("rejects an OCR candidate ID that is not in the verified manifest", async () => {


### PR DESCRIPTION
## Summary

- eliminate all nine reported production dependency advisories
- add one bounded input boundary for local and Scryfall-hosted images
- preserve regression-qualified OCR and image-matching behavior

## What Changed

- remove vulnerable `image-size` parsing and accept only bounded JPEG, PNG, GIF, and BMP inputs
- route OCR, set-symbol processing, and perceptual hashing through validated buffers
- upgrade Jimp to 1.6.1 while preserving the existing additive brightness contract
- pin Tesseract.js 3.0.3 and apply version-scoped `flatted` and `brace-expansion` overrides
- recycle regression OCR workers after 40 cases to bound Tesseract 3 WASM state
- document advisory reachability, compensating controls, and residual risk

## Validation

- `fnm exec --using=22.22.1 -- pnpm check:fast`
- `fnm exec --using=22.22.1 -- pnpm coverage:check` — 440 tests; 92.77% statements
- `fnm exec --using=22.22.1 -- pnpm test:regression` — 151/151 blocking, 156/158 overall
- `CARD_NAMES_DB_PATH=<isolated seeded db> fnm exec --using=22.22.1 -- pnpm verify`
- `fnm exec --using=22.22.1 -- pnpm install --frozen-lockfile --ignore-scripts --offline`
- `fnm exec --using=22.22.1 -- pnpm audit --prod` — no known vulnerabilities

## Scope Notes

- Tesseract.js remains pinned to the regression-qualified 3.0.3 engine
- two existing pending MIR fixtures remain explicitly non-blocking
- no expectations or fixture labels were weakened
