### PR TITLE
Prepare the 0.2.0 distribution and release contract

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,4 @@
-# No "v" prefix: matches the project's existing published tags (0.1.6, 0.1.8). The old "v$..."
-# templates here never matched those tags, so version-resolver could never find a prior release
-# to bump from and the draft stuck at a hardcoded 0.1.0 baseline indefinitely (see the v0.2.0
-# release published to reset this).
+# Release tags intentionally omit a "v" prefix to preserve the published 0.1.6/0.1.8 convention.
 name-template: "$RESOLVED_VERSION 🌈"
 tag-template: "$RESOLVED_VERSION"
 categories:

--- a/.github/workflows/gh-release.action.yml
+++ b/.github/workflows/gh-release.action.yml
@@ -6,7 +6,8 @@ on:
         branches:
             - master
         tags:
-            - "v*"
+            # Keep this aligned with release-drafter.yml's no-v tag template.
+            - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
     update_release_draft:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,9 @@ cd MTG-Card-Analyzer
 node scripts/setup.mjs
 ```
 
-That installs deps (also runs `lefthook install` via the `prepare` script, wiring up git hooks for lint-staged), creates local config files, and seeds the card names dictionary. Full walkthrough, flags, and troubleshooting: **[docs/LOCAL_DEV.md](docs/LOCAL_DEV.md)**.
+That installs dependencies and repository Git hooks, creates local config files, and seeds the card
+names dictionary. Full walkthrough, flags, and troubleshooting:
+**[docs/LOCAL_DEV.md](docs/LOCAL_DEV.md)**.
 
 ## AI-Assisted Development
 
@@ -63,6 +65,20 @@ CI runs `check:fast` and the unit suite on Node 20 and Node 22. Coverage is coll
 and the cold-cache OCR regression remains a single Node 22 job so the compatibility matrix does not
 multiply the expensive benchmark.
 
+Distribution changes must also inspect and execute the packed artifact:
+
+```bash
+pnpm test:package
+npm pack --dry-run --json
+```
+
+## Releases
+
+Release tags use bare semantic versions such as `0.2.0`, without a `v` prefix. Keep
+`package.json`, the Release Drafter tag template, and the release workflow tag filter aligned.
+Publishing and creating the release tag remain explicit maintainer steps after the release commit
+has passed its gates.
+
 Type checking is being introduced incrementally for this ESM JavaScript codebase. The strict
 checked-module list lives in `tsconfig.checked.json`; add a touched production module there once its
 JSDoc contracts pass `pnpm typecheck`.
@@ -99,7 +115,7 @@ Quick orientation — see individual `index.mjs` files in each folder for the pu
 - `src/rds/` — legacy/optional MySQL persistence backend, not used by default
 - `src/processor/` — orchestrates the end-to-end scan pipeline
 - `src/config/` — single source of truth for runtime settings (CLI flag > env var > config file > default)
-- `index.mjs` — CLI entry point (`scan`, `log`, `collection`, `migrate`, `diagnostics`, `config`)
+- `index.mjs` — CLI entry point (`scan`, `names`, `log`, `collection`, `migrate`, `diagnostics`, `config`)
 - `scripts/` — setup, verification, regression, fixture-import, and OCR-training tooling
 - `docker-compose.yml` — local MySQL for the optional `rds` adapter
 - `docs/` — CLI, configuration, architecture, regression, OCR-training, and local setup guides

--- a/Readme.md
+++ b/Readme.md
@@ -31,47 +31,43 @@ before decoding it; TIFF, ICNS, JXL, HEIF, and other container formats are rejec
 You need:
 
 - [Node.js](https://nodejs.org/) 20 or newer
-- [pnpm](https://pnpm.io/installation) 8 or newer (the repository pins pnpm 10.13.1)
-- Git and a network connection for installation and the initial Scryfall card-name seed
+- npm and a network connection for installation and the initial Scryfall card-name seed
 
 ```bash
-git clone https://github.com/dills122/MTG-Card-Analyzer.git
-cd MTG-Card-Analyzer
-node scripts/setup.mjs
-node index.mjs scan ./test-images/PlatinumAngel.jpg
+npm install --global mtg-card-analyzer
+mtg-card-analyzer names seed
+mtg-card-analyzer scan ./path/to/card.jpg
 ```
 
-The setup script installs dependencies, creates local configuration files without overwriting
-existing ones, and seeds the card-name index. Seeding is safe to repeat: it applies the same
-normalization contract used by matching, rejects unmatchable catalog entries, and repairs invalid
-or duplicate rows while upserting names. A required seed failure makes setup exit nonzero; use
-`--skip-seed` only when diagnostics already reports a healthy index. Setup does not start MySQL
-unless you explicitly pass `--with-mysql`.
-
-The package exposes `mtg-card-analyzer` as its installed executable. Commands in this source
-checkout use the equivalent `node index.mjs` form; generated help and examples use the installed
-command name.
+Run `names seed` once before the first scan. It downloads the Scryfall card-name catalog into the
+local name index. Seeding is safe to repeat: it applies the same normalization contract used by
+matching, rejects unmatchable catalog entries, repairs invalid or duplicate rows, and upserts names
+idempotently. A required seed failure exits nonzero. npm installs the `mtg-card-analyzer` command and
+the bundled English OCR model. Configuration and local data use the current directory or your home
+configuration directory as described in
+[Configuration and local data](docs/configuration.md).
 
 If the scan does not complete, check the environment before digging into individual settings:
 
 ```bash
-node scripts/verify-env.mjs
+mtg-card-analyzer diagnostics
 ```
 
-See the [local setup guide](docs/LOCAL_DEV.md) for setup flags and troubleshooting.
+Contributors working from a source checkout should use the
+[local development setup](docs/LOCAL_DEV.md), which requires pnpm and Git.
 
 ## Common workflows
 
 ### Identify a card without changing your collection
 
 ```bash
-node index.mjs scan ./path/to/card.jpg
+mtg-card-analyzer scan ./path/to/card.jpg
 ```
 
 You can also omit the `scan` word for backward compatibility:
 
 ```bash
-node index.mjs ./path/to/card.jpg
+mtg-card-analyzer ./path/to/card.jpg
 ```
 
 ### Save successful scans to a local collection
@@ -80,26 +76,26 @@ Collection tracking and writes are separate opt-ins. Set both once in `mtg.confi
 CLI:
 
 ```bash
-node index.mjs config set collectionEnabled true
-node index.mjs config set queryingEnabled true
-node index.mjs scan ./path/to/card.jpg
+mtg-card-analyzer config set collectionEnabled true
+mtg-card-analyzer config set queryingEnabled true
+mtg-card-analyzer scan ./path/to/card.jpg
 ```
 
 Or enable both for only one run:
 
 ```bash
-node index.mjs scan ./path/to/card.jpg --enable-collection --query
+mtg-card-analyzer scan ./path/to/card.jpg --enable-collection --query
 ```
 
 ### Inspect recent scan activity
 
 ```bash
-node index.mjs log dump --limit 20
-node index.mjs log stats
-node index.mjs diagnostics
+mtg-card-analyzer log dump --limit 20
+mtg-card-analyzer log stats
+mtg-card-analyzer diagnostics
 ```
 
-Run `node index.mjs --help` for the command list or see the
+Run `mtg-card-analyzer --help` for the command list or see the
 [CLI reference](docs/cli-reference.md) for every command and flag.
 
 ## How matching works
@@ -119,7 +115,7 @@ The scan promise includes local cache/log completion and removal of its bounded 
 directory, so the CLI does not exit while those writes or cleanup operations are still pending.
 
 <p align="center">
-  <img width="320" src="test-images/PlatinumAngel.jpg" alt="Platinum Angel card used by the example scan">
+  <img width="320" src="https://raw.githubusercontent.com/dills122/MTG-Card-Analyzer/master/test-images/PlatinumAngel.jpg" alt="Platinum Angel card used by the example scan">
 </p>
 
 OCR quality varies with lighting, focus, rotation, framing, and card layout. The OCR minimum is

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -46,6 +46,7 @@ the existing index without duplicating it. Use `--skip-seed` only when
 | Node version check | Warns if `<20`                                                                                          |
 | pnpm check         | Warns with the fix if pnpm isn't installed                                                              |
 | `pnpm install`     | Skip with `--skip-install`                                                                              |
+| Git hooks          | Installs Lefthook when its development binary and repository hook path are available                    |
 | Local config files | Creates `secure.config.cjs` and `mtg.config.json` if missing (leaves existing ones alone)               |
 | Seed card names    | Runs `node ./src/db-local/bulk-insert.mjs` (needs network access to Scryfall) — skip with `--skip-seed` |
 | MySQL (opt-in)     | With `--with-mysql`: starts `docker compose`, waits for the healthcheck, runs `pnpm setup-db`           |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -9,6 +9,7 @@ same commands with `node index.mjs`; for example, `node index.mjs --help`.
 | Command             | Purpose                                                   |
 | ------------------- | --------------------------------------------------------- |
 | `scan <filePath>`   | Identify a card image and optionally persist the result   |
+| `names seed`        | Seed the required local card-name index from Scryfall     |
 | `log dump`          | Print recent local operations-log entries                 |
 | `log stats`         | Summarize the local operations log                        |
 | `collection update` | Set an existing collection entry's quantity               |
@@ -21,14 +22,22 @@ same commands with `node index.mjs`; for example, `node index.mjs --help`.
 
 ## Scan a card
 
+Before the first scan, seed the local name index. The command needs network access. It is safe to
+repeat: the seeder rejects unmatchable catalog entries, repairs invalid or duplicate rows, and
+upserts names idempotently.
+
 ```bash
-node index.mjs scan ./path/to/card.jpg
+mtg-card-analyzer names seed
+```
+
+```bash
+mtg-card-analyzer scan ./path/to/card.jpg
 ```
 
 A bare image path is accepted as a backward-compatible shorthand:
 
 ```bash
-node index.mjs ./path/to/card.jpg
+mtg-card-analyzer ./path/to/card.jpg
 ```
 
 Scan inputs are limited to JPEG, PNG, GIF, and BMP files. Local files may be at most 32 MiB,
@@ -90,10 +99,10 @@ write and any image-hash cache writes before exiting. Cache failures are reporte
 the primary scan result.
 
 ```bash
-node index.mjs log dump
-node index.mjs log dump --limit 20
-node index.mjs log dump --format json --since 2026-01-01
-node index.mjs log stats
+mtg-card-analyzer log dump
+mtg-card-analyzer log dump --limit 20
+mtg-card-analyzer log dump --format json --since 2026-01-01
+mtg-card-analyzer log stats
 ```
 
 `log dump` options:
@@ -108,9 +117,9 @@ node index.mjs log stats
 ## Generate diagnostics
 
 ```bash
-node index.mjs diagnostics
-node index.mjs diagnostics --limit 50
-node index.mjs diagnostics --with-mysql
+mtg-card-analyzer diagnostics
+mtg-card-analyzer diagnostics --limit 50
+mtg-card-analyzer diagnostics --with-mysql
 ```
 
 Diagnostics prints JSON containing application, Node.js, and platform versions; environment
@@ -131,10 +140,10 @@ Options:
 ## Manage configuration
 
 ```bash
-node index.mjs config list
-node index.mjs config get storageAdapter
-node index.mjs config set queryingEnabled true
-node index.mjs config set collectionEnabled true --config ./another-config.json
+mtg-card-analyzer config list
+mtg-card-analyzer config get storageAdapter
+mtg-card-analyzer config set queryingEnabled true
+mtg-card-analyzer config set collectionEnabled true --config ./another-config.json
 ```
 
 - `config list` shows every runtime setting and whether its value came from the environment, the
@@ -152,8 +161,8 @@ Scanning the same unambiguous card again adds one to its quantity. These command
 corrections through the active persistence backend:
 
 ```bash
-node index.mjs collection update "Pacifism" M20 --quantity 3
-node index.mjs collection remove "Pacifism" M20
+mtg-card-analyzer collection update "Pacifism" M20 --quantity 3
+mtg-card-analyzer collection remove "Pacifism" M20
 ```
 
 `collection update` overwrites the quantity with the supplied non-negative value and rescales the
@@ -169,8 +178,8 @@ Both commands accept `--storage-adapter <nedb|rds>` and `--config <path>`.
 The only supported migration is from local NeDB collection and needs-attention data to RDS:
 
 ```bash
-node index.mjs migrate --to rds --dry-run
-node index.mjs migrate --to rds
+mtg-card-analyzer migrate --to rds --dry-run
+mtg-card-analyzer migrate --to rds
 ```
 
 The command always reads from local NeDB regardless of the active storage adapter. By default it

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,9 +58,9 @@ Example:
 ## Change settings through the CLI
 
 ```bash
-node index.mjs config list
-node index.mjs config get queryingEnabled
-node index.mjs config set queryingEnabled true
+mtg-card-analyzer config list
+mtg-card-analyzer config get queryingEnabled
+mtg-card-analyzer config set queryingEnabled true
 ```
 
 `config list` is useful when a value is surprising because it reports the winning source for every
@@ -81,14 +81,14 @@ This makes both the intent to write and the intent to maintain an inventory expl
 the settings:
 
 ```bash
-node index.mjs config set collectionEnabled true
-node index.mjs config set queryingEnabled true
+mtg-card-analyzer config set collectionEnabled true
+mtg-card-analyzer config set queryingEnabled true
 ```
 
 Or override them for one scan:
 
 ```bash
-node index.mjs scan ./card.jpg --enable-collection --query
+mtg-card-analyzer scan ./card.jpg --enable-collection --query
 ```
 
 Explicit `collection update`, `collection remove`, and `migrate` commands do not require

--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { access } from "node:fs/promises";
+import { readFileSync, realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { Command } from "commander";
 import processorModule from "./src/processor/index.mjs";
@@ -15,9 +16,13 @@ import storage from "./src/storage/index.mjs";
 import migrate from "./src/migrate/nedb-to-rds.mjs";
 import diagnostics from "./src/diagnostics/index.mjs";
 import { textExtraction } from "./src/image-analysis/index.mjs";
+import { executeBulkInsert } from "./src/db-local/bulk-insert.mjs";
 
 const { Processor } = processorModule;
-const KNOWN_COMMANDS = ["scan", "log", "migrate", "collection", "diagnostics", "config"];
+const APP_VERSION = JSON.parse(
+    readFileSync(new URL("./package.json", import.meta.url), "utf8")
+).version;
+const KNOWN_COMMANDS = ["scan", "names", "log", "migrate", "collection", "diagnostics", "config"];
 const HELP_TOKENS = ["--help", "-h", "help"];
 
 function buildCli(argv) {
@@ -34,7 +39,8 @@ function buildCli(argv) {
     program.exitOverride();
     program
         .name("mtg-card-analyzer")
-        .description("Identify Magic: The Gathering cards from images");
+        .description("Identify Magic: The Gathering cards from images")
+        .version(APP_VERSION);
 
     program
         .command("scan")
@@ -76,6 +82,18 @@ function buildCli(argv) {
             parsed.filePath = filePath;
             parsed.flags = options || {};
             parsed.flags._localCacheExplicit = command.getOptionValueSource("localCache") === "cli";
+        });
+
+    program
+        .command("names")
+        .description("Manage the local card-name index")
+        .command("seed")
+        .description("Seed card names from Scryfall (required before the first scan)")
+        .option("--card-names-db <path>", "Path (dir or .db file) for the local card names DB")
+        .option("--config <path>", "Path to a JSON config file")
+        .action((options) => {
+            parsed.command = "names-seed";
+            parsed.flags = options || {};
         });
 
     const logCommand = program.command("log").description("Inspect the local operations log");
@@ -212,6 +230,7 @@ function buildCli(argv) {
         "after",
         `
 Examples:
+  $ mtg-card-analyzer names seed
   $ mtg-card-analyzer scan ./img-path --query
   $ mtg-card-analyzer scan ./img-path --no-query
   $ mtg-card-analyzer scan ./img-path --no-pretty
@@ -354,6 +373,16 @@ const runLogStats = withConfig(async (config, flags, logger) => {
     return 0;
 });
 
+const runNamesSeed = withConfig(async (config, flags, logger, seedNamesFn) => {
+    try {
+        await seedNamesFn({ logger });
+        return 0;
+    } catch (err) {
+        logger.log(err?.message || String(err));
+        return 1;
+    }
+});
+
 async function runMigrate(flags, logger, migrateFn) {
     if (flags.to !== "rds") {
         logger.log(
@@ -466,6 +495,7 @@ export async function run(options = {}) {
         ocrShutdown = textExtraction.shutDown,
         migrateFn = migrate.migrateNedbToRds,
         diagnosticsFn = diagnostics.gatherDiagnostics,
+        seedNamesFn = executeBulkInsert,
         exit = process.exit,
         logger = console
     } = options;
@@ -488,6 +518,11 @@ export async function run(options = {}) {
 
     if (cli.command === "log-dump") {
         exit(await runLogDump(flags, logger));
+        return;
+    }
+
+    if (cli.command === "names-seed") {
+        exit(await runNamesSeed(flags, logger, seedNamesFn));
         return;
     }
 
@@ -576,7 +611,8 @@ export async function run(options = {}) {
 
 export { buildCli };
 
-const isDirectRun = import.meta.url === pathToFileURL(process.argv[1]).href;
+const isDirectRun =
+    process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
 if (isDirectRun) {
     run().catch((err) => {
         console.error(err);

--- a/package.json
+++ b/package.json
@@ -149,8 +149,12 @@
     },
     "pnpm": {
         "overrides": {
+            "brace-expansion@>=2.0.0 <2.1.4": "2.1.4",
             "brace-expansion@>=4.0.0 <5.0.9": "5.0.9",
-            "flatted@<3.4.2": "3.4.2"
+            "diff@>=6.0.0 <8.0.3": "8.0.4",
+            "flatted@<3.4.2": "3.4.2",
+            "js-yaml@>=4.0.0 <4.3.1": "4.3.1",
+            "serialize-javascript@<=7.0.4": "7.0.5"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,45 @@
 {
     "name": "mtg-card-analyzer",
     "version": "0.2.0",
-    "description": "a mtg ocr app for documenting a collection",
+    "description": "Local-first CLI for identifying Magic: The Gathering cards from images",
     "type": "module",
     "main": "index.mjs",
     "bin": {
         "mtg-card-analyzer": "./index.mjs"
     },
+    "files": [
+        "index.mjs",
+        "eng.traineddata",
+        "mtg.config.example.json",
+        "secure.config.template.cjs",
+        "Readme.md",
+        "LICENSE",
+        "docs/cli-reference.md",
+        "docs/configuration.md",
+        "src/config/",
+        "src/console/",
+        "src/db-local/",
+        "src/diagnostics/",
+        "src/export-processor/",
+        "src/file-io.mjs",
+        "src/fuzzy-matching/",
+        "src/image-analysis/",
+        "src/image-hashing/",
+        "src/image-processing/",
+        "src/logger/",
+        "src/matcher/",
+        "src/migrate/",
+        "src/models/",
+        "src/processor/",
+        "src/rds/",
+        "src/scryfall-api/api.config.mjs",
+        "src/scryfall-api/get-card-name.mjs",
+        "src/scryfall-api/http-client.mjs",
+        "src/scryfall-api/index.mjs",
+        "src/scryfall-api/search-name.mjs",
+        "src/storage/",
+        "src/util.mjs"
+    ],
     "repository": {
         "type": "git",
         "url": "git+https://github.com/dills122/MTG-Card-Analyzer.git"
@@ -24,6 +57,7 @@
         "ai:check": "node scripts/setup-ai-context.mjs --check",
         "ai:setup": "node scripts/setup-ai-context.mjs",
         "test": "mocha \"./test/**/*.spec.mjs\"",
+        "test:package": "node scripts/package-smoke.mjs",
         "test:regression": "node scripts/run-regression.mjs",
         "regression:compare": "node scripts/compare-ocr-models.mjs",
         "training:data:check": "node scripts/validate-ocr-training-data.mjs",
@@ -49,8 +83,7 @@
         "verify": "node scripts/verify-env.mjs",
         "docker:up": "docker compose up -d",
         "docker:down": "docker compose down",
-        "docker:logs": "docker compose logs -f mysql",
-        "prepare": "lefthook install"
+        "docker:logs": "docker compose logs -f mysql"
     },
     "keywords": [
         "mtg",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion@>=2.0.0 <2.1.4: 2.1.4
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
+  diff@>=6.0.0 <8.0.3: 8.0.4
   flatted@<3.4.2: 3.4.2
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  serialize-javascript@<=7.0.4: 7.0.5
 
 importers:
 
@@ -454,8 +458,8 @@ packages:
   bmp-ts@1.0.9:
     resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -539,10 +543,6 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
-
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
-    engines: {node: '>=0.3.1'}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -812,8 +812,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1061,9 +1061,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -1084,9 +1081,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1101,8 +1095,9 @@ packages:
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1789,7 +1784,7 @@ snapshots:
 
   bmp-ts@1.0.9: {}
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -1869,8 +1864,6 @@ snapshots:
   deep-is@0.1.4: {}
 
   denque@2.1.0: {}
-
-  diff@7.0.0: {}
 
   diff@8.0.4: {}
 
@@ -2164,7 +2157,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2275,7 +2268,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minipass@7.1.3: {}
 
@@ -2284,18 +2277,18 @@ snapshots:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      diff: 7.0.0
+      diff: 8.0.4
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 9.3.4
@@ -2395,10 +2388,6 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   readdirp@4.1.2: {}
 
   regenerator-runtime@0.13.11: {}
@@ -2413,8 +2402,6 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  safe-buffer@5.2.1: {}
-
   safer-buffer@2.1.2: {}
 
   sax@1.4.1: {}
@@ -2423,9 +2410,7 @@ snapshots:
 
   seq-queue@0.0.5: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const gitMarker = path.join(repoRoot, ".git");
+const executableName = process.platform === "win32" ? "lefthook.exe" : "lefthook";
+const lefthook = path.join(repoRoot, "node_modules", ".bin", executableName);
+const packagingCommands = new Set(["pack", "publish"]);
+
+// Published packages have no repository hooks to install. A source checkout without dev
+// dependencies should also remain packable; the next pnpm install will run this again once the
+// lefthook binary exists.
+if (
+    packagingCommands.has(process.env.npm_command) ||
+    !fs.existsSync(gitMarker) ||
+    !fs.existsSync(lefthook)
+) {
+    process.exit(0);
+}
+
+const result = spawnSync(lefthook, ["install"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: process.platform === "win32"
+});
+
+if (result.error) {
+    console.warn(`Skipping Git hook installation: ${result.error.message}`);
+    process.exit(0);
+}
+
+if (result.status !== 0) {
+    console.warn("Skipping Git hook installation because Lefthook could not update the hooks.");
+}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "mtg-card-analyzer-package-"));
+const installDirectory = path.join(tempDirectory, "install");
+const npmCacheDirectory = path.join(tempDirectory, "npm-cache");
+
+function run(command, args, options = {}) {
+    const result = spawnSync(command, args, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        shell: process.platform === "win32",
+        ...options
+    });
+    if (result.status !== 0) {
+        throw new Error(
+            [
+                `${command} ${args.join(" ")} failed with exit code ${result.status}`,
+                result.stdout,
+                result.stderr
+            ]
+                .filter(Boolean)
+                .join("\n")
+        );
+    }
+    return result;
+}
+
+try {
+    fs.mkdirSync(installDirectory);
+    const packResult = run("npm", [
+        "--cache",
+        npmCacheDirectory,
+        "pack",
+        "--json",
+        "--pack-destination",
+        tempDirectory
+    ]);
+    const [metadata] = JSON.parse(packResult.stdout);
+    const includedFiles = new Set(metadata.files.map(({ path: filePath }) => filePath));
+    const requiredFiles = [
+        "LICENSE",
+        "Readme.md",
+        "docs/cli-reference.md",
+        "docs/configuration.md",
+        "eng.traineddata",
+        "index.mjs",
+        "mtg.config.example.json",
+        "package.json",
+        "secure.config.template.cjs"
+    ];
+    for (const requiredFile of requiredFiles) {
+        assert(includedFiles.has(requiredFile), `packed artifact is missing ${requiredFile}`);
+    }
+
+    const excludedPrefixes = [
+        ".codex/",
+        ".github/",
+        "coverage/",
+        "scripts/",
+        "test/",
+        "test-images/",
+        "training/"
+    ];
+    for (const filePath of includedFiles) {
+        assert(
+            !excludedPrefixes.some((prefix) => filePath.startsWith(prefix)),
+            `packed artifact unexpectedly contains ${filePath}`
+        );
+    }
+    assert(metadata.entryCount <= 90, `packed artifact has ${metadata.entryCount} files`);
+    assert(
+        metadata.unpackedSize <= 18 * 1024 * 1024,
+        `packed artifact is unexpectedly large (${metadata.unpackedSize} bytes unpacked)`
+    );
+
+    const tarballPath = path.join(tempDirectory, metadata.filename);
+    run(
+        "npm",
+        [
+            "--cache",
+            npmCacheDirectory,
+            "install",
+            "--no-audit",
+            "--no-fund",
+            "--no-package-lock",
+            tarballPath
+        ],
+        { cwd: installDirectory }
+    );
+
+    const binName = process.platform === "win32" ? "mtg-card-analyzer.cmd" : "mtg-card-analyzer";
+    const cliPath = path.join(installDirectory, "node_modules", ".bin", binName);
+    assert(fs.existsSync(cliPath), "npm install did not create the mtg-card-analyzer bin");
+
+    const versionResult = run(cliPath, ["--version"], { cwd: installDirectory });
+    assert.equal(versionResult.stdout.trim(), packageJson.version);
+    const helpResult = run(cliPath, ["--help"], { cwd: installDirectory });
+    assert.match(helpResult.stdout, /Usage: mtg-card-analyzer/);
+    assert.match(helpResult.stdout, /names/);
+    assert.match(helpResult.stdout, /scan/);
+
+    console.log(
+        `Package smoke passed: ${metadata.filename}, ${metadata.entryCount} files, ${metadata.size} bytes packed, ${metadata.unpackedSize} bytes unpacked.`
+    );
+} finally {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -123,6 +123,8 @@ if (!flags.skipInstall) {
     step("Installing dependencies", () => run("pnpm", ["install"]));
 }
 
+step("Installing Git hooks", () => run("node", ["scripts/install-git-hooks.mjs"]));
+
 step("Setting up local config files", () => {
     if (flags.withMysql) {
         writeMysqlSecureConfig();

--- a/src/diagnostics/env-check.mjs
+++ b/src/diagnostics/env-check.mjs
@@ -39,7 +39,9 @@ function checkDefaultOcrModel() {
     const inspection = inspectDefaultOcrModel(fs.readFileSync(DEFAULT_OCR_MODEL_PATH));
     if (inspection.unsupportedParameters.length > 0) {
         return {
-            label: `English OCR model contains unsupported parameters: ${inspection.unsupportedParameters.join(", ")}`,
+            label: `English OCR model contains unsupported parameters: ${inspection.unsupportedParameters.join(
+                ", "
+            )}`,
             status: "fail"
         };
     }
@@ -61,7 +63,7 @@ function evaluateCardNameIndex(records) {
     if (health.uniqueNames < MIN_USABLE_CARD_NAMES) {
         return {
             health,
-            label: `card names DB is unusable (${counts}; expected at least ${MIN_USABLE_CARD_NAMES}) -- run \`node ./src/db-local/bulk-insert.mjs\` to repair it`,
+            label: `card names DB is unusable (${counts}; expected at least ${MIN_USABLE_CARD_NAMES}) -- run \`mtg-card-analyzer names seed\` to repair it`,
             status: "fail",
             required: true
         };
@@ -69,7 +71,7 @@ function evaluateCardNameIndex(records) {
     if (health.invalidRows > 0 || health.duplicateRows > 0) {
         return {
             health,
-            label: `card names DB needs repair (${counts}) -- rerun \`node ./src/db-local/bulk-insert.mjs\``,
+            label: `card names DB needs repair (${counts}) -- rerun \`mtg-card-analyzer names seed\``,
             status: "fail",
             required: false
         };

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -270,6 +270,39 @@ describe("CLI::index.mjs", () => {
         });
     });
 
+    describe("names subcommands", () => {
+        it("names seed seeds the configured name database and exits 0", async () => {
+            const seedNamesFn = sandbox.stub().resolves({ inserted: 10 });
+
+            await runCli(
+                { command: "names-seed", flags: { cardNamesDb: "/tmp/names.db" } },
+                undefined,
+                { seedNamesFn }
+            );
+
+            assert.equal(process.env.CARD_NAMES_DB_PATH, "/tmp/names.db");
+            assert.isTrue(seedNamesFn.calledOnce);
+            assert.isTrue(processExitStub.calledWith(0));
+        });
+
+        it("names seed reports failures and exits 1", async () => {
+            const seedNamesFn = sandbox.stub().rejects(new Error("Scryfall unavailable"));
+
+            await runCli({ command: "names-seed", flags: {} }, undefined, { seedNamesFn });
+
+            assert.isTrue(consoleLogStub.calledWith("Scryfall unavailable"));
+            assert.isTrue(processExitStub.calledWith(1));
+        });
+
+        it("names seed treats an unchanged idempotent seed as success", async () => {
+            const seedNamesFn = sandbox.stub().resolves({ inserted: 0, unchanged: 35059 });
+
+            await runCli({ command: "names-seed", flags: {} }, undefined, { seedNamesFn });
+
+            assert.isTrue(processExitStub.calledWith(0));
+        });
+    });
+
     describe("migrate subcommand", () => {
         function fakeCliFor(flags) {
             return { command: "migrate", filePath: "", flags, helpRequested: false };
@@ -628,6 +661,12 @@ describe("CLI::index.mjs buildCli (real commander wiring)", () => {
     it("parses `log stats`", () => {
         const parsed = buildCli(["log", "stats"]);
         assert.equal(parsed.command, "log-stats");
+    });
+
+    it("parses `names seed`", () => {
+        const parsed = buildCli(["names", "seed", "--card-names-db", "./names.db"]);
+        assert.equal(parsed.command, "names-seed");
+        assert.equal(parsed.flags.cardNamesDb, "./names.db");
     });
 
     it("does not throw on empty argv -- commander shows top-level help instead", () => {

--- a/test/scripts/setup.spec.mjs
+++ b/test/scripts/setup.spec.mjs
@@ -18,6 +18,10 @@ describe("fresh-clone setup smoke", () => {
             path.join(cloneRoot, "scripts/setup.mjs")
         );
         fs.copyFileSync(
+            path.join(repoRoot, "scripts/install-git-hooks.mjs"),
+            path.join(cloneRoot, "scripts/install-git-hooks.mjs")
+        );
+        fs.copyFileSync(
             path.join(repoRoot, "mtg.config.example.json"),
             path.join(cloneRoot, "mtg.config.example.json")
         );


### PR DESCRIPTION
## Summary

- publish a minimal npm runtime package with the bundled OCR model and supported CLI assets
- add the installed `mtg-card-analyzer names seed` first-run workflow and version output
- make the live seed command idempotent and preserve the hardened name-index contract
- align the release workflow with the repository's bare semantic-version tags
- move Git-hook installation to source setup and add a real pack/install/execute smoke test

## Release impact

The 0.2.0 artifact now contains 69 files and is 12.86 MB packed / 15.64 MB unpacked, down from
470 files and 42.70 MB. Tests, fixtures, training data, coverage, and repository automation are
excluded while the OCR model, CLI runtime, configuration templates, license, and user docs remain.

## Verification

- `pnpm check` — 449 tests passed
- `pnpm coverage:check` — 92.85% statements/lines, 92% functions, 78.45% branches
- `pnpm test:regression` — 151/151 blocking fixtures; 156/158 overall with two known non-blocking misses
- `pnpm test:package` — packed artifact installed and executed successfully
- `pnpm audit` and `pnpm audit --prod` — no known vulnerabilities
- installed-artifact live seed — 35,059 inserted; repeat seed zero writes and exit 0
- installed-artifact live scan — Platinum Angel matched at 100%; ambiguous printing routed to needs-attention; cache/log writes persisted; temp directory removed

## Release convention

The release tag is `0.2.0` without a `v` prefix, matching existing `0.1.6` and `0.1.8` tags and
the Release Drafter template.
