### PR TITLE
Define GitHub-only release distribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,9 @@ npm pack --dry-run --json
 
 Release tags use bare semantic versions such as `0.2.0`, without a `v` prefix. Keep
 `package.json`, the Release Drafter tag template, and the release workflow tag filter aligned.
-Publishing and creating the release tag remain explicit maintainer steps after the release commit
-has passed its gates.
+Releases are published on GitHub with the `npm pack` archive attached; this project is not published
+to the npm registry. Creating the release tag and publishing its archive remain explicit maintainer
+steps after the release commit has passed its gates.
 
 Type checking is being introduced incrementally for this ESM JavaScript codebase. The strict
 checked-module list lives in `tsconfig.checked.json`; add a touched production module there once its

--- a/Readme.md
+++ b/Readme.md
@@ -31,10 +31,11 @@ before decoding it; TIFF, ICNS, JXL, HEIF, and other container formats are rejec
 You need:
 
 - [Node.js](https://nodejs.org/) 20 or newer
-- npm and a network connection for installation and the initial Scryfall card-name seed
+- npm and a network connection for the GitHub release, its dependencies, and the initial Scryfall
+  card-name seed
 
 ```bash
-npm install --global mtg-card-analyzer
+npm install --global https://github.com/dills122/MTG-Card-Analyzer/releases/latest/download/mtg-card-analyzer-0.2.0.tgz
 mtg-card-analyzer names seed
 mtg-card-analyzer scan ./path/to/card.jpg
 ```
@@ -42,9 +43,10 @@ mtg-card-analyzer scan ./path/to/card.jpg
 Run `names seed` once before the first scan. It downloads the Scryfall card-name catalog into the
 local name index. Seeding is safe to repeat: it applies the same normalization contract used by
 matching, rejects unmatchable catalog entries, repairs invalid or duplicate rows, and upserts names
-idempotently. A required seed failure exits nonzero. npm installs the `mtg-card-analyzer` command and
-the bundled English OCR model. Configuration and local data use the current directory or your home
-configuration directory as described in
+idempotently. A required seed failure exits nonzero. The GitHub release archive installs the
+`mtg-card-analyzer` command and the bundled English OCR model; the project is not published to the
+npm registry. Configuration and local data use the current directory or your home configuration
+directory as described in
 [Configuration and local data](docs/configuration.md).
 
 If the scan does not complete, check the environment before digging into individual settings:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "mtg-card-analyzer",
     "version": "0.2.0",
+    "private": true,
     "description": "Local-first CLI for identifying Magic: The Gathering cards from images",
     "type": "module",
     "main": "index.mjs",


### PR DESCRIPTION
## Summary

- install the CLI from the versioned archive attached to the latest GitHub release
- document GitHub Releases as the sole distribution channel
- mark the package private to prevent accidental npm registry publication

## Why

Version 0.2.0 is being distributed as a GitHub-only release. The previously merged npm registry installation instructions did not match that release contract.

## Verification

- `pnpm check:fast`
- `pnpm test:package` — 69 files, 12,862,983 bytes packed
