### PR TITLE
Parallelize OCR regression fixtures across three workers

### DIFF
--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -35,8 +35,9 @@ Every regression case is evaluated with cold application state. Image hashes are
 both the fixture and every candidate reference image; the runner has no in-memory or persistent
 hash cache. Fixture names are injected before the fuzzy matcher can initialize NeDB. Tesseract
 runs with `cacheMethod: none` and reads the bundled `eng.traineddata`, so it neither reads nor writes
-an OCR cache. One initialized Tesseract worker is shared sequentially for at most 40 selected cases,
-then terminated and replaced before the next case. This bounds the Tesseract 3 WASM heap during the
+an OCR cache. The selected cases are distributed deterministically across a bounded pool of one to
+three shards. Each shard owns an initialized Tesseract worker, processes its cases sequentially,
+and replaces its worker after at most 40 cases. This bounds each Tesseract 3 WASM heap during the
 expanded corpus without loading the OCR engine and language model for every crop. Each worker's
 adaptive recognition state is reset before every crop. OCR results remain independent of earlier
 fixtures, and the persistent language-data cache stays off.
@@ -66,6 +67,10 @@ pnpm test:regression --case pacifism-clean-scan --case pacifism-blur
 # Run one or more quality groups
 pnpm test:regression --quality clean-scan --quality low-resolution
 
+# Override the default parallelism for constrained machines or timing comparisons
+pnpm test:regression --workers 1
+pnpm test:regression --workers 3
+
 # Use another manifest or output directory
 pnpm test:regression --manifest ./path/manifest.json --output ./path/reports
 
@@ -75,12 +80,16 @@ pnpm test:regression \
     --ocr-model official-eng-fast
 ```
 
-Execution stays sequential to keep OCR timings and CPU contention comparable. Runs over 40 cases
-pay a worker initialization cost between case batches; per-case runtime thresholds exclude that
-between-case initialization.
+The CLI uses three OCR workers by default and accepts `--workers 1`, `2`, or `3`. Cases are assigned
+round-robin to fixed shards and merged back into manifest order for deterministic reports. Each
+shard remains sequential because one Tesseract worker cannot recognize multiple crops concurrently.
+Runs with more than 40 cases per shard pay a worker initialization cost between case batches;
+per-case runtime thresholds exclude that between-case initialization. Reports record both the sum
+of per-case runtimes and elapsed wall runtime so speed comparisons can use the latter.
 
-Run multiple fixture IDs or quality groups in one command to reuse its worker.
-Each separate command starts a new worker.
+Run multiple fixture IDs or quality groups in one command to reuse the worker pool. Each separate
+command starts a new pool. Use one worker when collecting controlled model-comparison timings; use
+the default bounded parallelism for the ordinary regression gate.
 
 The generated `artifacts/regression` directory is ignored by Git.
 

--- a/scripts/run-regression.mjs
+++ b/scripts/run-regression.mjs
@@ -2,7 +2,7 @@
 
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { loadOcrModelManifest } from "../src/regression/ocr-model-candidate.mjs";
 import { QUALITY_LEVELS, loadManifest } from "../src/regression/manifest.mjs";
 import { runRegression } from "../src/regression/regression-runner.mjs";
@@ -17,9 +17,17 @@ const defaultOcrModelManifest = path.join(
     "test/regression/ocr-models/manifest.json"
 );
 const defaultOcrModel = "bundled-eng-control";
+const defaultWorkers = 3;
 
 function collect(value, previous) {
     return previous.concat(value);
+}
+
+function parseWorkerCount(value) {
+    if (!/^[1-3]$/.test(value)) {
+        throw new InvalidArgumentError("must be an integer from 1 to 3");
+    }
+    return Number(value);
 }
 
 function buildProgram() {
@@ -34,6 +42,12 @@ function buildProgram() {
             defaultOcrModelManifest
         )
         .option("--ocr-model <id>", "OCR model candidate ID", defaultOcrModel)
+        .option(
+            "-w, --workers <count>",
+            "parallel OCR worker sessions (1-3)",
+            parseWorkerCount,
+            defaultWorkers
+        )
         .option("-c, --case <id>", "run a fixture id (repeatable)", collect, [])
         .option(
             "-q, --quality <level>",
@@ -69,7 +83,8 @@ async function main(argv = process.argv, overrides = {}) {
     const report = await runRegressionFn(manifest, {
         caseIds: options.case,
         qualities: options.quality,
-        ocrModel
+        ocrModel,
+        workers: options.workers
     });
     const paths = await writeBenchmarkReportFn(report, options.output);
     writeLine(`OCR model: ${ocrModel.id}`);
@@ -81,6 +96,7 @@ async function main(argv = process.argv, overrides = {}) {
     );
     writeLine("Application persistence, image-hash cache, and OCR cache: disabled");
     writeLine(`Tesseract worker: ${report.isolation.ocrWorkerLifecycle}`);
+    writeLine(`Wall runtime: ${report.summary.wallRuntimeMs} ms`);
     if (report.pending.cases > 0) {
         writeLine(`Disabled fixtures: ${report.pending.cases}`);
     }
@@ -106,4 +122,4 @@ if (isDirectRun) {
     });
 }
 
-export { buildProgram, main };
+export { buildProgram, defaultWorkers, main, parseWorkerCount };

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -14,6 +14,7 @@ const noCacheOcrOptions = Object.freeze({
     cacheMethod: "none"
 });
 const maximumCasesPerOcrSession = 40;
+const maximumOcrWorkers = 3;
 
 const silentLogger = {
     info: () => {},
@@ -317,7 +318,25 @@ function summarizeGate(results) {
     };
 }
 
+function resolveOcrWorkerCount(value) {
+    const workerCount = value ?? 1;
+    if (!Number.isInteger(workerCount) || workerCount < 1 || workerCount > maximumOcrWorkers) {
+        throw new Error(`OCR worker count must be an integer from 1 to ${maximumOcrWorkers}`);
+    }
+    return workerCount;
+}
+
+function shardCases(cases, workerCount) {
+    const shardCount = Math.min(workerCount, cases.length);
+    const shards = Array.from({ length: shardCount }, () => []);
+    cases.forEach((fixture, index) => {
+        shards[index % shardCount].push({ fixture, index });
+    });
+    return shards;
+}
+
 async function runRegression(manifest, options = {}) {
+    const workerCount = resolveOcrWorkerCount(options.workers);
     const ocrOptions = options.ocrModel
         ? {
               ...noCacheOcrOptions,
@@ -350,58 +369,91 @@ async function runRegression(manifest, options = {}) {
         name
     }));
     const context = { cardNames, catalog: activeCatalog };
-    const results = [];
     const managesOcrSession =
         dependencies.ImageProcessor === imageProcessorModule ||
         typeof options.dependencies?.createOcrSession === "function";
-    let ocrSession;
 
-    async function startOcrSession() {
-        await ocrSession?.terminate();
-        ocrSession = undefined;
-        ocrSession = await dependencies.createOcrSession({ ...ocrOptions, logger: silentLogger });
-        dependencies.ocrOptions = { ...ocrOptions, session: ocrSession };
-    }
+    async function runShard(shard) {
+        const shardDependencies = { ...dependencies, ocrOptions };
+        const indexedResults = [];
+        let ocrSession;
 
-    try {
-        for (const [index, fixture] of selectedCases.entries()) {
-            if (managesOcrSession && index % maximumCasesPerOcrSession === 0) {
-                await startOcrSession();
-            }
-            results.push(await analyzeFixture(fixture, manifest, context, dependencies));
+        async function startOcrSession() {
+            await ocrSession?.terminate();
+            ocrSession = undefined;
+            ocrSession = await dependencies.createOcrSession({
+                ...ocrOptions,
+                logger: silentLogger
+            });
+            shardDependencies.ocrOptions = { ...ocrOptions, session: ocrSession };
         }
-        return {
-            schemaVersion: 1,
-            generatedAt: new Date().toISOString(),
-            manifest: manifest.path,
-            offline: true,
-            ocrModel: reportOcrModel(options.ocrModel),
-            isolation: {
-                applicationPersistence: "disabled",
-                imageHashCache: "disabled",
-                ocrCache: "disabled",
-                ocrLanguageSource: options.ocrModel
-                    ? `OCR candidate ${options.ocrModel.id}`
-                    : "bundled official tessdata_best eng.traineddata",
-                ocrWorkerLifecycle:
-                    `shared sequentially for at most ${maximumCasesPerOcrSession} cases; ` +
-                    "adaptive state reset per crop",
-                temporaryArtifacts: "deleted after each case"
-            },
-            pending: {
-                catalogEntries: manifest.catalog.length - activeCatalog.length,
-                cases: manifest.cases.length - activeCases.length,
-                placeholderCases: manifest.cases.filter((fixture) =>
-                    JSON.stringify(fixture).includes("CHANGE_ME")
-                ).length
-            },
-            summary: summarize(results),
-            gate: summarizeGate(results),
-            results
-        };
-    } finally {
-        await ocrSession?.terminate();
+
+        try {
+            for (const [shardIndex, { fixture, index }] of shard.entries()) {
+                if (managesOcrSession && shardIndex % maximumCasesPerOcrSession === 0) {
+                    await startOcrSession();
+                }
+                indexedResults.push({
+                    index,
+                    result: await analyzeFixture(fixture, manifest, context, shardDependencies)
+                });
+            }
+            return indexedResults;
+        } finally {
+            await ocrSession?.terminate();
+        }
     }
+
+    const startedAt = performance.now();
+    const shards = shardCases(selectedCases, workerCount);
+    const shardRuns = await Promise.allSettled(shards.map(runShard));
+    const failedShard = shardRuns.find((result) => result.status === "rejected");
+    if (failedShard) {
+        throw failedShard.reason;
+    }
+    const results = shardRuns
+        .filter((result) => result.status === "fulfilled")
+        .map((result) => result.value)
+        .flat()
+        .sort((left, right) => left.index - right.index)
+        .map(({ result }) => result);
+    const lifecyclePrefix =
+        shards.length === 1
+            ? "shared sequentially"
+            : `${shards.length} parallel shards; each shared`;
+    return {
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        manifest: manifest.path,
+        offline: true,
+        ocrModel: reportOcrModel(options.ocrModel),
+        isolation: {
+            applicationPersistence: "disabled",
+            imageHashCache: "disabled",
+            ocrCache: "disabled",
+            ocrWorkers: shards.length,
+            ocrLanguageSource: options.ocrModel
+                ? `OCR candidate ${options.ocrModel.id}`
+                : "bundled official tessdata_best eng.traineddata",
+            ocrWorkerLifecycle:
+                `${lifecyclePrefix} for at most ${maximumCasesPerOcrSession} cases; ` +
+                "adaptive state reset per crop",
+            temporaryArtifacts: "deleted after each case"
+        },
+        pending: {
+            catalogEntries: manifest.catalog.length - activeCatalog.length,
+            cases: manifest.cases.length - activeCases.length,
+            placeholderCases: manifest.cases.filter((fixture) =>
+                JSON.stringify(fixture).includes("CHANGE_ME")
+            ).length
+        },
+        summary: {
+            ...summarize(results),
+            wallRuntimeMs: elapsedSince(startedAt)
+        },
+        gate: summarizeGate(results),
+        results
+    };
 }
 
 export {
@@ -409,8 +461,11 @@ export {
     comparisonScore,
     evaluateResult,
     maximumCasesPerOcrSession,
+    maximumOcrWorkers,
     rankPrintCandidates,
+    resolveOcrWorkerCount,
     runRegression,
+    shardCases,
     summarize,
     summarizeGate
 };
@@ -420,8 +475,11 @@ export default {
     comparisonScore,
     evaluateResult,
     maximumCasesPerOcrSession,
+    maximumOcrWorkers,
     rankPrintCandidates,
+    resolveOcrWorkerCount,
     runRegression,
+    shardCases,
     summarize,
     summarizeGate
 };

--- a/src/regression/report.mjs
+++ b/src/regression/report.mjs
@@ -38,6 +38,7 @@ function formatBenchmarkReport(report) {
         `- Undersized-input fixtures: ${report.summary.undersizedInputs || 0}`,
         `- Fixtures containing CHANGE_ME: ${report.pending?.placeholderCases || 0}`,
         `- Total runtime: ${report.summary.totalRuntimeMs} ms`,
+        `- Wall runtime: ${report.summary.wallRuntimeMs ?? report.summary.totalRuntimeMs} ms`,
         `- Mean runtime: ${report.summary.meanRuntimeMs} ms`,
         `- P95 runtime: ${report.summary.p95RuntimeMs} ms`,
         "",

--- a/test/regression/regression-runner.spec.mjs
+++ b/test/regression/regression-runner.spec.mjs
@@ -7,7 +7,10 @@ import { QUALITY_LEVELS, loadManifest, validateManifest } from "../../src/regres
 import { formatBenchmarkReport } from "../../src/regression/report.mjs";
 import {
     maximumCasesPerOcrSession,
+    maximumOcrWorkers,
+    resolveOcrWorkerCount,
     runRegression,
+    shardCases,
     summarize,
     summarizeGate
 } from "../../src/regression/regression-runner.mjs";
@@ -29,6 +32,34 @@ async function listRelativeFiles(directory, relativeDirectory = "") {
 }
 
 describe("Regression framework::", () => {
+    it("validates and deterministically shards the requested OCR worker count", () => {
+        const fixtures = Array.from({ length: 7 }, (_, index) => ({ id: `case-${index}` }));
+        const shards = shardCases(fixtures, 3);
+
+        assert.equal(resolveOcrWorkerCount(undefined), 1);
+        assert.equal(resolveOcrWorkerCount(maximumOcrWorkers), maximumOcrWorkers);
+        assert.throws(() => resolveOcrWorkerCount(0), "must be an integer from 1 to 3");
+        assert.throws(() => resolveOcrWorkerCount(1.5), "must be an integer from 1 to 3");
+        assert.deepEqual(
+            shards.map((shard) => shard.map(({ fixture, index }) => [fixture.id, index])),
+            [
+                [
+                    ["case-0", 0],
+                    ["case-3", 3],
+                    ["case-6", 6]
+                ],
+                [
+                    ["case-1", 1],
+                    ["case-4", 4]
+                ],
+                [
+                    ["case-2", 2],
+                    ["case-5", 5]
+                ]
+            ]
+        );
+    });
+
     it("loads labeled fixtures for every supported quality level", async () => {
         const manifest = await loadManifest(manifestPath);
         assert.sameMembers(
@@ -428,6 +459,180 @@ describe("Regression framework::", () => {
             Array(maximumCasesPerOcrSession).fill(sessions[0])
         );
         assert.equal(receivedSessions.at(-1), sessions[1]);
+        assert.deepEqual(
+            sessions.map((session) => session.terminateCalls),
+            [1, 1]
+        );
+    });
+
+    it("runs independent OCR shards concurrently and restores manifest result order", async () => {
+        const manifest = {
+            path: "/fixtures/manifest.json",
+            catalog: [
+                {
+                    name: "Pacifism",
+                    set: "BBD",
+                    collectorNumber: "101",
+                    referenceImagePath: "/fixtures/reference.jpg"
+                }
+            ],
+            cases: Array.from({ length: 6 }, (_, index) => ({
+                id: `case-${index}`,
+                image: `case-${index}.jpg`,
+                imagePath: `/fixtures/case-${index}.jpg`,
+                quality: "clean-scan",
+                expected: { name: "Pacifism", set: "BBD", collectorNumber: "101" }
+            }))
+        };
+        const sessions = [];
+        const assignments = [];
+        let activeExtractions = 0;
+        let maximumActiveExtractions = 0;
+
+        const report = await runRegression(manifest, {
+            workers: 3,
+            dependencies: {
+                ImageProcessor: {
+                    create: ({ path: imagePath, ocrOptions }) => ({
+                        extract: (callback) => {
+                            assignments.push([imagePath, ocrOptions.session.id]);
+                            activeExtractions += 1;
+                            maximumActiveExtractions = Math.max(
+                                maximumActiveExtractions,
+                                activeExtractions
+                            );
+                            setTimeout(() => {
+                                activeExtractions -= 1;
+                                callback(null, {
+                                    cleanText: "PACIFISM",
+                                    dirtyText: "Pacifism",
+                                    confidence: 99,
+                                    bestVariant: { region: "name-core" }
+                                });
+                            }, 10);
+                        }
+                    })
+                },
+                MatchName: matchNameModule,
+                Hash: {
+                    hashImage: (_imagePath, callback) => callback(null, "fresh-hash"),
+                    compareHash: () => ({
+                        twoBitMatches: 1,
+                        fourBitMatches: 1,
+                        stringCompare: 1
+                    })
+                },
+                materializeFixture: async (fixture) => fixture.imagePath,
+                createOcrSession: async () => {
+                    const session = {
+                        id: sessions.length,
+                        terminateCalls: 0,
+                        async terminate() {
+                            this.terminateCalls += 1;
+                        }
+                    };
+                    sessions.push(session);
+                    return session;
+                }
+            }
+        });
+
+        assert.equal(maximumActiveExtractions, 3);
+        assert.deepEqual(
+            report.results.map((result) => result.id),
+            manifest.cases.map((fixture) => fixture.id)
+        );
+        assert.sameDeepMembers(assignments, [
+            ["/fixtures/case-0.jpg", 0],
+            ["/fixtures/case-1.jpg", 1],
+            ["/fixtures/case-2.jpg", 2],
+            ["/fixtures/case-3.jpg", 0],
+            ["/fixtures/case-4.jpg", 1],
+            ["/fixtures/case-5.jpg", 2]
+        ]);
+        assert.deepEqual(
+            sessions.map((session) => session.terminateCalls),
+            [1, 1, 1]
+        );
+        assert.equal(report.isolation.ocrWorkers, 3);
+        assert.equal(
+            report.isolation.ocrWorkerLifecycle,
+            "3 parallel shards; each shared for at most 40 cases; adaptive state reset per crop"
+        );
+        assert.isAtLeast(report.summary.wallRuntimeMs, 20);
+    });
+
+    it("waits for parallel shard cleanup before reporting an OCR session startup failure", async () => {
+        const manifest = {
+            path: "/fixtures/manifest.json",
+            catalog: [
+                {
+                    name: "Pacifism",
+                    set: "BBD",
+                    collectorNumber: "101",
+                    referenceImagePath: "/fixtures/reference.jpg"
+                }
+            ],
+            cases: Array.from({ length: 3 }, (_, index) => ({
+                id: `case-${index}`,
+                image: `case-${index}.jpg`,
+                imagePath: `/fixtures/case-${index}.jpg`,
+                quality: "clean-scan",
+                expected: { name: "Pacifism", set: "BBD", collectorNumber: "101" }
+            }))
+        };
+        const sessions = [];
+        let createSessionCalls = 0;
+        let error;
+
+        try {
+            await runRegression(manifest, {
+                workers: 3,
+                dependencies: {
+                    ImageProcessor: {
+                        create: () => ({
+                            extract: (callback) =>
+                                callback(null, {
+                                    cleanText: "PACIFISM",
+                                    dirtyText: "Pacifism",
+                                    confidence: 99,
+                                    bestVariant: { region: "name-core" }
+                                })
+                        })
+                    },
+                    MatchName: matchNameModule,
+                    Hash: {
+                        hashImage: (_imagePath, callback) => callback(null, "fresh-hash"),
+                        compareHash: () => ({
+                            twoBitMatches: 1,
+                            fourBitMatches: 1,
+                            stringCompare: 1
+                        })
+                    },
+                    materializeFixture: async (fixture) => fixture.imagePath,
+                    createOcrSession: async () => {
+                        createSessionCalls += 1;
+                        if (createSessionCalls === 2) {
+                            throw new Error("session startup failed");
+                        }
+                        const session = {
+                            terminateCalls: 0,
+                            async terminate() {
+                                this.terminateCalls += 1;
+                            }
+                        };
+                        sessions.push(session);
+                        return session;
+                    }
+                }
+            });
+        } catch (caught) {
+            error = caught;
+        }
+
+        assert.instanceOf(error, Error);
+        assert.equal(error.message, "session startup failed");
+        assert.lengthOf(sessions, 2);
         assert.deepEqual(
             sessions.map((session) => session.terminateCalls),
             [1, 1]

--- a/test/scripts/run-regression.spec.mjs
+++ b/test/scripts/run-regression.spec.mjs
@@ -1,7 +1,25 @@
 import { assert } from "chai";
-import { buildProgram, main } from "../../scripts/run-regression.mjs";
+import {
+    buildProgram,
+    defaultWorkers,
+    main,
+    parseWorkerCount
+} from "../../scripts/run-regression.mjs";
 
 describe("run-regression CLI::", () => {
+    it("uses a bounded parallel worker default and accepts an explicit worker count", () => {
+        const defaults = buildProgram().parse(["node", "run-regression.mjs"]).opts();
+        const explicit = buildProgram()
+            .parse(["node", "run-regression.mjs", "--workers", "3"])
+            .opts();
+
+        assert.equal(defaults.workers, defaultWorkers);
+        assert.equal(explicit.workers, 3);
+        assert.throws(() => parseWorkerCount("0"), "must be an integer from 1 to 3");
+        assert.throws(() => parseWorkerCount("4"), "must be an integer from 1 to 3");
+        assert.throws(() => parseWorkerCount("2.5"), "must be an integer from 1 to 3");
+    });
+
     it("parses an explicit OCR candidate manifest and candidate ID", () => {
         const options = buildProgram()
             .parse([
@@ -62,6 +80,7 @@ describe("run-regression CLI::", () => {
 
         assert.strictEqual(result, report);
         assert.strictEqual(receivedOptions.ocrModel, selectedCandidate);
+        assert.equal(receivedOptions.workers, defaultWorkers);
         assert.include(lines, "OCR model: official-eng-fast");
         assert.include(
             lines,


### PR DESCRIPTION
## Summary

Reduce the cold-cache OCR regression wall time by distributing fixtures across a bounded pool of independent Tesseract sessions.

## What changed

- Add `--workers 1|2|3` to the regression CLI, defaulting to three workers.
- Assign fixtures round-robin to deterministic shards and restore manifest order in the merged report.
- Give each shard an isolated Tesseract session with the existing 40-case recycling limit.
- Wait for every shard to clean up before surfacing session startup failures.
- Record elapsed wall runtime alongside the existing sum of per-case runtimes.
- Document the parallel execution and controlled single-worker timing workflows.
- Add coverage for worker validation, deterministic sharding, real overlap, session isolation, ordering, and failure cleanup.

## Why

The 158-fixture OCR regression suite was entirely sequential even though each fixture is isolated. The test therefore underused available CPU and took over seven minutes on the measured development machine.

## Impact

A full cold-cache comparison produced result-for-result identical OCR and matching output:

- 1 worker: 433,723.54 ms
- 3 workers: 307,786.28 ms
- Reduction: 125,937.26 ms (29.04%)
- Blocking gate: 151/151 passed in both runs
- Overall: 156/158 passed in both runs, with the same two known non-blocking misses

## Validation

- `pnpm check:fast`
- `pnpm test` — 452 passing
- `pnpm coverage:check`
- `pnpm test:regression` — 151/151 blocking fixtures passed
- Full `--workers 1` versus `--workers 3` stable-result equivalence comparison
