### PR TITLE
feat: benchmark and adopt PDQ image fingerprints

### DIFF
--- a/.github/workflows/ci.action.yml
+++ b/.github/workflows/ci.action.yml
@@ -20,7 +20,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: ["20", "22"]
+                node-version: ["22"]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -45,16 +45,11 @@ jobs:
             - name: Lint + Format + Types
               run: pnpm check:fast
 
-            - name: Unit tests
-              if: matrix.node-version == '20'
-              run: pnpm test
-
             - name: Test + Coverage gate
-              if: matrix.node-version == '22'
               run: pnpm coverage:check
 
             - name: Upload coverage report
-              if: always() && matrix.node-version == '22'
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: mtg-coverage-node-${{ matrix.node-version }}-${{ github.run_id }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for looking at MTG Card Analyzer. This doc covers how to set up, work on,
 
 ## Setup
 
-- Node >= 20 (CI tests the supported floor on Node 20 and the primary runtime on Node 22)
+- Node >= 22.14 (CI uses Node 22)
 - [pnpm](https://pnpm.io/) >= 8: `corepack enable` or `npm i -g pnpm`
 - Clone and run the setup script:
 
@@ -61,9 +61,8 @@ pnpm test:regression
 sequence. The OCR regression run is especially important for changes to image preprocessing,
 OCR, fuzzy matching, hashing, or print selection.
 
-CI runs `check:fast` and the unit suite on Node 20 and Node 22. Coverage is collected on Node 22,
-and the cold-cache OCR regression remains a single Node 22 job so the compatibility matrix does not
-multiply the expensive benchmark.
+CI runs `check:fast`, the coverage-enforced unit suite, and the cold-cache OCR regression on
+Node 22.
 
 Distribution changes must also inspect and execute the packed artifact:
 

--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ before decoding it; TIFF, ICNS, JXL, HEIF, and other container formats are rejec
 
 You need:
 
-- [Node.js](https://nodejs.org/) 20 or newer
+- [Node.js](https://nodejs.org/) 22.14 or newer
 - npm and a network connection for the GitHub release, its dependencies, and the initial Scryfall
   card-name seed
 
@@ -127,16 +127,17 @@ local-first rather than fully offline.
 
 ## Documentation
 
-| If you want to...                                                | Read...                                               |
-| ---------------------------------------------------------------- | ----------------------------------------------------- |
-| Install the project or fix a local setup problem                 | [Local development setup](docs/LOCAL_DEV.md)          |
-| Look up commands, flags, logging, migration, or collection edits | [CLI reference](docs/cli-reference.md)                |
-| Change settings or understand local database files               | [Configuration and local data](docs/configuration.md) |
-| Understand the scan pipeline and module boundaries               | [Architecture](docs/architecture.md)                  |
-| Review production dependency and image-input security controls   | [Dependency security](docs/dependency-security.md)    |
-| Add or evaluate OCR and matching fixtures                        | [Regression testing](docs/regression-testing.md)      |
-| Build a reviewed custom OCR fine-tuning corpus                   | [OCR training data](docs/ocr-training-data.md)        |
-| Prepare a change or pull request                                 | [Contributing](CONTRIBUTING.md)                       |
+| If you want to...                                                | Read...                                                      |
+| ---------------------------------------------------------------- | ------------------------------------------------------------ |
+| Install the project or fix a local setup problem                 | [Local development setup](docs/LOCAL_DEV.md)                 |
+| Look up commands, flags, logging, migration, or collection edits | [CLI reference](docs/cli-reference.md)                       |
+| Change settings or understand local database files               | [Configuration and local data](docs/configuration.md)        |
+| Understand the scan pipeline and module boundaries               | [Architecture](docs/architecture.md)                         |
+| Review production dependency and image-input security controls   | [Dependency security](docs/dependency-security.md)           |
+| Review the Blockhash-versus-PDQ benchmark and selection          | [Fingerprint benchmark](docs/image-fingerprint-benchmark.md) |
+| Add or evaluate OCR and matching fixtures                        | [Regression testing](docs/regression-testing.md)             |
+| Build a reviewed custom OCR fine-tuning corpus                   | [OCR training data](docs/ocr-training-data.md)               |
+| Prepare a change or pull request                                 | [Contributing](CONTRIBUTING.md)                              |
 
 The default NeDB backend is the recommended path. A legacy MySQL/RDS adapter remains available for
 existing users; its setup and migration instructions live in the
@@ -159,8 +160,8 @@ pnpm test:regression
 ```
 
 The unit suite is deterministic, ignores machine-local configuration and credentials, and does not
-require live Scryfall or MySQL access. CI runs the fast/unit gate on both Node 20 and Node 22 while
-running the expensive cold-cache OCR regression once on Node 22. See
+require live Scryfall or MySQL access. CI runs the fast/unit/coverage gate and the separate
+cold-cache OCR regression on Node 22. See
 [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## License

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -98,8 +98,8 @@ node scripts/verify-env.mjs  # is the environment actually usable
 ```
 
 `pnpm check` is the standard local gate and remains deterministic after setup creates
-`mtg.config.json` and `secure.config.cjs`. CI runs the fast/unit gate on Node 20 and Node 22,
-collects coverage on Node 22, and runs a single separate Node 22 `pnpm test:regression` job; see
+`mtg.config.json` and `secure.config.cjs`. CI runs the fast/unit/coverage gate and a separate
+Node 22 `pnpm test:regression` job; see
 [CONTRIBUTING.md](../CONTRIBUTING.md#before-opening-a-pr) for the exact sequence.
 
 ## Troubleshooting

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,10 @@ the hash cache should live somewhere else.
 Disabling the local cache turns off the image-hash cache and operations log. It does not disable
 the card-name index, which is required for matching and has no remote fallback.
 
+Image fingerprints are stored as versioned records. Legacy raw Blockhash values remain readable
+but are not comparable with the current PDQ records; the next remote comparison refreshes those
+cache entries without requiring a manual database migration.
+
 The card-name seeder stores a normalized key beside each canonical name. Rerunning it is
 idempotent: catalog entries are validated with the matching normalization contract, duplicate and
 invalid legacy rows are removed, and remaining names are upserted. `diagnostics` reports the

--- a/docs/dependency-security.md
+++ b/docs/dependency-security.md
@@ -33,10 +33,11 @@ Remote set-symbol images additionally require HTTPS on `cards.scryfall.io` or
 after 15 seconds, and stream at most 16 MiB. These controls prevent cross-origin forwarding of the
 Scryfall request headers and bound work even when `Content-Length` is absent or false.
 
-Perceptual hashing receives only the already-validated buffer form, so `image-hash` cannot reopen a
-user-controlled path or perform its own unbounded fetch. Direct library users should use
-`imageProcessing.util.readImage` or `readImageInput` before handing image data to any lower-level
-decoder.
+Perceptual hashing receives only the already-validated buffer form, so `image-fingerprint` cannot
+reopen a user-controlled path or perform its own unbounded fetch. Production fingerprints use the
+versioned PDQ v1 record and the library's explicit Hamming-distance and quality policy. Direct
+library users should use `imageProcessing.util.readImage` or `readImageInput` before handing image
+data to any lower-level decoder.
 
 ## Residual risk
 

--- a/docs/image-fingerprint-benchmark.md
+++ b/docs/image-fingerprint-benchmark.md
@@ -1,0 +1,70 @@
+# Image fingerprint mode benchmark
+
+This benchmark compares the hashing modes available in `image-fingerprint@0.1.1` against the
+project's reviewed local card corpus. It is intended to choose a production default for card-print
+ranking, not to make a universal claim about perceptual-hash quality.
+
+## Run it
+
+```bash
+pnpm benchmark:fingerprints
+```
+
+The command is offline and deterministic apart from runtime measurements. It uses the enabled
+catalog in `test/regression/fixtures/manifest.json`, writes transformed images only to a temporary
+directory, removes that directory on success or failure, and prints a JSON report.
+
+## Method
+
+The 2026-08-11 run used 151 enabled reference prints. A deterministic 34-print sample was tested
+with eight queries per print: exact, good-photo, average-photo, poor-lighting, blur, rotation,
+cropping, and low-resolution. Each of the 272 resulting full-card queries ranked against all 151
+reference prints. This is stricter than production, where OCR first limits candidates to printings
+of one card name.
+
+The manifest currently contains only two names with multiple enabled printings: `Unsummon` and
+`Island`. Their four source prints produced 32 set-symbol queries across the same eight variants,
+ranked only against the other printing of the same name. The small set-symbol cohort is useful
+directional evidence, but it is not large enough to support fine threshold tuning.
+
+All modes used 256-bit fingerprints:
+
+- Blockhash v1, 16 bits per side, precise method, historical `image-hash@7` decoding
+- Blockhash v1, 16 bits per side, precise method, normalized decoding
+- PDQ v1 with normalized decoding
+
+## Results
+
+| Mode                          |    Full-card top 1 | Full-card mean margin | Set-symbol top 1 | Set-symbol mean margin |
+| ----------------------------- | -----------------: | --------------------: | ---------------: | ---------------------: |
+| Blockhash, historical decoder |   270/272 (99.26%) |                0.1534 |   30/32 (93.75%) |             **0.3340** |
+| Blockhash, normalized decoder |   270/272 (99.26%) |                0.1534 |   30/32 (93.75%) |             **0.3340** |
+| **PDQ, normalized decoder**   | **272/272 (100%)** |            **0.2702** |   30/32 (93.75%) |                 0.3235 |
+
+PDQ recovered both poor-lighting full-card cases that tied under Blockhash and increased the mean
+gap between the correct print and the closest wrong print by 76%. It tied both Blockhash modes on
+set-symbol top-1 accuracy. Blockhash's set-symbol margin was 0.0105 higher, but that result covers
+only four source prints and all modes missed two cropped-symbol queries.
+
+The three passes took 109.6, 108.6, and 112.1 seconds respectively on the test machine. Those
+end-to-end timings include Jimp transformation and temporary PNG work and should not be read as an
+isolated algorithm microbenchmark.
+
+## Decision
+
+Use normalized PDQ v1 as the production default. Store the full versioned fingerprint record and
+compare it using Hamming distance plus the package's explicit starting policy (`maxDistance: 31`,
+`minQuality: 50`). When no candidate satisfies that conservative policy, the existing bounded
+closest-candidate fallback may still rank comparable PDQ records.
+
+Legacy raw Blockhash values are recognized as historical records but are intentionally
+non-comparable with PDQ. A scan that encounters only legacy cache rows falls through to the remote
+comparison path and stores fresh PDQ records; no destructive cache migration is required.
+
+## Limits and next evidence
+
+The synthetic variants measure controlled robustness, not arbitrary handheld framing or
+perspective distortion. The package's own MTG calibration likewise warns that unrectified camera
+frames are not reliable standalone PDQ inputs. Keep the application's crop and normalization path,
+and repeat this benchmark after adding real captures or additional names with multiple reviewed
+print references. Do not weaken regression expectations to accommodate a hash-mode change.

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -29,6 +29,9 @@ also depends on a separately seeded NeDB database. The regression runner therefo
 names from the fixture catalog and compares against local reference images. This exercises
 the same OCR, fuzzy matcher, and hash implementation while keeping the input corpus fixed.
 
+For the standalone Blockhash-versus-PDQ retrieval comparison and the production-mode decision,
+see [Image fingerprint mode benchmark](image-fingerprint-benchmark.md).
+
 <!-- markdownlint-disable MD013 -->
 
 Every regression case is evaluated with cold application state. Image hashes are recomputed for
@@ -255,8 +258,8 @@ Minimal example:
 
 Only `name`, `set`, and `collectorNumber` are required inside `expected`. Optional thresholds
 let the suite catch candidate explosions, confidence changes, metadata regressions, and large
-runtime regressions without requiring an exact OCR string. Print selection uses a weighted
-score over the production hash metrics and defaults to a minimum score of 0.75.
+runtime regressions without requiring an exact OCR string. Print selection uses normalized PDQ
+Hamming similarity and defaults to a minimum score of 0.75.
 
 ## Quality labels and transformations
 
@@ -397,9 +400,9 @@ the regression suite repeatable and independent of API availability or Scryfall 
 
 Each case records the raw and normalized OCR text promoted from the title candidate that produced
 the selected name match, Tesseract confidence and region, fuzzy name matches, name-candidate count,
-print-candidate count, the selected print, its three hash
-comparison metrics, set/collector verification, failures, per-stage timing, and total runtime.
-The summary includes pass rate, the blocking CI-gate result, non-blocking failure counts,
+print-candidate count, the selected print, its PDQ similarity, Hamming distance, bit length, and
+input quality, set/collector verification, failures, per-stage timing, and total runtime. The
+summary includes pass rate, the blocking CI-gate result, non-blocking failure counts,
 disabled and placeholder fixture counts, totals by quality, total/mean runtime, and p95 runtime.
 
 ## Pull request gate

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "LICENSE",
         "docs/cli-reference.md",
         "docs/configuration.md",
+        "docs/image-fingerprint-benchmark.md",
         "src/config/",
         "src/console/",
         "src/db-local/",
@@ -51,7 +52,7 @@
     },
     "packageManager": "pnpm@10.13.1",
     "engines": {
-        "node": ">=20.0.0",
+        "node": ">=22.14.0",
         "pnpm": ">=8.0.0"
     },
     "scripts": {
@@ -63,6 +64,7 @@
         "test": "mocha \"./test/**/*.spec.mjs\"",
         "test:package": "node scripts/package-smoke.mjs",
         "test:regression": "node scripts/run-regression.mjs",
+        "benchmark:fingerprints": "node scripts/benchmark-image-fingerprints.mjs",
         "regression:compare": "node scripts/compare-ocr-models.mjs",
         "training:data:check": "node scripts/validate-ocr-training-data.mjs",
         "training:review:promote": "node scripts/promote-ocr-training-review.mjs",
@@ -128,7 +130,7 @@
         "clean-text-utils": "^1.3.0",
         "commander": "^15.0.0",
         "fuzzyset.js": "1.0.7",
-        "image-hash": "^7.0.1",
+        "image-fingerprint": "^0.1.1",
         "jimp": "1.6.1",
         "joi": "^18.2.3",
         "lodash": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,9 @@ importers:
       fuzzyset.js:
         specifier: 1.0.7
         version: 1.0.7
-      image-hash:
-        specifier: ^7.0.1
-        version: 7.0.1
+      image-fingerprint:
+        specifier: ^0.1.1
+        version: 0.1.1(@types/node@25.9.1)
       jimp:
         specifier: 1.6.1
         version: 1.6.1
@@ -1717,8 +1717,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  image-hash@7.0.1:
-    resolution: {integrity: sha512-UFd/RfmacH3c1MISLm1k1AFOtG1py2gy46qNE8aK7UwmAEHAZGzTfsBsF6VbLxirD30p6t2GgULzSZh1XmsWQA==}
+  image-fingerprint@0.1.1:
+    resolution: {integrity: sha512-T0wcPj1zJiQLTjkEMQ2qfkj7fQeIF7g3hMsH97bR2iD2tI5SU/V9hm1AfkUM7lIlQ7D8/18lRC91PFIJGUBpYQ==}
+    engines: {node: '>=22.14.0'}
 
   image-q@4.0.0:
     resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
@@ -3129,8 +3130,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
@@ -4390,14 +4390,14 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  image-hash@7.0.1:
+  image-fingerprint@0.1.1(@types/node@25.9.1):
     dependencies:
       '@cwasm/webp': 0.1.5
-      file-type: 21.3.4
       jpeg-js: 0.4.4
       pngjs: 7.0.0
+      sharp: 0.35.3(@types/node@25.9.1)
     transitivePeerDependencies:
-      - supports-color
+      - '@types/node'
 
   image-q@4.0.0:
     dependencies:
@@ -5048,7 +5048,6 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 25.9.1
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/scripts/benchmark-image-fingerprints.mjs
+++ b/scripts/benchmark-image-fingerprints.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import {
+    compareFingerprints,
+    decodeImage,
+    fingerprintImage,
+    fingerprintPixels
+} from "image-fingerprint/node";
+import { readImage } from "../src/image-processing/util.mjs";
+import { cropSetSymbolFromImage } from "../src/image-processing/smart-crop.mjs";
+import { materializeFixture } from "../src/regression/image-fixture.mjs";
+import { loadManifest } from "../src/regression/manifest.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const manifestPath = path.join(repositoryRoot, "test/regression/fixtures/manifest.json");
+
+const MODES = [
+    {
+        id: "blockhash-v1-image-hash-v7",
+        async fingerprint(source) {
+            return fingerprintImage(source, {
+                algorithm: "blockhash-v1",
+                bitsPerSide: 16,
+                method: 2,
+                decoderMode: "image-hash-v7"
+            });
+        }
+    },
+    {
+        id: "blockhash-v1-normalized",
+        async fingerprint(source) {
+            const pixels = await decodeImage(source);
+            return fingerprintPixels(pixels, {
+                algorithm: "blockhash-v1",
+                bitsPerSide: 16,
+                method: 2
+            });
+        }
+    },
+    {
+        id: "pdq-v1-normalized",
+        async fingerprint(source) {
+            const pixels = await decodeImage(source);
+            return fingerprintPixels(pixels, { algorithm: "pdq-v1" });
+        }
+    }
+];
+
+const VARIANTS = [
+    ["exact", {}],
+    ["good-photo", { brightness: -0.04, contrast: -0.03 }],
+    ["average-photo", { brightness: -0.12, contrast: -0.08, blur: 1 }],
+    ["poor-lighting", { brightness: -0.35, contrast: -0.12 }],
+    ["blur", { blur: 1 }],
+    ["rotation", { rotate: 0.25 }],
+    ["cropping", { crop: { left: 0, top: 0, right: 0.015, bottom: 0.015 } }],
+    ["low-resolution", { resize: { width: 600, height: 836 } }]
+];
+
+function identity(card) {
+    return `${card.name}|${card.set}|${card.collectorNumber}`;
+}
+
+function evenlySample(items, count) {
+    if (items.length <= count) return [...items];
+    return Array.from({ length: count }, (_unused, index) => {
+        const selectedIndex = Math.round((index * (items.length - 1)) / (count - 1));
+        return items[selectedIndex];
+    });
+}
+
+function score(left, right) {
+    const comparison = compareFingerprints(left, right);
+    if (!comparison.comparable) {
+        throw new Error(`Unexpected incompatible fingerprints: ${comparison.reason}`);
+    }
+    return 1 - comparison.normalizedDistance;
+}
+
+function round(value, digits = 4) {
+    const scale = 10 ** digits;
+    return Math.round(value * scale) / scale;
+}
+
+function average(values) {
+    return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+async function writeSetSymbol(source, directory, label) {
+    const image = await readImage(source);
+    const crop = cropSetSymbolFromImage(image);
+    if (crop.lowConfidence) {
+        throw new Error(`${label}: set-symbol crop is low confidence (${crop.reason})`);
+    }
+    const output = path.join(directory, `${label.replace(/[^a-z0-9-]/gi, "-")}.png`);
+    await crop.image.write(output);
+    return output;
+}
+
+async function materializeVariant(card, variant, directory) {
+    const [quality, transform] = variant;
+    return materializeFixture(
+        {
+            id: `${identity(card)}-${quality}`,
+            imagePath: card.referenceImagePath,
+            transform
+        },
+        directory
+    );
+}
+
+function summarize(rows) {
+    const correct = rows.filter((row) => row.rank === 1).length;
+    const byVariant = Object.fromEntries(
+        VARIANTS.map(([variant]) => {
+            const selected = rows.filter((row) => row.variant === variant);
+            return [
+                variant,
+                {
+                    total: selected.length,
+                    top1: selected.filter((row) => row.rank === 1).length,
+                    meanPositiveSimilarity: round(
+                        average(selected.map((row) => row.positiveSimilarity))
+                    ),
+                    meanMargin: round(average(selected.map((row) => row.margin)))
+                }
+            ];
+        })
+    );
+    return {
+        total: rows.length,
+        top1: correct,
+        top1Rate: round(correct / rows.length),
+        top5: rows.filter((row) => row.rank <= 5).length,
+        meanReciprocalRank: round(average(rows.map((row) => 1 / row.rank))),
+        meanPositiveSimilarity: round(average(rows.map((row) => row.positiveSimilarity))),
+        meanClosestNegativeSimilarity: round(
+            average(rows.map((row) => row.closestNegativeSimilarity))
+        ),
+        meanMargin: round(average(rows.map((row) => row.margin))),
+        lowQuality: rows.filter((row) => row.quality !== undefined && row.quality < 50).length,
+        byVariant
+    };
+}
+
+async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory) {
+    const startedAt = performance.now();
+    const referenceFingerprints = new Map();
+    for (const card of cards) {
+        referenceFingerprints.set(identity(card), await mode.fingerprint(card.referenceImagePath));
+    }
+
+    const fullCardRows = [];
+    for (const card of queryCards) {
+        for (const variant of VARIANTS) {
+            const queryPath = await materializeVariant(card, variant, directory);
+            const queryFingerprint = await mode.fingerprint(queryPath);
+            const ranking = cards
+                .map((candidate) => ({
+                    card: candidate,
+                    similarity: score(
+                        queryFingerprint,
+                        referenceFingerprints.get(identity(candidate))
+                    )
+                }))
+                .sort((left, right) => right.similarity - left.similarity);
+            const expectedId = identity(card);
+            const rank = ranking.findIndex((entry) => identity(entry.card) === expectedId) + 1;
+            const positiveSimilarity = ranking.find(
+                (entry) => identity(entry.card) === expectedId
+            ).similarity;
+            const closestNegativeSimilarity = ranking.find(
+                (entry) => identity(entry.card) !== expectedId
+            ).similarity;
+            fullCardRows.push({
+                card: expectedId,
+                variant: variant[0],
+                rank,
+                positiveSimilarity,
+                closestNegativeSimilarity,
+                margin: positiveSimilarity - closestNegativeSimilarity,
+                quality: queryFingerprint.quality
+            });
+        }
+    }
+
+    const setSymbolRows = [];
+    for (const group of duplicateGroups) {
+        const referenceSymbols = new Map();
+        for (const card of group) {
+            const symbolPath = await writeSetSymbol(
+                card.referenceImagePath,
+                directory,
+                `${mode.id}-${identity(card)}-reference`
+            );
+            referenceSymbols.set(identity(card), await mode.fingerprint(symbolPath));
+        }
+        for (const card of group) {
+            for (const variant of VARIANTS) {
+                const queryPath = await materializeVariant(card, variant, directory);
+                const symbolPath = await writeSetSymbol(
+                    queryPath,
+                    directory,
+                    `${mode.id}-${identity(card)}-${variant[0]}`
+                );
+                const queryFingerprint = await mode.fingerprint(symbolPath);
+                const ranking = group
+                    .map((candidate) => ({
+                        card: candidate,
+                        similarity: score(
+                            queryFingerprint,
+                            referenceSymbols.get(identity(candidate))
+                        )
+                    }))
+                    .sort((left, right) => right.similarity - left.similarity);
+                const expectedId = identity(card);
+                const rank = ranking.findIndex((entry) => identity(entry.card) === expectedId) + 1;
+                const positiveSimilarity = ranking.find(
+                    (entry) => identity(entry.card) === expectedId
+                ).similarity;
+                const closestNegativeSimilarity = ranking.find(
+                    (entry) => identity(entry.card) !== expectedId
+                ).similarity;
+                setSymbolRows.push({
+                    card: expectedId,
+                    variant: variant[0],
+                    rank,
+                    positiveSimilarity,
+                    closestNegativeSimilarity,
+                    margin: positiveSimilarity - closestNegativeSimilarity,
+                    quality: queryFingerprint.quality
+                });
+            }
+        }
+    }
+
+    return {
+        id: mode.id,
+        runtimeMs: round(performance.now() - startedAt, 2),
+        fullCard: summarize(fullCardRows),
+        setSymbol: summarize(setSymbolRows),
+        failures: {
+            fullCard: fullCardRows.filter((row) => row.rank !== 1).slice(0, 20),
+            setSymbol: setSymbolRows.filter((row) => row.rank !== 1).slice(0, 20)
+        }
+    };
+}
+
+async function main() {
+    const manifest = await loadManifest(manifestPath);
+    const cards = manifest.catalog.filter((card) => card.enabled !== false);
+    const duplicateGroups = Object.values(Object.groupBy(cards, (card) => card.name)).filter(
+        (group) => group.length > 1
+    );
+    const mustInclude = new Set(
+        cards
+            .filter(
+                (card) =>
+                    card.name === "Pacifism" ||
+                    duplicateGroups.some((group) => group.includes(card))
+            )
+            .map(identity)
+    );
+    const queryCards = [
+        ...new Map(
+            [
+                ...evenlySample(cards, 30),
+                ...cards.filter((card) => mustInclude.has(identity(card)))
+            ].map((card) => [identity(card), card])
+        ).values()
+    ];
+    const directory = await mkdtemp(path.join(os.tmpdir(), "mtg-fingerprint-benchmark-"));
+    try {
+        const results = [];
+        for (const mode of MODES) {
+            console.error(`Benchmarking ${mode.id}...`);
+            results.push(await benchmarkMode(mode, cards, queryCards, duplicateGroups, directory));
+        }
+        console.log(
+            JSON.stringify(
+                {
+                    schemaVersion: 1,
+                    manifest: path.relative(repositoryRoot, manifest.path),
+                    referencePrints: cards.length,
+                    fullCardQueries: queryCards.length * VARIANTS.length,
+                    setSymbolQueries:
+                        duplicateGroups.reduce((sum, group) => sum + group.length, 0) *
+                        VARIANTS.length,
+                    variants: VARIANTS.map(([id]) => id),
+                    results
+                },
+                null,
+                2
+            )
+        );
+    } finally {
+        await rm(directory, { recursive: true, force: true });
+    }
+}
+
+await main();

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -51,6 +51,7 @@ try {
         "Readme.md",
         "docs/cli-reference.md",
         "docs/configuration.md",
+        "docs/image-fingerprint-benchmark.md",
         "eng.traineddata",
         "index.mjs",
         "mtg.config.example.json",

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -40,10 +40,10 @@ function run(cmd, cmdArgs, opts = {}) {
 }
 
 function checkNodeVersion() {
-    const major = Number(process.versions.node.split(".")[0]);
-    if (major < 20) {
+    const [major, minor] = process.versions.node.split(".").map(Number);
+    if (major < 22 || (major === 22 && minor < 14)) {
         console.warn(
-            `  ⚠ Node ${process.versions.node} detected -- this project targets Node >=20. Things may not work.`
+            `  ⚠ Node ${process.versions.node} detected -- this project targets Node >=22.14. Things may not work.`
         );
         return false;
     }

--- a/src/diagnostics/env-check.mjs
+++ b/src/diagnostics/env-check.mjs
@@ -108,11 +108,11 @@ async function runEnvironmentCheck({ withMysql = false } = {}, dependencies = {}
         }
     }
 
-    const nodeMajor = Number(process.versions.node.split(".")[0]);
-    if (nodeMajor >= 20) {
+    const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+    if (nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 14)) {
         record(`Node ${process.versions.node}`, "pass");
     } else {
-        record(`Node ${process.versions.node} -- this project targets Node >=20`, "fail");
+        record(`Node ${process.versions.node} -- this project targets Node >=22.14`, "fail");
     }
 
     const ocrModelCheck = checkDefaultOcrModel();

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -9,19 +9,9 @@ import FileIO from "../file-io.mjs";
 import { round, orderBy, omit } from "../util.mjs";
 
 const config = {
-    remoteMatch: {
-        twoBit: 0.75,
-        fourBit: 0.7,
-        stringCompare: 0.75
-    },
     remoteBestGuess: {
         maxCandidates: 3,
         minScoreDeltaFromTop: 0.03
-    },
-    dbMatch: {
-        twoBit: 0.92,
-        fourBit: 0.85,
-        stringCompare: 0.92
     }
 };
 
@@ -80,11 +70,7 @@ class ProcessHashes {
                 this.localHash,
                 dbHash.cardHash
             );
-            const isMatch =
-                compareResults.twoBitMatches >= config.dbMatch.twoBit &&
-                compareResults.fourBitMatches >= config.dbMatch.fourBit &&
-                compareResults.stringCompare >= config.dbMatch.stringCompare;
-            if (isMatch) {
+            if (compareResults.matches) {
                 matches.push(
                     Object.assign(compareResults, {
                         setName: dbHash.setName
@@ -146,7 +132,7 @@ class ProcessHashes {
                     this.localHash,
                     remoteImageHash
                 );
-                if (Object.keys(comparisonResults).length > 0) {
+                if (comparisonResults.comparable) {
                     comparisonResultsList.push(
                         Object.assign(comparisonResults, {
                             setName
@@ -157,14 +143,7 @@ class ProcessHashes {
         } finally {
             await done();
         }
-        const matchValues = config.remoteMatch;
-        let bestMatches = comparisonResultsList.filter((match) => {
-            return (
-                match.twoBitMatches >= matchValues.twoBit &&
-                match.fourBitMatches >= matchValues.fourBit &&
-                match.stringCompare >= matchValues.stringCompare
-            );
-        });
+        let bestMatches = comparisonResultsList.filter((match) => match.matches);
         if (
             this.allowRemoteBestGuess &&
             bestMatches.length === 0 &&
@@ -173,15 +152,10 @@ class ProcessHashes {
             const sortedByScore = orderBy(
                 comparisonResultsList.map((match) => ({
                     ...match,
-                    confidenceScore: round(
-                        match.stringCompare * 0.5 +
-                            match.twoBitMatches * 0.3 +
-                            match.fourBitMatches * 0.2,
-                        4
-                    )
+                    confidenceScore: round(match.similarity, 4)
                 })),
-                ["confidenceScore", "stringCompare", "twoBitMatches", "fourBitMatches"],
-                ["desc", "desc", "desc", "desc"]
+                ["confidenceScore", "minQuality", "distance"],
+                ["desc", "desc", "asc"]
             );
             const topScore = sortedByScore[0].confidenceScore;
             bestMatches = sortedByScore

--- a/src/image-hashing/hash-image.mjs
+++ b/src/image-hashing/hash-image.mjs
@@ -1,5 +1,11 @@
-import stringSimilarity from "string-similarity";
-import { imageHash } from "image-hash";
+import {
+    compareFingerprints,
+    evaluatePdqMatch,
+    fingerprintImage,
+    parseFingerprint,
+    PDQ_STARTING_POLICY,
+    serializeFingerprint
+} from "image-fingerprint/node";
 import { JimpMime } from "jimp";
 import log from "../logger/log.mjs";
 import { round } from "../util.mjs";
@@ -9,11 +15,12 @@ const defaultLogger = log.create({
     isPretty: true
 });
 
-// Scryfall's image CDN (cards.scryfall.io) returns HTTP 400 for a header-less request -- Node's
-// global fetch (what the image-hash package uses under the hood) sends no User-Agent by default,
-// so every remote hash was failing outright. Same header value as scryfall-api/http-client.mjs's
-// REQUEST_HEADERS; duplicated locally (like regression-fixtures.mjs's own copy) rather than
-// importing across the image-hashing/scryfall-api boundary for one constant.
+export const FINGERPRINT_OPTIONS = Object.freeze({ algorithm: "pdq-v1" });
+export const FINGERPRINT_MATCH_POLICY = PDQ_STARTING_POLICY;
+
+// Scryfall's image CDN (cards.scryfall.io) returns HTTP 400 for a header-less request. Remote
+// fetching remains at the application's bounded input boundary; image-fingerprint receives only
+// the validated bytes and never reopens a user-controlled path or URL.
 export const REMOTE_IMAGE_REQUEST_HEADERS = {
     "User-Agent": "MTG-Card-Analyzer/0.2 (+https://github.com/dills122/MTG-Card-Analyzer)",
     Accept: "image/*"
@@ -23,8 +30,50 @@ export function isRemoteUrl(value) {
     return typeof value === "string" && /^https?:\/\//i.test(value);
 }
 
+function legacyBlockHash(value) {
+    if (!/^[a-f0-9]{64}$/i.test(value)) {
+        return undefined;
+    }
+    return {
+        schemaVersion: 1,
+        algorithm: "blockhash-v1",
+        encoding: "hex",
+        hash: value.toLowerCase(),
+        bitLength: 256,
+        parameters: { bitsPerSide: 16, method: 2 }
+    };
+}
+
+function readStoredFingerprint(value) {
+    const serialized = String(value || "").trim();
+    try {
+        return parseFingerprint(serialized);
+    } catch {
+        const legacy = legacyBlockHash(serialized);
+        if (legacy) {
+            return legacy;
+        }
+        throw new Error("Stored image fingerprint is invalid");
+    }
+}
+
+function incompatibleResult(reason) {
+    return {
+        comparable: false,
+        reason,
+        similarity: 0,
+        distance: null,
+        bitLength: 0,
+        leftQuality: null,
+        rightQuality: null,
+        minQuality: null,
+        eligible: false,
+        matches: false
+    };
+}
+
 export function createHashing({
-    imageHash: hashImageSource = imageHash,
+    fingerprintImage: fingerprintImageSource = fingerprintImage,
     loadImageInput = readImageInput,
     decodeImage = decodeImageInput,
     logger = defaultLogger
@@ -32,62 +81,75 @@ export function createHashing({
     async function prepareHashSource(imgUrl, options) {
         const input = await loadImageInput(imgUrl, options);
         if (input.dimensions.format === "jpeg" || input.dimensions.format === "png") {
-            return {
-                data: input.buffer,
-                ext: input.dimensions.format === "jpeg" ? JimpMime.jpeg : JimpMime.png
-            };
+            return input.buffer;
         }
 
-        // image-hash only decodes JPEG/PNG/WebP. Preserve the scanner's bounded GIF/BMP input
-        // contract by decoding the already-validated bytes and normalizing them to PNG first.
+        // image-fingerprint decodes JPEG, PNG, and WebP. Preserve the scanner's bounded GIF/BMP
+        // input contract by decoding already-validated bytes and normalizing them to PNG first.
         const image = await decodeImage(input);
-        return { data: await image.getBuffer(JimpMime.png), ext: JimpMime.png };
+        return image.getBuffer(JimpMime.png);
     }
 
     function hashImage(imgUrl, cb) {
-        logger.info(`Hashing image: ${formatImageSource(imgUrl)}`);
+        logger.info(`Fingerprinting image: ${formatImageSource(imgUrl)} (PDQ v1)`);
         const options = isRemoteUrl(imgUrl) ? { headers: REMOTE_IMAGE_REQUEST_HEADERS } : {};
-        prepareHashSource(imgUrl, options).then(
-            (source) => {
-                // Never let image-hash reopen a user path or perform its own unbounded fetch. Its
-                // buffer form receives bytes already capped, signature-checked, and dimension-checked
-                // by the shared image-input boundary.
-                hashImageSource(source, 16, true, (error, data) => {
-                    if (error) {
-                        return cb(error);
-                    }
-                    return cb(null, data);
-                });
-            },
-            (error) => cb(error)
-        );
+        prepareHashSource(imgUrl, options)
+            .then((source) => fingerprintImageSource(source, FINGERPRINT_OPTIONS))
+            .then(
+                (fingerprint) => cb(null, serializeFingerprint(fingerprint)),
+                (error) => cb(error)
+            );
     }
 
     function compareHash(hashOne, hashTwo) {
-        const hashLength = hashOne.length;
-        let twoBitMatches = 0;
-        let fourBitMatches = 0;
-        hashOne.split("").forEach((_character, index) => {
-            if (index % 2 === 0) {
-                const hashOneDoubleStr = hashOne.slice(index - 2, index);
-                const hashTwoDoubleStr = hashTwo.slice(index - 2, index);
-                twoBitMatches += hashOneDoubleStr === hashTwoDoubleStr ? 1 : 0;
-            }
-            if (index % 4 === 0) {
-                const hashOneQuadStr = hashOne.slice(index - 4, index);
-                const hashTwoQuadStr = hashTwo.slice(index - 4, index);
-                fourBitMatches += hashOneQuadStr === hashTwoQuadStr ? 1 : 0;
-            }
-        });
-        const comparisonResults = {
-            twoBitMatches: round(twoBitMatches / (hashLength / 2), 2),
-            fourBitMatches: round(fourBitMatches / (hashLength / 4), 2),
-            stringCompare: round(stringSimilarity.compareTwoStrings(hashOne, hashTwo), 2)
+        let first;
+        let second;
+        try {
+            first = readStoredFingerprint(hashOne);
+            second = readStoredFingerprint(hashTwo);
+        } catch (error) {
+            logger.warn(error.message);
+            return incompatibleResult("invalid-fingerprint");
+        }
+
+        const comparison = compareFingerprints(first, second);
+        if (!comparison.comparable) {
+            logger.info(`Image fingerprints are not comparable: ${comparison.reason}`);
+            return incompatibleResult(comparison.reason);
+        }
+
+        const similarity = round(1 - comparison.normalizedDistance, 4);
+        let eligible = true;
+        let matches = false;
+        if (first.algorithm === "pdq-v1" && second.algorithm === "pdq-v1") {
+            const policyResult = evaluatePdqMatch(first, second, FINGERPRINT_MATCH_POLICY);
+            eligible = policyResult.eligible;
+            matches = policyResult.matches;
+        } else {
+            matches = similarity >= 0.75;
+        }
+        const leftQuality = first.algorithm === "pdq-v1" ? first.quality : null;
+        const rightQuality = second.algorithm === "pdq-v1" ? second.quality : null;
+        const minQuality =
+            leftQuality === null || rightQuality === null
+                ? null
+                : Math.min(leftQuality, rightQuality);
+        const result = {
+            comparable: true,
+            algorithm: comparison.algorithm,
+            similarity,
+            distance: comparison.distance,
+            bitLength: comparison.bitLength,
+            leftQuality,
+            rightQuality,
+            minQuality,
+            eligible,
+            matches
         };
         logger.info(
-            `Hash similarity: 2-bit ${toPercent(comparisonResults.twoBitMatches)}, 4-bit ${toPercent(comparisonResults.fourBitMatches)}, text ${toPercent(comparisonResults.stringCompare)}`
+            `Fingerprint similarity: ${toPercent(result.similarity)} (distance ${result.distance}/${result.bitLength}, minimum quality ${result.minQuality ?? "n/a"})`
         );
-        return comparisonResults;
+        return result;
     }
 
     return Object.freeze({ compareHash, hashImage });
@@ -124,5 +186,7 @@ export default {
     hashImage,
     createHashing,
     isRemoteUrl,
-    REMOTE_IMAGE_REQUEST_HEADERS
+    REMOTE_IMAGE_REQUEST_HEADERS,
+    FINGERPRINT_OPTIONS,
+    FINGERPRINT_MATCH_POLICY
 };

--- a/src/image-processing/smart-crop.mjs
+++ b/src/image-processing/smart-crop.mjs
@@ -4,7 +4,7 @@ import { readImage } from "./util.mjs";
 import { round, clamp } from "../util.mjs";
 
 // Reusable region registry -- the shared "layer" every crop spot plugs into. setSymbol feeds the
-// image-hash path; name/type/rules-name/default feed OCR (region templates, one or more crop
+// image-fingerprint path; name/type/rules-name/default feed OCR (region templates, one or more crop
 // candidates per type -- ocr-preprocessing.mjs runs each through its own pixel preprocessing and
 // picks the best result after real OCR scoring, so these carry no confidence heuristic here).
 const regions = {
@@ -153,7 +153,7 @@ function computeSourceUpscaleFactor(dimensions) {
 
 /**
  * OCR-specific sizing gate (GitHub issue #156). Unlike assertSourceSizeOk's hard cutoff --
- * used for set-symbol image-hash crops, where a soft/undersized crop actively hurts hash
+ * used for set-symbol image-fingerprint crops, where a soft/undersized crop actively hurts hash
  * comparison -- every OCR crop is upscaled to a fixed minimum width by padAndScale
  * (see binarize.mjs) regardless of source resolution. So a source that's merely somewhat
  * under the standard minimum can still reach OCR instead of being rejected outright; only a
@@ -235,7 +235,7 @@ function cropSetSymbolFromImage(img) {
 
 /**
  * Crop the set-symbol region from a file on disk and write it to a temp file, for callers that
- * need a file path (e.g. the promisified image-hash lib). Throws on undersized source images and
+ * need a file path. Throws on undersized source images and
  * on low-confidence crops -- both cases should fall back to full-card hashing at the call site.
  */
 async function writeSetSymbolSnippet(imgPath, directory) {

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -55,14 +55,7 @@ function hashImage(imagePath, dependencies) {
 }
 
 function comparisonScore(comparison) {
-    return (
-        Math.round(
-            (comparison.stringCompare * 0.5 +
-                comparison.twoBitMatches * 0.3 +
-                comparison.fourBitMatches * 0.2) *
-                10000
-        ) / 10000
-    );
+    return Math.round(comparison.similarity * 10000) / 10000;
 }
 
 async function rankPrintCandidates(imagePath, cards, dependencies) {

--- a/test/diagnostics/env-check.spec.mjs
+++ b/test/diagnostics/env-check.spec.mjs
@@ -100,11 +100,11 @@ describe("diagnostics::env-check", () => {
         });
     });
 
-    it("checks Node version against the >=20 floor", async () => {
+    it("checks Node version against the >=22.14 floor", async () => {
         const result = await runCheck();
         const nodeCheck = result.checks.find((check) => check.label.startsWith("Node "));
         assert.exists(nodeCheck);
-        assert.equal(nodeCheck.status, "pass", "this test suite itself requires Node >=20");
+        assert.equal(nodeCheck.status, "pass", "this test suite itself requires Node >=22.14");
     });
 
     it("checks the pinned official LSTM English model used at runtime", async () => {

--- a/test/export-processor/process-hashes-fallback.spec.mjs
+++ b/test/export-processor/process-hashes-fallback.spec.mjs
@@ -21,9 +21,11 @@ describe("ProcessHashes fallback behavior", () => {
             .onSecondCall()
             .callsArgWith(1, null, "hash2");
         const compareHashStub = sandbox.stub().returns({
-            twoBitMatches: 0.6,
-            fourBitMatches: 0.5,
-            stringCompare: 0.65
+            comparable: true,
+            matches: false,
+            similarity: 0.65,
+            minQuality: 100,
+            distance: 90
         });
 
         const hasher = ProcessHashesModule.create({

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -12,9 +12,20 @@ const { ProcessHashes } = exportProcessor;
 const CardHashes = storage.hashes;
 const { Hash } = imageHashing;
 
-const FAKE_HASH = "THISISANEXAMPLEOFAFAKEHASHEEEEEE";
-const CLOSE_DIFF_HASH = "THISISANEXAMPLEOFAFAKAHASHEEEEEE";
-const FAR_DIFF_HASH = "THISISANEXAMPLEOFAHASHAADDEEDD";
+function pdq(hash) {
+    return JSON.stringify({
+        schemaVersion: 1,
+        algorithm: "pdq-v1",
+        encoding: "hex",
+        hash,
+        bitLength: 256,
+        quality: 100
+    });
+}
+
+const FAKE_HASH = pdq("0".repeat(64));
+const CLOSE_DIFF_HASH = pdq(`${"0".repeat(63)}1`);
+const FAR_DIFF_HASH = pdq("f".repeat(64));
 const FAKE_SET = "FAKESET";
 
 const FakeCards = [

--- a/test/hashing/hashing.spec.mjs
+++ b/test/hashing/hashing.spec.mjs
@@ -4,19 +4,26 @@ import { createHashing } from "../../src/image-hashing/hash-image.mjs";
 
 describe("Hashing::", () => {
     const url = "https://img.scryfall.com/cards/normal/en/shm/53.jpg?1517813031";
-    const fakeHash = "0773063f063f36070e070a070f378e7f1f000fff0fff020103f00ffb0f810ff0";
+    const fakeFingerprint = {
+        schemaVersion: 1,
+        algorithm: "pdq-v1",
+        encoding: "hex",
+        hash: "0773063f063f36070e070a070f378e7f1f000fff0fff020103f00ffb0f810ff0",
+        bitLength: 256,
+        quality: 100
+    };
     let Hashing;
-    let imageHashStub;
+    let fingerprintImageStub;
     let loadImageInputStub;
     describe("ImageHashing::", () => {
         beforeEach(() => {
-            imageHashStub = sinon.stub().callsArgWith(3, null, fakeHash);
+            fingerprintImageStub = sinon.stub().resolves(fakeFingerprint);
             loadImageInputStub = sinon.stub().resolves({
                 buffer: Buffer.from("validated image"),
                 dimensions: { width: 10, height: 10, format: "jpeg" }
             });
             Hashing = createHashing({
-                imageHash: imageHashStub,
+                fingerprintImage: fingerprintImageStub,
                 loadImageInput: loadImageInputStub
             });
         });
@@ -28,10 +35,11 @@ describe("Hashing::", () => {
             Hashing.hashImage(url, (error, hash) => {
                 assert.isNull(error);
                 assert.isString(hash);
-                assert.isTrue(imageHashStub.calledOnce, "Image Hash called");
+                assert.equal(JSON.parse(hash).algorithm, "pdq-v1");
+                assert.isTrue(fingerprintImageStub.calledOnce, "Image fingerprint called");
                 assert.isTrue(
                     consoleLogStub.calledOnceWithExactly(
-                        "INFO  Hashing image: img.scryfall.com/53.jpg"
+                        "INFO  Fingerprinting image: img.scryfall.com/53.jpg (PDQ v1)"
                     )
                 );
                 done();
@@ -43,7 +51,7 @@ describe("Hashing::", () => {
             Hashing.hashImage("", (error, hash) => {
                 assert.deepEqual(error, {});
                 assert.isUndefined(hash);
-                assert.isFalse(imageHashStub.called, "Image Hash not called");
+                assert.isFalse(fingerprintImageStub.called, "Image fingerprint not called");
                 done();
             });
         });
@@ -58,7 +66,9 @@ describe("Hashing::", () => {
                 assert.match(error.message, /remote URL is invalid/);
                 assert.isUndefined(hash);
                 assert.isTrue(
-                    consoleLogStub.calledOnceWithExactly("INFO  Hashing image: invalid URL")
+                    consoleLogStub.calledOnceWithExactly(
+                        "INFO  Fingerprinting image: invalid URL (PDQ v1)"
+                    )
                 );
                 done();
             });
@@ -77,12 +87,11 @@ describe("Hashing::", () => {
             const consoleLogStub = sinon.stub(console, "log");
             let hashComparisonResults = Hashing.compareHash(hashOne, hashTwo);
             assert.isObject(hashComparisonResults);
-            assert.equal(hashComparisonResults.twoBitMatches, 1);
-            assert.equal(hashComparisonResults.fourBitMatches, 1);
-            assert.equal(hashComparisonResults.stringCompare, 1);
+            assert.equal(hashComparisonResults.similarity, 1);
+            assert.equal(hashComparisonResults.distance, 0);
             assert.isTrue(
                 consoleLogStub.calledOnceWithExactly(
-                    "INFO  Hash similarity: 2-bit 100%, 4-bit 100%, text 100%"
+                    "INFO  Fingerprint similarity: 100% (distance 0/256, minimum quality n/a)"
                 )
             );
             done();

--- a/test/image-hashing/hash-image.spec.mjs
+++ b/test/image-hashing/hash-image.spec.mjs
@@ -4,21 +4,21 @@ import { compareHash, createHashing } from "../../src/image-hashing/hash-image.m
 
 describe("image-hashing::hash-image", () => {
     let sandbox;
-    let imageHashStub;
+    let fingerprintImageStub;
     let loadImageInputStub;
     let decodeImageStub;
     let hashImage;
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
-        imageHashStub = sandbox.stub();
+        fingerprintImageStub = sandbox.stub();
         loadImageInputStub = sandbox.stub().resolves({
             buffer: Buffer.from("validated image"),
             dimensions: { width: 10, height: 10, format: "jpeg" }
         });
         decodeImageStub = sandbox.stub();
         ({ hashImage } = createHashing({
-            imageHash: imageHashStub,
+            fingerprintImage: fingerprintImageStub,
             loadImageInput: loadImageInputStub,
             decodeImage: decodeImageStub
         }));
@@ -30,33 +30,47 @@ describe("image-hashing::hash-image", () => {
 
     describe("hashImage::", () => {
         it("loads remote images through the bounded boundary with a User-Agent", (done) => {
-            imageHashStub.callsArgWith(3, null, "hash");
+            fingerprintImageStub.resolves({
+                schemaVersion: 1,
+                algorithm: "pdq-v1",
+                encoding: "hex",
+                hash: "0".repeat(64),
+                bitLength: 256,
+                quality: 100
+            });
 
             hashImage("https://cards.scryfall.io/normal/front/a/b/card.jpg", (err, hash) => {
                 assert.isNull(err);
-                assert.equal(hash, "hash");
+                assert.equal(JSON.parse(hash).algorithm, "pdq-v1");
                 assert.isTrue(loadImageInputStub.calledOnce);
                 const [url, options] = loadImageInputStub.firstCall.args;
                 assert.equal(url, "https://cards.scryfall.io/normal/front/a/b/card.jpg");
                 assert.property(options.headers, "User-Agent");
-                assert.isTrue(imageHashStub.calledOnce);
-                const [source] = imageHashStub.firstCall.args;
-                assert.instanceOf(source.data, Buffer);
-                assert.equal(source.ext, "image/jpeg");
+                assert.isTrue(fingerprintImageStub.calledOnce);
+                const [source, fingerprintOptions] = fingerprintImageStub.firstCall.args;
+                assert.instanceOf(source, Buffer);
+                assert.deepEqual(fingerprintOptions, { algorithm: "pdq-v1" });
                 done(err);
             });
         });
 
         it("loads local images through the bounded boundary without request headers", (done) => {
-            imageHashStub.callsArgWith(3, null, "hash");
+            fingerprintImageStub.resolves({
+                schemaVersion: 1,
+                algorithm: "pdq-v1",
+                encoding: "hex",
+                hash: "0".repeat(64),
+                bitLength: 256,
+                quality: 100
+            });
 
             hashImage("/tmp/some/local/card.png", (err) => {
                 assert.isTrue(
                     loadImageInputStub.calledOnceWithExactly("/tmp/some/local/card.png", {})
                 );
-                assert.isTrue(imageHashStub.calledOnce);
-                const [source] = imageHashStub.firstCall.args;
-                assert.instanceOf(source.data, Buffer);
+                assert.isTrue(fingerprintImageStub.calledOnce);
+                const [source] = fingerprintImageStub.firstCall.args;
+                assert.instanceOf(source, Buffer);
                 done(err);
             });
         });
@@ -69,21 +83,27 @@ describe("image-hashing::hash-image", () => {
             decodeImageStub.resolves({
                 getBuffer: sandbox.stub().resolves(Buffer.from("normalized png"))
             });
-            imageHashStub.callsArgWith(3, null, "hash");
+            fingerprintImageStub.resolves({
+                schemaVersion: 1,
+                algorithm: "pdq-v1",
+                encoding: "hex",
+                hash: "0".repeat(64),
+                bitLength: 256,
+                quality: 100
+            });
 
             hashImage("/tmp/card.gif", (err, hash) => {
                 assert.isNull(err);
-                assert.equal(hash, "hash");
+                assert.equal(JSON.parse(hash).algorithm, "pdq-v1");
                 assert.isTrue(decodeImageStub.calledOnce);
-                const [source] = imageHashStub.firstCall.args;
-                assert.equal(source.ext, "image/png");
-                assert.equal(source.data.toString(), "normalized png");
+                const [source] = fingerprintImageStub.firstCall.args;
+                assert.equal(source.toString(), "normalized png");
                 done(err);
             });
         });
 
         it("forwards a hashing error to the callback", (done) => {
-            imageHashStub.callsArgWith(3, new Error("boom"));
+            fingerprintImageStub.rejects(new Error("boom"));
 
             hashImage("https://cards.scryfall.io/normal/front/a/b/card.jpg", (err, hash) => {
                 assert.instanceOf(err, Error);
@@ -93,14 +113,14 @@ describe("image-hashing::hash-image", () => {
             });
         });
 
-        it("does not invoke image-hash when bounded input validation fails", (done) => {
+        it("does not invoke image-fingerprint when bounded input validation fails", (done) => {
             loadImageInputStub.rejects(
                 new Error("Invalid or unsupported image: dimensions exceed limit")
             );
 
             hashImage("/tmp/hostile.jpg", (err) => {
                 assert.match(err.message, /dimensions exceed limit/);
-                assert.isFalse(imageHashStub.called);
+                assert.isFalse(fingerprintImageStub.called);
                 done();
             });
         });
@@ -110,9 +130,42 @@ describe("image-hashing::hash-image", () => {
         it("scores an identical hash as a perfect match", () => {
             const hash = "a".repeat(64);
             const result = compareHash(hash, hash);
-            assert.equal(result.twoBitMatches, 1);
-            assert.equal(result.fourBitMatches, 1);
-            assert.equal(result.stringCompare, 1);
+            assert.isTrue(result.comparable);
+            assert.equal(result.similarity, 1);
+            assert.equal(result.distance, 0);
+            assert.isTrue(result.matches);
+        });
+
+        it("does not compare legacy Blockhash cache entries with PDQ fingerprints", () => {
+            const pdq = JSON.stringify({
+                schemaVersion: 1,
+                algorithm: "pdq-v1",
+                encoding: "hex",
+                hash: "0".repeat(64),
+                bitLength: 256,
+                quality: 100
+            });
+            const result = compareHash("a".repeat(64), pdq);
+            assert.isFalse(result.comparable);
+            assert.equal(result.reason, "algorithm-mismatch");
+            assert.isFalse(result.matches);
+        });
+
+        it("keeps PDQ quality eligibility separate from mathematical similarity", () => {
+            const lowQualityPdq = JSON.stringify({
+                schemaVersion: 1,
+                algorithm: "pdq-v1",
+                encoding: "hex",
+                hash: "0".repeat(64),
+                bitLength: 256,
+                quality: 10
+            });
+            const result = compareHash(lowQualityPdq, lowQualityPdq);
+            assert.isTrue(result.comparable);
+            assert.equal(result.similarity, 1);
+            assert.equal(result.minQuality, 10);
+            assert.isFalse(result.eligible);
+            assert.isFalse(result.matches);
         });
     });
 });

--- a/test/regression/regression-runner.spec.mjs
+++ b/test/regression/regression-runner.spec.mjs
@@ -187,11 +187,7 @@ describe("Regression framework::", () => {
                 callback(null, imagePath.includes("alternative") ? "bbbb" : "aaaa"),
             compareHash: (left, right) => {
                 const score = left === right ? 1 : 0;
-                return {
-                    twoBitMatches: score,
-                    fourBitMatches: score,
-                    stringCompare: score
-                };
+                return { similarity: score };
             }
         };
 
@@ -257,7 +253,7 @@ describe("Regression framework::", () => {
                 hashCalls.push(imagePath);
                 callback(null, "fresh-hash");
             },
-            compareHash: () => ({ twoBitMatches: 1, fourBitMatches: 1, stringCompare: 1 })
+            compareHash: () => ({ similarity: 1 })
         };
 
         const report = await runRegression(manifest, {
@@ -352,11 +348,7 @@ describe("Regression framework::", () => {
                 MatchName: matchNameModule,
                 Hash: {
                     hashImage: (_imagePath, callback) => callback(null, "fresh-hash"),
-                    compareHash: () => ({
-                        twoBitMatches: 1,
-                        fourBitMatches: 1,
-                        stringCompare: 1
-                    })
+                    compareHash: () => ({ similarity: 1 })
                 },
                 materializeFixture: async (fixture) => fixture.imagePath,
                 createOcrSession: async (options) => {
@@ -432,11 +424,7 @@ describe("Regression framework::", () => {
                 MatchName: matchNameModule,
                 Hash: {
                     hashImage: (_imagePath, callback) => callback(null, "fresh-hash"),
-                    compareHash: () => ({
-                        twoBitMatches: 1,
-                        fourBitMatches: 1,
-                        stringCompare: 1
-                    })
+                    compareHash: () => ({ similarity: 1 })
                 },
                 materializeFixture: async (fixture) => fixture.imagePath,
                 createOcrSession: async () => {


### PR DESCRIPTION
## Summary

- replace `image-hash` with the maintained `image-fingerprint@0.1.1` package
- adopt normalized PDQ v1 fingerprints and explicit Hamming-distance/quality policy
- preserve safe handling of legacy raw Blockhash cache rows by refreshing them through the remote comparison path
- add an offline, deterministic Blockhash-versus-PDQ retrieval benchmark and document the decision
- align the runtime, setup checks, diagnostics, documentation, packaging, and CI with the dependency's Node 22.14 minimum

## Why

The project is moving to its maintained image-fingerprint fork regardless of algorithm. The benchmark determines which available mode best fits MTG print ranking before changing production behavior.

Across 272 transformed full-card retrieval queries ranked against 151 reference prints, PDQ placed the correct print first in 272/272 cases versus 270/272 for both Blockhash decoder modes. Its mean correct-versus-nearest-wrong margin was 0.2702 versus 0.1534. Set-symbol top-1 accuracy tied at 30/32 for all modes.

## Impact

Fresh hashes are stored as versioned PDQ records. Existing raw Blockhash cache entries remain readable but are intentionally incompatible with PDQ, so they fall through and are refreshed without a destructive cache migration. Conservative PDQ policy matching remains separate from the existing bounded nearest-candidate fallback.

## Validation

- `pnpm check:fast`
- `pnpm test`
- `pnpm coverage:check` — 92.8% statements/lines, 78.39% branches
- `pnpm test:regression` — 151/151 blocking fixtures; 156/158 overall with the two existing non-blocking vintage misses
- `pnpm test:package` — packed CLI smoke passed with 70 files
- `pnpm audit --prod` — no known vulnerabilities
- `pnpm benchmark:fingerprints` — 272 full-card and 32 set-symbol queries across all three modes
