### PR TITLE
fix: calibrate PDQ print fallback

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,7 +108,9 @@ Run `mtg-card-analyzer --help` for the command list or see the
    unambiguous individual face names resolve back to their canonical compound card name.
 4. Failed title matches progressively try soft/inverted title variants, rotated title bands, and
    finally supplemental rules text, avoiding the extra OCR work for ordinary successful scans.
-5. Candidate printings come from Scryfall and are ranked with cached or downloaded image hashes.
+5. Candidate printings come from Scryfall and are ranked with cached or downloaded PDQ
+   fingerprints. A high-confidence set-symbol result wins; an inconclusive symbol comparison is
+   retried with the full card instead of forcing a weak print guess.
 6. Results are printed and, only when enabled, a single confirmed printing is written to the
    collection backend. A resolved name with multiple possible sets is saved to needs-attention
    instead of being treated as confirmed.

--- a/docs/image-fingerprint-benchmark.md
+++ b/docs/image-fingerprint-benchmark.md
@@ -8,6 +8,9 @@ ranking, not to make a universal claim about perceptual-hash quality.
 
 ```bash
 pnpm benchmark:fingerprints
+
+# Re-run only the selected production mode while tuning application policy
+pnpm benchmark:fingerprints --mode pdq-v1-normalized
 ```
 
 The command is offline and deterministic apart from runtime measurements. It uses the enabled
@@ -54,8 +57,32 @@ isolated algorithm microbenchmark.
 
 Use normalized PDQ v1 as the production default. Store the full versioned fingerprint record and
 compare it using Hamming distance plus the package's explicit starting policy (`maxDistance: 31`,
-`minQuality: 50`). When no candidate satisfies that conservative policy, the existing bounded
-closest-candidate fallback may still rank comparable PDQ records.
+`minQuality: 50`).
+
+The application-specific fallback is deliberately weaker than confirmation but no longer
+unbounded. It requires both fingerprints to satisfy the quality policy and the closest candidate
+to have at least 0.75 similarity. Candidates within 0.03 of the top score remain visible, up to
+three results. When a set-symbol pass produces no candidate at that floor, the matcher retries the
+original full-card image against full-card references rather than accepting a weak symbol guess.
+
+## Application-policy calibration
+
+A PDQ-only rerun on 2026-08-12 evaluated the conservative confirmation policy and the bounded
+application fallback independently. “Correct” means that the selected cohort contained the exact
+printing; “incorrect” means that a cohort was accepted without it.
+
+| Input scope | Policy                    | Accepted | Correct | Incorrect | Abstained |
+| ----------- | ------------------------- | -------: | ------: | --------: | --------: |
+| Full card   | PDQ starting policy       |  243/272 |     243 |         0 |        29 |
+| Full card   | 0.75 application fallback |  272/272 |     272 |         0 |         0 |
+| Set symbol  | PDQ starting policy       |    19/32 |      19 |         0 |        13 |
+| Set symbol  | 0.75 application fallback |    24/32 |      24 |         0 |         8 |
+
+The two wrong set-symbol rankings were cropped variants with top similarities of 0.4922 and
+0.5625. The 0.75 floor therefore withheld both. Every transformed full-card query ranked the
+correct print first and cleared the fallback floor, which supports the full-card retry for this
+application pipeline. This is evidence for the current reviewed corpus, not a universal PDQ
+threshold.
 
 Legacy raw Blockhash values are recognized as historical records but are intentionally
 non-comparable with PDQ. A scan that encounters only legacy cache rows falls through to the remote

--- a/scripts/benchmark-image-fingerprints.mjs
+++ b/scripts/benchmark-image-fingerprints.mjs
@@ -9,7 +9,8 @@ import {
     compareFingerprints,
     decodeImage,
     fingerprintImage,
-    fingerprintPixels
+    fingerprintPixels,
+    PDQ_STARTING_POLICY
 } from "image-fingerprint/node";
 import { readImage } from "../src/image-processing/util.mjs";
 import { cropSetSymbolFromImage } from "../src/image-processing/smart-crop.mjs";
@@ -19,6 +20,23 @@ import { loadManifest } from "../src/regression/manifest.mjs";
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptDirectory, "..");
 const manifestPath = path.join(repositoryRoot, "test/regression/fixtures/manifest.json");
+
+const APPLICATION_POLICIES = Object.freeze([
+    {
+        id: "pdq-starting-policy",
+        minSimilarity: 1 - PDQ_STARTING_POLICY.maxDistance / 256,
+        minQuality: PDQ_STARTING_POLICY.minQuality,
+        maxCandidates: 3,
+        maxSimilarityDeltaFromTop: 0.03
+    },
+    {
+        id: "application-fallback-0.75",
+        minSimilarity: 0.75,
+        minQuality: PDQ_STARTING_POLICY.minQuality,
+        maxCandidates: 3,
+        maxSimilarityDeltaFromTop: 0.03
+    }
+]);
 
 const MODES = [
     {
@@ -80,7 +98,10 @@ function score(left, right) {
     if (!comparison.comparable) {
         throw new Error(`Unexpected incompatible fingerprints: ${comparison.reason}`);
     }
-    return 1 - comparison.normalizedDistance;
+    return {
+        similarity: 1 - comparison.normalizedDistance,
+        distance: comparison.distance
+    };
 }
 
 function round(value, digits = 4) {
@@ -149,6 +170,41 @@ function summarize(rows) {
     };
 }
 
+function evaluateApplicationPolicy(rows, policy) {
+    const results = rows.map((row) => {
+        const qualityEligible =
+            row.queryQuality === undefined ||
+            (row.queryQuality >= policy.minQuality && row.topQuality >= policy.minQuality);
+        const scoreEligible = row.topSimilarity >= policy.minSimilarity;
+        const selected = qualityEligible && scoreEligible ? row.candidatesWithinDelta : [];
+        return {
+            selected,
+            correct: selected.includes(row.card),
+            ambiguous: selected.length > 1
+        };
+    });
+    const accepted = results.filter((result) => result.selected.length > 0);
+    const correct = accepted.filter((result) => result.correct);
+    return {
+        policy,
+        total: rows.length,
+        accepted: accepted.length,
+        abstained: rows.length - accepted.length,
+        correct: correct.length,
+        incorrect: accepted.length - correct.length,
+        ambiguous: accepted.filter((result) => result.ambiguous).length,
+        precision: round(correct.length / (accepted.length || 1)),
+        recall: round(correct.length / rows.length)
+    };
+}
+
+function applicationCalibration(rows, mode) {
+    if (mode.id !== "pdq-v1-normalized") {
+        return undefined;
+    }
+    return APPLICATION_POLICIES.map((policy) => evaluateApplicationPolicy(rows, policy));
+}
+
 async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory) {
     const startedAt = performance.now();
     const referenceFingerprints = new Map();
@@ -164,10 +220,8 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
             const ranking = cards
                 .map((candidate) => ({
                     card: candidate,
-                    similarity: score(
-                        queryFingerprint,
-                        referenceFingerprints.get(identity(candidate))
-                    )
+                    fingerprint: referenceFingerprints.get(identity(candidate)),
+                    ...score(queryFingerprint, referenceFingerprints.get(identity(candidate)))
                 }))
                 .sort((left, right) => right.similarity - left.similarity);
             const expectedId = identity(card);
@@ -178,6 +232,7 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
             const closestNegativeSimilarity = ranking.find(
                 (entry) => identity(entry.card) !== expectedId
             ).similarity;
+            const topSimilarity = ranking[0].similarity;
             fullCardRows.push({
                 card: expectedId,
                 variant: variant[0],
@@ -185,7 +240,18 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
                 positiveSimilarity,
                 closestNegativeSimilarity,
                 margin: positiveSimilarity - closestNegativeSimilarity,
-                quality: queryFingerprint.quality
+                quality: queryFingerprint.quality,
+                queryQuality: queryFingerprint.quality,
+                topQuality: ranking[0].fingerprint.quality,
+                topSimilarity,
+                candidatesWithinDelta: ranking
+                    .filter(
+                        (entry) =>
+                            topSimilarity - entry.similarity <=
+                            APPLICATION_POLICIES[0].maxSimilarityDeltaFromTop
+                    )
+                    .slice(0, APPLICATION_POLICIES[0].maxCandidates)
+                    .map((entry) => identity(entry.card))
             });
         }
     }
@@ -213,10 +279,8 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
                 const ranking = group
                     .map((candidate) => ({
                         card: candidate,
-                        similarity: score(
-                            queryFingerprint,
-                            referenceSymbols.get(identity(candidate))
-                        )
+                        fingerprint: referenceSymbols.get(identity(candidate)),
+                        ...score(queryFingerprint, referenceSymbols.get(identity(candidate)))
                     }))
                     .sort((left, right) => right.similarity - left.similarity);
                 const expectedId = identity(card);
@@ -227,6 +291,7 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
                 const closestNegativeSimilarity = ranking.find(
                     (entry) => identity(entry.card) !== expectedId
                 ).similarity;
+                const topSimilarity = ranking[0].similarity;
                 setSymbolRows.push({
                     card: expectedId,
                     variant: variant[0],
@@ -234,7 +299,18 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
                     positiveSimilarity,
                     closestNegativeSimilarity,
                     margin: positiveSimilarity - closestNegativeSimilarity,
-                    quality: queryFingerprint.quality
+                    quality: queryFingerprint.quality,
+                    queryQuality: queryFingerprint.quality,
+                    topQuality: ranking[0].fingerprint.quality,
+                    topSimilarity,
+                    candidatesWithinDelta: ranking
+                        .filter(
+                            (entry) =>
+                                topSimilarity - entry.similarity <=
+                                APPLICATION_POLICIES[0].maxSimilarityDeltaFromTop
+                        )
+                        .slice(0, APPLICATION_POLICIES[0].maxCandidates)
+                        .map((entry) => identity(entry.card))
                 });
             }
         }
@@ -245,6 +321,10 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
         runtimeMs: round(performance.now() - startedAt, 2),
         fullCard: summarize(fullCardRows),
         setSymbol: summarize(setSymbolRows),
+        applicationCalibration: {
+            fullCard: applicationCalibration(fullCardRows, mode),
+            setSymbol: applicationCalibration(setSymbolRows, mode)
+        },
         failures: {
             fullCard: fullCardRows.filter((row) => row.rank !== 1).slice(0, 20),
             setSymbol: setSymbolRows.filter((row) => row.rank !== 1).slice(0, 20)
@@ -252,7 +332,24 @@ async function benchmarkMode(mode, cards, queryCards, duplicateGroups, directory
     };
 }
 
+function selectedModes(arguments_) {
+    const modeIndex = arguments_.indexOf("--mode");
+    if (modeIndex === -1) {
+        return MODES;
+    }
+    const modeId = arguments_[modeIndex + 1];
+    if (!modeId || modeId.startsWith("--")) {
+        throw new Error("--mode requires a benchmark mode id");
+    }
+    const mode = MODES.find((candidate) => candidate.id === modeId);
+    if (!mode) {
+        throw new Error(`Unknown benchmark mode: ${modeId}`);
+    }
+    return [mode];
+}
+
 async function main() {
+    const modes = selectedModes(process.argv.slice(2));
     const manifest = await loadManifest(manifestPath);
     const cards = manifest.catalog.filter((card) => card.enabled !== false);
     const duplicateGroups = Object.values(Object.groupBy(cards, (card) => card.name)).filter(
@@ -278,7 +375,7 @@ async function main() {
     const directory = await mkdtemp(path.join(os.tmpdir(), "mtg-fingerprint-benchmark-"));
     try {
         const results = [];
-        for (const mode of MODES) {
+        for (const mode of modes) {
             console.error(`Benchmarking ${mode.id}...`);
             results.push(await benchmarkMode(mode, cards, queryCards, duplicateGroups, directory));
         }

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -11,7 +11,8 @@ import { round, orderBy, omit } from "../util.mjs";
 const config = {
     remoteBestGuess: {
         maxCandidates: 3,
-        minScoreDeltaFromTop: 0.03
+        minSimilarity: 0.75,
+        maxSimilarityDeltaFromTop: 0.03
     }
 };
 
@@ -150,27 +151,39 @@ class ProcessHashes {
             comparisonResultsList.length > 0
         ) {
             const sortedByScore = orderBy(
-                comparisonResultsList.map((match) => ({
-                    ...match,
-                    confidenceScore: round(match.similarity, 4)
-                })),
+                comparisonResultsList
+                    .filter(
+                        (match) =>
+                            match.eligible !== false &&
+                            match.similarity >= config.remoteBestGuess.minSimilarity
+                    )
+                    .map((match) => ({
+                        ...match,
+                        confidenceScore: round(match.similarity, 4)
+                    })),
                 ["confidenceScore", "minQuality", "distance"],
                 ["desc", "desc", "asc"]
             );
-            const topScore = sortedByScore[0].confidenceScore;
-            bestMatches = sortedByScore
-                .filter(
-                    (match) =>
-                        topScore - match.confidenceScore <=
-                        config.remoteBestGuess.minScoreDeltaFromTop
-                )
-                .slice(0, config.remoteBestGuess.maxCandidates)
-                .map((match) => omit(match, ["confidenceScore"]));
-            this.logger.info(
-                `Using closest image matches for "${this.name}": ${bestMatches
-                    .map((match) => match.setName)
-                    .join(", ")}`
-            );
+            if (sortedByScore.length > 0) {
+                const topScore = sortedByScore[0].confidenceScore;
+                bestMatches = sortedByScore
+                    .filter(
+                        (match) =>
+                            topScore - match.confidenceScore <=
+                            config.remoteBestGuess.maxSimilarityDeltaFromTop
+                    )
+                    .slice(0, config.remoteBestGuess.maxCandidates)
+                    .map((match) => omit(match, ["confidenceScore"]));
+                this.logger.info(
+                    `Using closest image matches for "${this.name}": ${bestMatches
+                        .map((match) => match.setName)
+                        .join(", ")}`
+                );
+            } else {
+                this.logger.info(
+                    `Closest image matches for "${this.name}" were below the quality or similarity floor`
+                );
+            }
         }
         this.logger.info(`Scryfall image matches for "${this.name}": ${bestMatches.length}`);
         return bestMatches;
@@ -206,11 +219,11 @@ class ProcessHashes {
         }
         try {
             return await this._hashRemoteSetSymbol(url, tempDirectory);
-        } catch {
+        } catch (error) {
             this.logger.error(
-                `Remote set-symbol hash failed for "${this.name}"; using full card image`
+                `Remote set-symbol hash failed for "${this.name}"; full-card retry required`
             );
-            return this._hashImage(url);
+            throw error;
         }
     }
 

--- a/src/matcher/matching-processor.mjs
+++ b/src/matcher/matching-processor.mjs
@@ -137,6 +137,29 @@ class MatcherProcessor {
     }
 
     async _processMultiSetMatchesAsync() {
+        const initialHashMode = this.hashMode || "full-card";
+        try {
+            const initialMatches = await this._compareCurrentHashesAsync();
+            if (initialMatches.length > 0 || initialHashMode !== "set-symbol") {
+                return initialMatches;
+            }
+            this.logger.info(
+                `Set-symbol comparison was inconclusive for "${this.name}"; retrying full card`
+            );
+        } catch (error) {
+            if (initialHashMode !== "set-symbol") {
+                throw error;
+            }
+            this.logger.error(
+                `Set-symbol comparison failed for "${this.name}"; retrying full card`
+            );
+        }
+
+        await this._hashFromPathAsync(this.filePath);
+        return this._compareCurrentHashesAsync();
+    }
+
+    async _compareCurrentHashesAsync() {
         const processHashes = this.dependencies.processHashes.create({
             name: this.name,
             cards: this.cards,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -328,27 +328,28 @@ const paletteItems = [
                         <article class="evidence-step evidence-step-hash">
                             <div class="evidence-step-head">
                                 <span>04 / Compare</span>
-                                <code>16 × 16 pHash</code>
+                                <code>256-bit PDQ</code>
                             </div>
                             <h3>Ask whether the printing looks like its candidate.</h3>
                             <p>
                                 Full-card compares to full-card; set-symbol compares to the same crop.
-                                Each perceptual hash is checked three ways against reviewed thresholds.
+                                Hamming distance and fingerprint quality are checked against explicit,
+                                benchmarked policy.
                             </p>
                             <dl class="hash-thresholds">
                                 <div>
-                                    <dt>Local cache</dt>
-                                    <dd><span>2-bit ≥ 92%</span><span>4-bit ≥ 85%</span><span>text ≥ 92%</span></dd>
+                                    <dt>Confirmation</dt>
+                                    <dd><span>distance ≤ 31</span><span>quality ≥ 50</span></dd>
                                 </div>
                                 <div>
-                                    <dt>Remote candidate</dt>
-                                    <dd><span>2-bit ≥ 75%</span><span>4-bit ≥ 70%</span><span>text ≥ 75%</span></dd>
+                                    <dt>Closest fallback</dt>
+                                    <dd><span>similarity ≥ 75%</span><span>within 3% of top</span></dd>
                                 </div>
                             </dl>
                             <p class="fallback-note">
                                 If the set-symbol crop is too flat (standard deviation below 10) or
-                                cannot be prepared, the analyzer falls back to full-card hashing rather
-                                than comparing noise.
+                                its comparison is inconclusive, the analyzer retries full-card
+                                fingerprints rather than comparing noise or forcing a weak guess.
                             </p>
                         </article>
                     </div>

--- a/test/export-processor/process-hashes-fallback.spec.mjs
+++ b/test/export-processor/process-hashes-fallback.spec.mjs
@@ -23,9 +23,10 @@ describe("ProcessHashes fallback behavior", () => {
         const compareHashStub = sandbox.stub().returns({
             comparable: true,
             matches: false,
-            similarity: 0.65,
+            eligible: true,
+            similarity: 0.8,
             minQuality: 100,
-            distance: 90
+            distance: 51
         });
 
         const hasher = ProcessHashesModule.create({
@@ -57,4 +58,54 @@ describe("ProcessHashes fallback behavior", () => {
         assert.isAtLeast(matches.length, 1);
         assert.isAtMost(matches.length, 2);
     });
+
+    for (const example of [
+        {
+            name: "similarity is below the calibrated floor",
+            comparison: {
+                comparable: true,
+                matches: false,
+                eligible: true,
+                similarity: 0.74,
+                minQuality: 100,
+                distance: 67
+            }
+        },
+        {
+            name: "PDQ quality is ineligible",
+            comparison: {
+                comparable: true,
+                matches: false,
+                eligible: false,
+                similarity: 0.99,
+                minQuality: 10,
+                distance: 2
+            }
+        }
+    ]) {
+        it(`withholds fallback candidates when ${example.name}`, async () => {
+            const hasher = ProcessHashesModule.create({
+                cards: [{ image_uris: { normal: "a" }, set_name: "A" }],
+                localHash: "local",
+                name: "Test",
+                allowRemoteBestGuess: true,
+                dependencies: {
+                    Hash: {
+                        hashImage: sandbox.stub().callsArgWith(1, null, "remote"),
+                        compareHash: sandbox.stub().returns(example.comparison)
+                    },
+                    CardHashes: {
+                        getByCardName: sandbox.stub().resolves([]),
+                        upsert: sandbox.stub().returns()
+                    }
+                },
+                logger: {
+                    info: sandbox.stub(),
+                    error: sandbox.stub()
+                }
+            });
+
+            assert.deepEqual(await hasher.compareRemoteImages(), []);
+        });
+    }
 });

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -237,7 +237,7 @@ describe("Integration::", () => {
             );
         });
 
-        it("Should fall back to full remote hash when remote set-symbol hashing fails", async () => {
+        it("requests a full-card retry when remote set-symbol hashing fails", async () => {
             stubs.hashImageStub = sandbox.stub(Hash, "hashImage").callsArgWith(1, null, FAKE_HASH);
             let hasher = ProcessHashes.create({
                 cards: [
@@ -261,10 +261,15 @@ describe("Integration::", () => {
                 .stub(hasher, "_hashRemoteSetSymbol")
                 .rejects(new Error("crop failed"));
 
-            await hasher.compareRemoteImages();
+            let caughtError;
+            try {
+                await hasher.compareRemoteImages();
+            } catch (error) {
+                caughtError = error;
+            }
             assert.isTrue(stubs.symbolStub.calledOnce);
-            assert.isTrue(stubs.hashImageStub.calledOnce);
-            assert.equal(stubs.hashImageStub.firstCall.args[0], "http://www.fake.url/img");
+            assert.equal(caughtError.message, "crop failed");
+            assert.isFalse(stubs.hashImageStub.called);
         });
 
         it("awaits remote set-symbol directory cleanup", async () => {
@@ -388,7 +393,7 @@ describe("Integration::", () => {
             assert.isTrue(readStub.calledOnceWithExactly(fixturePath, undefined));
         });
 
-        it("Should fall back to full remote hash when set-symbol crop is low confidence", async () => {
+        it("requests a full-card retry when the remote set-symbol crop is low confidence", async () => {
             const fixturePath = path.resolve(
                 "test-images/regression/scryfall/fin-570-vivi-ornitier-25ef2d44.jpg"
             );
@@ -416,10 +421,15 @@ describe("Integration::", () => {
                 reason: "flat region (stdDev 1 < 10)"
             });
 
-            await hasher.compareRemoteImages();
+            let caughtError;
+            try {
+                await hasher.compareRemoteImages();
+            } catch (error) {
+                caughtError = error;
+            }
             assert.isTrue(stubs.cropStub.calledOnce);
-            assert.isTrue(stubs.hashImageStub.calledOnce);
-            assert.equal(stubs.hashImageStub.firstCall.args[0], fixturePath);
+            assert.match(caughtError.message, /Set symbol crop is low confidence/);
+            assert.isFalse(stubs.hashImageStub.called);
         });
     });
 });

--- a/test/matcher/matching-processor.spec.mjs
+++ b/test/matcher/matching-processor.spec.mjs
@@ -223,6 +223,90 @@ describe("MatcherProcessor::", () => {
         });
     });
 
+    it("retries with full-card fingerprints when set-symbol matching is inconclusive", async () => {
+        const setSymbolHasher = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().resolves([])
+        };
+        const fullCardHasher = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().resolves([{ setName: "M21" }])
+        };
+        sandbox.stub(dependencies, "searchPrintings").resolves([
+            { set_name: "M21", image_uris: { normal: "https://example.com/m21.jpg" } },
+            { set_name: "M20", image_uris: { normal: "https://example.com/m20.jpg" } }
+        ]);
+        const hashStub = sandbox
+            .stub(dependencies, "hashImage")
+            .onFirstCall()
+            .resolves("SET_SYMBOL_HASH")
+            .onSecondCall()
+            .resolves("FULL_CARD_HASH");
+        sandbox.stub(dependencies, "createDirectory").resolves("/tmp/set-symbol-dir");
+        sandbox
+            .stub(dependencies, "writeSetSymbolSnippet")
+            .resolves("/tmp/set-symbol-dir/set-symbol.png");
+        sandbox.stub(dependencies, "cleanUpFiles").resolves();
+        const processHashesStub = sandbox
+            .stub(dependencies.processHashes, "create")
+            .onFirstCall()
+            .returns(setSymbolHasher)
+            .onSecondCall()
+            .returns(fullCardHasher);
+
+        const result = await create({
+            name: "Pacifism",
+            filePath: "/tmp/pacifism.jpg",
+            logger: { info: sandbox.stub(), error: sandbox.stub() }
+        }).executeAsync();
+
+        assert.deepEqual(result, ["M21"]);
+        assert.isTrue(hashStub.calledTwice);
+        assert.equal(hashStub.secondCall.args[0], "/tmp/pacifism.jpg");
+        assert.equal(processHashesStub.firstCall.args[0].hashMode, "set-symbol");
+        assert.equal(processHashesStub.secondCall.args[0].hashMode, "full-card");
+        assert.equal(processHashesStub.secondCall.args[0].localHash, "FULL_CARD_HASH");
+    });
+
+    it("retries with full-card fingerprints when remote set-symbol comparison fails", async () => {
+        const setSymbolError = new Error("remote symbol crop failed");
+        const setSymbolHasher = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().rejects(setSymbolError)
+        };
+        const fullCardHasher = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().resolves([{ setName: "M21" }])
+        };
+        sandbox.stub(dependencies, "searchPrintings").resolves([
+            { set_name: "M21", image_uris: { normal: "https://example.com/m21.jpg" } },
+            { set_name: "M20", image_uris: { normal: "https://example.com/m20.jpg" } }
+        ]);
+        sandbox.stub(dependencies, "hashImage").resolves("HASH");
+        sandbox.stub(dependencies, "createDirectory").resolves("/tmp/set-symbol-dir");
+        sandbox
+            .stub(dependencies, "writeSetSymbolSnippet")
+            .resolves("/tmp/set-symbol-dir/set-symbol.png");
+        sandbox.stub(dependencies, "cleanUpFiles").resolves();
+        sandbox
+            .stub(dependencies.processHashes, "create")
+            .onFirstCall()
+            .returns(setSymbolHasher)
+            .onSecondCall()
+            .returns(fullCardHasher);
+        const error = sandbox.stub();
+
+        const result = await create({
+            name: "Pacifism",
+            filePath: "/tmp/pacifism.jpg",
+            logger: { info: sandbox.stub(), error }
+        }).executeAsync();
+
+        assert.deepEqual(result, ["M21"]);
+        assert.isTrue(error.calledWithMatch(sinon.match(/retrying full card/)));
+        assert.isTrue(fullCardHasher.compareRemoteImages.calledOnce);
+    });
+
     it("awaits local set-symbol cleanup before comparing hashes", async () => {
         const processHashesInstance = {
             compareDbHashes: sandbox.stub().resolves([]),


### PR DESCRIPTION
## Summary

- Require eligible PDQ quality and at least 0.75 similarity before returning closest-print fallback candidates.
- Retry inconclusive or failed set-symbol comparisons with full-card fingerprints.
- Extend the fingerprint benchmark with application-policy calibration and a PDQ-only mode.
- Update the README, benchmark documentation, site, and fallback-path tests.

## Why

The initial PDQ integration applied the library's strict starting policy directly to application fallback matching. Calibration showed that this rejected safe full-card matches while weak set-symbol crops could still produce misleading relative rankings. The application now uses an absolute similarity floor, respects quality eligibility, and falls back to the more reliable full-card fingerprint when the crop is inconclusive.

## Calibration

- Full card: 272/272 accepted and correct at the 0.75 fallback floor.
- Set symbol: 24/32 accepted, all 24 correct, with 8 weak cases abstained.
- Both incorrect cropped-symbol rankings were below the floor (0.4922 and 0.5625).

## Validation

- `pnpm check:fast`
- `pnpm test` — 459 passing
- `pnpm coverage:check` — 92.84% statements/lines, 78.78% branches
- `pnpm test:regression` — 151/151 blocking; 156/158 overall with two existing non-blocking vintage misses
- `pnpm test:package` — 70-file packed CLI smoke passed
- `pnpm site:build`
- `pnpm benchmark:fingerprints --mode pdq-v1-normalized`
