### PR TITLE
Add exact-print identity and verification foundation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,12 +108,13 @@ Run `mtg-card-analyzer --help` for the command list or see the
    unambiguous individual face names resolve back to their canonical compound card name.
 4. Failed title matches progressively try soft/inverted title variants, rotated title bands, and
    finally supplemental rules text, avoiding the extra OCR work for ordinary successful scans.
-5. Candidate printings come from Scryfall and are ranked with cached or downloaded PDQ
-   fingerprints. A high-confidence set-symbol result wins; an inconclusive symbol comparison is
-   retried with the full card instead of forcing a weak print guess.
+5. Candidate printings come from every page of the Scryfall print search and retain exact print IDs,
+   set codes, collector numbers, and treatment metadata while cached or downloaded PDQ fingerprints
+   rank them. A high-confidence set-symbol result wins; an inconclusive symbol comparison is retried
+   with the full card instead of forcing a weak print guess.
 6. Results are printed and, only when enabled, a single confirmed printing is written to the
-   collection backend. A resolved name with multiple possible sets is saved to needs-attention
-   instead of being treated as confirmed.
+   collection backend. A lone API candidate is not confirmation; unverified or multiple exact-print
+   candidates are saved to needs-attention instead.
 
 The scan promise includes local cache/log completion and removal of its bounded OCR temporary
 directory, so the CLI does not exit while those writes or cleanup operations are still pending.
@@ -129,17 +130,18 @@ local-first rather than fully offline.
 
 ## Documentation
 
-| If you want to...                                                | Read...                                                      |
-| ---------------------------------------------------------------- | ------------------------------------------------------------ |
-| Install the project or fix a local setup problem                 | [Local development setup](docs/LOCAL_DEV.md)                 |
-| Look up commands, flags, logging, migration, or collection edits | [CLI reference](docs/cli-reference.md)                       |
-| Change settings or understand local database files               | [Configuration and local data](docs/configuration.md)        |
-| Understand the scan pipeline and module boundaries               | [Architecture](docs/architecture.md)                         |
-| Review production dependency and image-input security controls   | [Dependency security](docs/dependency-security.md)           |
-| Review the Blockhash-versus-PDQ benchmark and selection          | [Fingerprint benchmark](docs/image-fingerprint-benchmark.md) |
-| Add or evaluate OCR and matching fixtures                        | [Regression testing](docs/regression-testing.md)             |
-| Build a reviewed custom OCR fine-tuning corpus                   | [OCR training data](docs/ocr-training-data.md)               |
-| Prepare a change or pull request                                 | [Contributing](CONTRIBUTING.md)                              |
+| If you want to...                                                | Read...                                                       |
+| ---------------------------------------------------------------- | ------------------------------------------------------------- |
+| Install the project or fix a local setup problem                 | [Local development setup](docs/LOCAL_DEV.md)                  |
+| Look up commands, flags, logging, migration, or collection edits | [CLI reference](docs/cli-reference.md)                        |
+| Change settings or understand local database files               | [Configuration and local data](docs/configuration.md)         |
+| Understand the scan pipeline and module boundaries               | [Architecture](docs/architecture.md)                          |
+| Review the exact-print and variant-detection research direction  | [Card detection spike](docs/card-detection-research-spike.md) |
+| Review production dependency and image-input security controls   | [Dependency security](docs/dependency-security.md)            |
+| Review the Blockhash-versus-PDQ benchmark and selection          | [Fingerprint benchmark](docs/image-fingerprint-benchmark.md)  |
+| Add or evaluate OCR and matching fixtures                        | [Regression testing](docs/regression-testing.md)              |
+| Build a reviewed custom OCR fine-tuning corpus                   | [OCR training data](docs/ocr-training-data.md)                |
+| Prepare a change or pull request                                 | [Contributing](CONTRIBUTING.md)                               |
 
 The default NeDB backend is the recommended path. A legacy MySQL/RDS adapter remains available for
 existing users; its setup and migration instructions live in the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,8 +64,14 @@ The persistence tier stores collection and needs-attention records. `storageAdap
 Collection persistence is off by default. A scan writes only when both `queryingEnabled` and
 `collectionEnabled` are true. Scanning the same unambiguous card again increments its quantity;
 explicit collection commands can correct or remove an entry. “Unambiguous” means exactly one card
-name and exactly one printing set. Multiple possible sets are written to needs-attention rather
-than selecting the first set as confirmed collection data.
+name and one image-verified exact printing. Exact print IDs, set codes, and collector numbers remain
+distinct through matching even when variants share a set name. A lone Scryfall result, a closest-image
+best guess, a set-symbol-only match, or multiple possible printings is written to needs-attention
+rather than confirmed.
+
+The hash cache keys refreshed rows by Scryfall print ID (falling back to set code, collector number,
+and language) plus hash mode and hash. Legacy set-only rows remain usable as unverified hints; they
+cannot confirm an exact printing.
 
 The processor owns one bounded OCR work directory per scan and removes it in a `finally` path on
 success and failure. Set-symbol hashing follows the same ownership rule for its local and remote

--- a/docs/card-detection-research-spike.md
+++ b/docs/card-detection-research-spike.md
@@ -1,0 +1,534 @@
+<!-- markdownlint-disable-file MD013 -->
+
+# Card detection research spike
+
+Date: 2026-08-11
+
+## Implementation status
+
+The first contract-and-benchmark slice is implemented:
+
+- Scryfall print searches follow bounded, same-origin pagination.
+- The matcher preserves print ID, set code, collector number, language, illustration, frame, treatment,
+  finish-availability, and image metadata instead of reducing candidates to set names.
+- Same-set variants remain distinct in match details and the hash cache.
+- A lone API candidate and closest-image best guesses are explicitly unverified and cannot trigger a
+  collection write.
+- CLI output shows exact printing labels without exposing internal URLs.
+- Regression expectations can assert `scryfallId`, and the benchmark reports exact-print verification.
+
+Perspective normalization, collector-block OCR, candidate-specific symbol matching, and improved
+regional artwork descriptors remain the next experimental slices.
+
+## Decision
+
+Evolve the scanner from a two-stage **name then set-name hash** pipeline into an explainable,
+multi-signal **name then exact-print** pipeline. Keep the existing title OCR as candidate generation,
+but identify a printing by combining independent evidence from:
+
+1. normalized title and printed-title aliases;
+2. bottom collector information when the frame has it;
+3. expansion symbol when the frame has one;
+4. registered artwork and whole-card visual similarity;
+5. frame, border, layout, language, and treatment compatibility.
+
+The ranker should return a Scryfall printing ID, set code, collector number, treatment metadata,
+confidence, and evidence breakdown. It should abstain when the evidence cannot distinguish candidates.
+The photographed finish (nonfoil, foil, etched, serialized, and similar) is a separate, often unknown
+property and must not be inferred merely because Scryfall says a printing is available in that finish.
+
+Do not begin with an end-to-end neural classifier or another broad Tesseract fine-tune. The repository
+does not yet have a variant benchmark, the existing 22-line OCR training pilot introduced blocking
+regressions, and deterministic geometry plus candidate-specific evidence is cheaper to test, easier to
+explain, and better aligned with the local-first architecture.
+
+## Questions this spike answers
+
+- How can the scanner distinguish printings and treatments of the same named card?
+- How can it detect a set when a conventional expansion symbol is present?
+- What evidence remains useful for early cards without modern collector information?
+- How can it handle showcase, borderless, extended-art, textless, Secret Lair, and Universes Beyond
+  cards whose title and frame geometry vary?
+- What should be benchmarked before production matching behavior changes?
+
+This spike does not attempt counterfeit detection, card grading, language expansion, or reliable foil
+finish classification from a single uncontrolled photograph.
+
+## Baseline findings
+
+These findings describe the pre-spike production pipeline and are retained as the rationale for the
+implemented contract slice above. Items called out as implemented in the status section are no longer
+open gaps on this branch.
+
+### What is already strong
+
+- Title recognition is bounded and progressively tries hard, soft, inverted, rotated, and rules-text
+  fallbacks.
+- Face-name aliases can resolve to canonical compound names for split, flip, and similar layouts.
+- Input decoding, remote image loading, temporary files, OCR workers, and caches have explicit limits
+  and cleanup.
+- The offline regression harness runs the production OCR and fuzzy-name path against reviewed fixtures.
+- The current enabled corpus has 158 cases: 151 blocking and 7 non-blocking. When enabled cases are
+  joined to their catalog entries, it includes 98 normal, 2 borderless, 7 extended-art, 9 full-art,
+  5 showcase, and 1 textless card, plus 36 entries without an explicit style label.
+
+### Gaps that block exact variant detection
+
+1. **The runtime identity is only a set name.** `src/matcher/matching-processor.mjs` reduces hash
+   results to `set_name` strings, deduplicates those strings, and returns `sets`. Multiple collector
+   numbers, arts, promo variants, or treatments in the same set therefore become one result.
+
+2. **The hash cache is not print-addressed.** `src/db-local/card-hash-cache.mjs` keys records with card
+   name, set name, foil/promo booleans, and hash. Current writers do not carry Scryfall ID, set code,
+   collector number, illustration ID, treatment, or actual finish; foil and promo default to false.
+
+3. **A single search result is accepted without visual verification.** The one-card path returns its
+   set name immediately. Candidate count is not evidence that the photographed printing matches.
+
+4. **The fixed expansion-symbol crop assumes one portrait geometry.** The crop at approximately
+   78% from the left and 53.5% from the top works for conventional frames, but showcase, full-art,
+   planar, split, retro, and historical frames can move, restyle, or omit that signal.
+
+5. **The fallback hash is global and low-detail.** A whole-card perceptual hash mixes artwork, frame,
+   text, camera perspective, glare, crop, and background. It can be useful for clean renders but is
+   not an exact-print identity by itself.
+
+6. **Production and regression print matching diverge.** Production prefers a fixed set-symbol crop
+   and falls back to a whole-card hash. `src/regression/regression-runner.mjs` ranks whole-card hashes
+   directly. The regression gate therefore does not exercise production's preferred print-selection
+   path.
+
+7. **The regression corpus does not test the requested ambiguity.** Its 220 catalog entries represent
+   218 distinct names. Only `Unsummon` and `Island` have two print candidates, and neither pair is in
+   the same set. There are no same-name/same-set treatment or collector-number pairs.
+
+8. **Candidate metadata is discarded early.** Scryfall exposes print-level fields useful to this
+   problem, including ID, set code, collector number, illustration ID, layout, card faces, frame,
+   frame effects, border color, full-art/textless flags, promo types, finishes, and image status. The
+   current matcher keeps mainly image URL and set name.
+
+9. **The live search boundary is incomplete for an offline-first exact-print index.** The search path
+   uses the first `data` page and does not follow `has_more`/`next_page`. It also downloads candidate
+   images during ordinary matching. A reviewed local print index would make tests deterministic,
+   eliminate per-scan catalog searches, and let remote images remain an explicit cache miss.
+
+## Why one signal is not enough
+
+| Signal                     | Good at                                                                  | Fails or becomes ambiguous when                                                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Title OCR                  | Finding an Oracle card or printed-title alias                            | Textless cards, decorative display fonts, renamed/reskinned cards, unusual orientation                                                                           |
+| Set-symbol template        | Identifying many expansion sets                                          | Pre-Sixth core cards have no symbol; old symbols do not encode rarity; special frames can move or restyle it                                                     |
+| Bottom-line OCR            | Exact modern set code and collector number                               | Collector numbers did not appear until Exodus in 1998; the machine-readable set/language block arrived with the M15 frame; tiny, foiled, or cropped text is hard |
+| Artwork match              | Alternate art, showcase, full-art, Secret Lair, and pop-culture variants | The same illustration can be reused across printings; glare and perspective hurt global hashes                                                                   |
+| Whole-card hash            | Near-identical clean scans or renders                                    | Background, crop, skew, foil reflection, border changes, and small treatment differences dominate or disappear                                                   |
+| Frame/treatment classifier | Routing to the right crop family                                         | Retro treatment is not necessarily vintage, and a treatment family is not an exact printing                                                                      |
+| Finish classifier          | Visually distinctive treatments in controlled capture                    | Ordinary foil/nonfoil and etched appearances vary heavily with lighting; metadata lists availability, not the photographed finish                                |
+
+The implication is a confidence model with independent evidence and an explicit abstain state, not a
+sequence that treats the first plausible signal as truth.
+
+## Historical and modern card evidence
+
+The card face has changed in ways that require era-aware extraction:
+
+- Wizards documents that core sets before Sixth Edition generally had no expansion symbol.
+- Rarity-colored expansion symbols and collector numbers first appeared in Exodus in June 1998.
+- The Eighth Edition frame changed title typography, text contrast, and region proportions in 2003.
+- The M15 frame moved collector information into a lower-left block containing collector number,
+  rarity, set code, and language; Wizards explicitly described it as machine-readable.
+- Since Throne of Eldraine, “showcase” is intentionally a catch-all for set-specific frames, while
+  borderless and extended-art treatments alter artwork geometry in different ways.
+- Universes Beyond can use distinct branding, holofoil stamps, standalone names, or reskinned versions
+  of existing cards. Ikoria's Godzilla treatment is an earlier example of a printed identity differing
+  from its underlying Magic identity.
+
+This rules out a single universal crop. It also means “vintage-looking” is not the same as “old”: modern
+sets deliberately print retro-frame treatments. Release date and catalog metadata must constrain any
+visual era guess.
+
+## Proposed identity contract
+
+Separate four concepts that are currently blended together:
+
+```text
+Oracle identity     The game object, including canonical and face names
+Printed title       What this card face actually says, including flavor/reskin names
+Printing identity   One Scryfall card object / print ID, set code, collector number, language
+Physical finish     The photographed copy's nonfoil/foil/etched/serialized treatment, possibly unknown
+```
+
+A candidate crossing the Scryfall boundary should retain at least:
+
+```js
+{
+    (printId,
+        oracleId,
+        name,
+        printedName,
+        flavorName,
+        aliases,
+        setCode,
+        setName,
+        collectorNumber,
+        language,
+        layout,
+        cardFaces,
+        illustrationId,
+        frame,
+        frameEffects,
+        borderColor,
+        fullArt,
+        textless,
+        promoTypes,
+        availableFinishes,
+        imageStatus,
+        imageUris);
+}
+```
+
+`printId` is the cache and result identity. `illustrationId` is useful artwork evidence but cannot be
+the primary key because art can recur. Finish detection should return `unknown` unless the pixels show
+a distinctive, benchmarked marker.
+
+The result contract should expose why a card was or was not confirmed:
+
+```js
+{
+    status: "confirmed" | "ambiguous" | "no-match",
+    oracleName,
+    printId,
+    setCode,
+    collectorNumber,
+    treatment,
+    observedFinish: "unknown",
+    confidence,
+    runnerUpDelta,
+    evidence: {
+        title: { score, text, region },
+        collector: { score, setCode, collectorNumber, region },
+        setSymbol: { score, templateId, region },
+        artwork: { score, method, inliers },
+        frame: { score, profile }
+    },
+    alternatives
+}
+```
+
+## Proposed pipeline
+
+```mermaid
+flowchart LR
+    A["Validated input image"] --> B["Card boundary, orientation, and perspective normalization"]
+    B --> C["Layout and frame-profile hypotheses"]
+    C --> D["Parallel bounded region extraction"]
+    D --> E["Title and printed-title aliases"]
+    D --> F["Bottom set code and collector number"]
+    D --> G["Expansion-symbol evidence"]
+    D --> H["Artwork and whole-card descriptors"]
+    E --> I["Local print-candidate index"]
+    I --> J["Pure evidence fusion and ranking"]
+    F --> J
+    G --> J
+    H --> J
+    C --> J
+    J --> K["Confirm only above threshold and margin"]
+    J --> L["Otherwise return alternatives / needs attention"]
+```
+
+### 1. Normalize the photographed card before fixed crops
+
+Detect the card quadrilateral, rotate it to portrait or the catalogued layout, and warp it to a
+canonical aspect ratio. Feature matching plus a RANSAC homography is a standard approach for locating
+and rectifying planar objects. It should be evaluated behind the existing image-processing boundary,
+with caps on decoded pixels, keypoints, candidates, and runtime.
+
+Start with contour/edge-based card-boundary detection and a confidence threshold. Preserve the current
+percentage crop path when rectification confidence is low so the experiment cannot make every clean
+scan dependent on a new native computer-vision package.
+
+### 2. Generate profile hypotheses; do not hard-route too early
+
+Use a small set of catalog-informed profiles rather than one classifier per named treatment:
+
+- pre-2003 / classic portrait;
+- 2003–2014 modern portrait;
+- M15+ machine-readable bottom line;
+- borderless, showcase, extended-art, full-art, or textless;
+- split, aftermath, flip, double-faced, saga, planar, and other explicit layouts.
+
+Run the two most plausible profiles when confidence is close. Modern retro treatments are constrained
+by candidate metadata and must not be routed as genuinely vintage merely because the frame looks old.
+
+### 3. Expand the alias index
+
+Seed canonical names, individual face names, localized `printed_name` values in supported languages,
+and `flavor_name`/reskin titles. Each alias maps to one or more Oracle identities and print IDs. This
+lets a pop-culture title produce the correct candidates without weakening fuzzy matching for ordinary
+Magic titles.
+
+For a textless card, skip the requirement that title OCR be nonempty and allow artwork retrieval to
+produce a bounded top-k candidate list. Do not apply this expensive global fallback to ordinary scans.
+
+### 4. Read modern collector information as structured text
+
+Add two or three bounded bottom-left/bottom-band OCR variants with code-specific whitelists and
+patterns. Parse a hypothesis such as:
+
+```text
+123/281 R FIN · EN
+```
+
+into collector number, rarity, set code, and language. The parser must support alphanumeric collector
+numbers and suffixes rather than assuming integers. Match partial fields independently; glare may leave
+the set code readable while losing the collector number.
+
+An exact title/alias plus exact set code and collector number can identify a modern print without
+downloading every candidate image. Artwork remains useful validation and protects against OCR
+hallucination.
+
+### 5. Treat the expansion symbol as candidate evidence
+
+Once title matching has reduced the search space, compare the normalized symbol region only against
+the candidate sets' symbol templates. This is a much smaller and safer problem than classifying every
+Magic symbol globally.
+
+Search a bounded region around the expected type-line area, not one exact crop. Use edge/shape or local
+feature matching so rarity color and illumination are not the primary signal. A symbol can identify a
+set family but not necessarily a same-set collector variant, so it should prune or score candidates,
+not finish the decision alone.
+
+### 6. Match art regionally and geometrically
+
+Compare like regions after rectification:
+
+- conventional artwork box for normal and retro frames;
+- catalog/profile-specific art masks for borderless, showcase, extended-art, and full-art cards;
+- whole-card descriptors as an additional signal, not the sole signal.
+
+First benchmark several cheap descriptors using the existing JS image stack: perceptual/difference
+hashes at more than one scale, luminance-normalized hashes, and coarse color histograms. Then run a
+small feasibility bakeoff of ORB or AKAZE keypoints plus RANSAC homography. Local features are likely to
+be more robust to phone-camera perspective and partial frame changes, but a native or WASM OpenCV
+dependency must earn its packaging and startup cost in the regression data before adoption.
+
+Use the candidate's `illustration_id` to group identical art and avoid doing redundant comparisons.
+If several printings share that artwork, artwork evidence raises all of them and leaves collector,
+symbol, border, and frame evidence to separate the print.
+
+### 7. Fuse evidence with confirmation guardrails
+
+Keep scoring pure and make thresholds visible. Initial policy should favor false-abstention over a
+false collection write:
+
+- Never confirm only because Scryfall returned one candidate.
+- Never confirm a same-set variant from expansion-symbol evidence alone.
+- Treat exact modern set-code plus collector-number OCR as the strongest structured signal.
+- Treat registered artwork as strong but non-unique when illustration IDs are shared.
+- Treat frame, border, and treatment as compatibility/tie-break evidence.
+- Require a minimum top score and a minimum delta over the runner-up.
+- Require two independent supporting signals unless an exact title plus exact structured collector
+  block uniquely identifies the print.
+- Preserve all print IDs until the final decision; deduplicate only identical print identities.
+
+Confidence should eventually be calibrated from fixture outcomes rather than presented as a
+probability derived from hand-written weights.
+
+## Vintage strategy
+
+Vintage is a separate evidence profile, not just a different Tesseract model.
+
+1. Use wider classic-frame title crops with soft/adaptive preprocessing and serif-aware morphology.
+2. Do not require collector information before Exodus-era prints introduced it in 1998.
+3. For pre-Sixth core-set candidates, expect no expansion symbol and use negative evidence carefully;
+   a missing symbol is meaningful only when the crop is high quality.
+4. Compare art after perspective normalization, then use border color, frame generation, copyright
+   line, artist line, tap-symbol style, and other catalogued visible differences as bounded tie-breaks.
+5. Keep Alpha/Beta/Unlimited/Revised and other visually close groups in an explicit ambiguity policy.
+   If the available pixels cannot separate them, return the candidates rather than manufacture a set.
+6. A modern retro-frame printing remains a modern candidate because release date, collector block,
+   set code, and catalog metadata contradict the vintage hypothesis.
+
+The first custom-training pilot should remain rejected. Tesseract's own guidance recommends fixing
+scale, skew, binarization, borders, and page segmentation before retraining; the repository's pilot also
+showed that narrow fine-tuning can regress unrelated frames. Revisit training only after profile crops
+and the expanded vintage/full-art corpus expose consistent glyph errors on correctly normalized lines.
+
+## Showcase, full-art, and pop-culture strategy
+
+- Use title aliases (`flavor_name`, printed names, and face names) so reskinned cards do not depend on
+  recognizing the underlying Oracle name.
+- Let metadata choose several region masks; “showcase” is intentionally not one stable geometry.
+- Prefer artwork retrieval for textless and radically restyled cards, then validate against print
+  metadata.
+- Model bonus sheets, Special Guests, Commander subsets, and main sets by their actual set codes. A
+  product can contain several independently coded sets.
+- Use Scryfall `frame_effects`, `full_art`, `textless`, `promo_types`, border color, and layout as
+  candidate compatibility, not as complete treatment truth. New treatments will continue to appear.
+- Keep `availableFinishes` separate from `observedFinish`. Serialized numbering, a visible stamp, or a
+  strongly benchmarked foil pattern can add evidence, but ordinary glare must not create a foil claim.
+
+## Data and storage direction
+
+Add a local, versioned print catalog seeded from Scryfall bulk data. Scryfall explicitly recommends
+bulk downloads for large local lookup workloads. The sync path should:
+
+- stream the format advertised by the bulk metadata endpoint rather than loading the entire file;
+- retain English paper cards initially, while keeping language in the schema;
+- normalize aliases and face data without losing the original values;
+- store Scryfall ID as the stable print key and set code plus collector number as a lookup index;
+- store image provenance, image status, and source revision/update time;
+- download reference images lazily with the existing origin, size, redirect, timeout, and cleanup
+  controls;
+- keep catalog records and derived image descriptors separate so metadata can refresh without
+  recomputing every descriptor;
+- migrate legacy hash rows as unverified cache hints or allow them to expire; do not relabel them as
+  exact print identities.
+
+The current per-name Scryfall query can remain a bounded fallback during migration, but it must follow
+list pagination and preserve complete card objects.
+
+## Experiment plan
+
+### Experiment 0: build the benchmark before changing ranking
+
+Create an exact-print cohort with at least:
+
+- 12 same-name/same-set pairs spanning normal versus showcase, borderless, extended-art, full-art,
+  retro, promo, and alternate art;
+- 12 cross-set same-art or same-illustration pairs;
+- 12 pre-Exodus vintage prints, including core cards without expansion symbols and expansions whose
+  symbols do not encode rarity;
+- 12 M15+ cards with readable set-code/collector blocks;
+- 12 Universes Beyond, Secret Lair, bonus-sheet, Special Guest, textless, or reskinned cards;
+- clean reference images plus reviewed photo transformations for perspective, rotation, crop, low
+  light, blur, and glare.
+
+Each fixture should identify `printId`, set code, collector number, style/treatment, layout, frame,
+illustration ID when present, and whether finish is knowable. Keep all new cases disabled until labels
+and image rights/provenance are reviewed, following the existing regression policy.
+
+Report metrics by cohort:
+
+- Oracle-name top-1 accuracy;
+- exact-print top-1 accuracy and top-3 recall;
+- set-code and collector-number accuracy;
+- false-confirm rate, ambiguity/abstention rate, and runner-up margin;
+- region/evidence availability and per-signal ablations;
+- warm/cold latency, peak memory, reference downloads, and cache hits.
+
+Do not use aggregate pass rate alone. A matcher that improves modern cards while confidently
+mislabeling Alpha/Beta is not an improvement.
+
+### Experiment 1: establish the current matcher baseline
+
+Run the new cohort through both production matching and the offline runner. Record where production's
+set-symbol path and regression's whole-card path disagree. This quantifies the real gap before changing
+algorithms.
+
+### Experiment 2: rectification and modern bottom-line OCR
+
+Add perspective normalization behind a confidence-gated adapter, then OCR set code and collector number
+with bounded variants. Measure candidate reduction and exact-print accuracy without changing artwork
+matching. This is the highest-value first implementation because the M15 collector block was designed
+for machine recognition and can avoid many remote image comparisons.
+
+### Experiment 3: regional visual descriptor bakeoff
+
+Using the same fixture cohort, compare:
+
+1. current whole-card hash;
+2. rectified whole-card hash;
+3. profile-specific artwork hashes at multiple scales;
+4. artwork hashes plus coarse color histogram;
+5. ORB/AKAZE plus RANSAC inlier score.
+
+Select the smallest implementation that materially improves photo and treatment cohorts without
+regressing clean scans or package portability.
+
+### Experiment 4: candidate-specific expansion-symbol search
+
+Benchmark a bounded symbol search against only candidate-set templates. Measure set accuracy,
+availability by profile, and false positives. Keep it as one ranker feature even if it performs well.
+
+### Experiment 5: vintage and textless fallbacks
+
+Add the classic-frame title profile and bounded artwork-first retrieval for textless or unresolved
+titles. Because global artwork search is more expensive, require a local descriptor index and strict
+top-k/runtime limits.
+
+### Experiment 6: calibrate and promote
+
+Tune confirmation threshold and runner-up delta on a development split, then evaluate once on a held-out
+split. Promotion gates should include:
+
+- all existing 151 blocking fixtures still pass;
+- no exact-print false confirmations in the reviewed held-out cohort;
+- at least 95% exact-print top-1 on clean same-set variant fixtures;
+- at least 90% top-3 recall on reviewed photo fixtures, with abstention allowed;
+- bounded p95 runtime, memory, downloads, and temporary artifacts;
+- production and regression use the same region/evidence ranker.
+
+The sample sizes above are a minimum feasibility cohort, not a claim of statistical completeness. Grow
+the corpus before treating confidence as calibrated for collection writes.
+
+## Recommended implementation order
+
+1. Define `PrintCandidate`, `PrintEvidence`, and exact-print result contracts.
+2. Extend the offline manifest and report before changing production decisions.
+3. Preserve Scryfall IDs and metadata through the API boundary; stop collapsing to set name.
+4. Add the local print catalog and exact-print cache key.
+5. Add confidence-gated rectification and bottom-line OCR.
+6. Add regional artwork descriptors and candidate-specific symbol matching.
+7. Add pure evidence fusion, margin, and abstention policy.
+8. Add vintage and textless fallback profiles.
+9. Consider a narrowly trained model only if the expanded corpus proves deterministic extraction and
+   non-ML visual matching are insufficient.
+
+This order keeps contract and benchmark changes ahead of behavior changes, preserves offline tests,
+and lets each expensive technique prove its value independently.
+
+## Risks and mitigations
+
+| Risk                                                     | Mitigation                                                                                                          |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| New native CV dependency complicates global installation | Bake off pure JS, WASM, and native options; keep rectification behind an adapter and require package-smoke evidence |
+| Bulk catalog and images increase disk use                | Stream metadata, index only supported paper cards, fetch images lazily, cap and report cache size                   |
+| More OCR regions increase latency                        | Gate collector/symbol/textless work by profile and candidate ambiguity; retain the current fast title path          |
+| Hand-written weights look precise but are not calibrated | Report raw evidence and margins; tune on development fixtures and validate on held-out fixtures                     |
+| Foil glare damages OCR and hashes                        | Use luminance-normalized regional evidence, allow abstention, and keep finish unknown by default                    |
+| New treatments appear faster than explicit classifiers   | Model a few geometry profiles and retain metadata as open-ended arrays/strings rather than exhaustive enums         |
+| Vintage groups remain visually indistinguishable         | Return an ambiguity set and never turn candidate count into confirmation                                            |
+| Regression images overrepresent clean Scryfall renders   | Add real reviewed photos and deterministic derived transformations; report cohorts separately                       |
+
+## Source notes
+
+Primary sources consulted:
+
+- [Scryfall API documentation](https://scryfall.com/docs/api) and [Cards API](https://scryfall.com/docs/api/cards) for print objects, list pagination, and card fields.
+- [Scryfall bulk-data documentation](https://scryfall.com/docs/api/bulk-data) and [API access guidance](https://scryfall.com/docs/faqs/i-m-having-trouble-accessing-the-scryfall-api-or-i-m-blocked-17) for local synchronization and request behavior.
+- Wizards, [Anatomy of a Magic Card](https://magic.wizards.com/en/news/feature/anatomy-magic-card-2006-10-21), for expansion symbol and collector-number locations and historical core-set symbol behavior.
+- Wizards, [In My Day…](https://magic.wizards.com/en/news/making-magic/my-day-2014-05-12-0), for the June 1998 introduction of rarity-colored symbols and collector numbers in Exodus.
+- Wizards, [Frames of Reference](https://magic.wizards.com/en/news/making-magic/frames-reference-2003-01-27), for the Eighth Edition frame and title/readability changes.
+- Wizards, [From the Director's Chair: 2013](https://magic.wizards.com/en/news/making-magic/directors-chair-2013-2014-01-06), for the M15 collector block and its machine-readable intent.
+- Wizards, [Project Booster Fun](https://magic.wizards.com/en/news/making-magic/project-booster-fun-2019-07-20), for the distinctions among borderless, extended-art, and set-specific showcase treatments.
+- Wizards, [Magic's Voyages to Universes Beyond](https://magic.wizards.com/en/news/announcements/magics-voyages-universes-beyond-2021-02-25) and [Collecting Ikoria](https://magic.wizards.com/en/news/card-preview/collecting-ikoria-2020-04-02), for standalone and reskinned pop-culture identities.
+- [OpenCV feature matching and homography](https://docs.opencv.org/4.x/d1/de0/tutorial_py_feature_homography.html) for registered planar-object matching.
+- [Tesseract input-quality guidance](https://tesseract-ocr.github.io/tessdoc/ImproveQuality.html) for scaling, skew, binarization, borders, segmentation modes, whitelists, and the recommendation to improve extraction before retraining.
+
+Repository evidence consulted:
+
+- `src/processor/processor.mjs`
+- `src/processor/name-resolver.mjs`
+- `src/matcher/matching-processor.mjs`
+- `src/export-processor/process-hashes.mjs`
+- `src/image-processing/smart-crop.mjs`
+- `src/image-processing/ocr-preprocessing.mjs`
+- `src/image-hashing/hash-image.mjs`
+- `src/scryfall-api/search-name.mjs`
+- `src/db-local/card-hash-cache.mjs`
+- `src/regression/regression-runner.mjs`
+- `test/regression/fixtures/manifest.json`
+- `docs/regression-testing.md`
+- `docs/regression-fixture-expansion-2026-08.md`
+- `docs/regression-fixture-era-expansion-2026-08.md`
+- `docs/ocr-training-pilot-2026-08.md`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -65,14 +65,16 @@ the check.
 needs-attention records only when both resolve to `true`. Without both, the full identification
 pipeline still runs and prints its results.
 
-Confirmed collection data requires exactly one matched card name and one matched printing set. If
-the name is clear but multiple sets remain possible, the scan writes one needs-attention record
-containing all candidate sets (when both persistence opt-ins are enabled). Dry runs and scans with
+Confirmed collection data requires exactly one matched card name and one image-verified exact
+printing. A lone Scryfall search result is only an unverified candidate. If multiple variants share a
+set, the match only verifies a set symbol, or any candidate otherwise remains unverified, the scan
+writes a needs-attention record containing set-code and collector-number labels (when both persistence
+opt-ins are enabled). Dry runs and scans with
 collection tracking disabled continue to print the candidates without persistence writes.
 
 Pretty logging is enabled by default. It keeps pipeline detail visible with compact, aligned level
-labels, emits one OCR progress heartbeat per crop, and prints final card/set candidates without
-internal verification objects:
+labels, emits one OCR progress heartbeat per crop, and prints final card, set, and exact-print
+candidate summaries without internal URLs or comparison objects:
 
 ```text
 INFO  Reading card name
@@ -84,12 +86,13 @@ Scan results
 
 1. Pacifism
    Sets: Core Set 2020
+   Printings: M20 #32 (verified)
 ```
 
 Interactive terminals receive colored level labels; redirected output remains color-free. Use
-`--no-pretty` when another tool needs unadorned log messages. Full match verification details stay
-available through the local operations log and `--debug` instead of being dumped into routine scan
-output.
+`--no-pretty` when another tool needs unadorned log messages. Full comparison metrics and Scryfall
+links stay available through the local operations log and `--debug` instead of being dumped into
+routine scan output.
 
 ## Inspect scan activity
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -201,7 +201,8 @@ Edit `test/regression/fixtures/manifest.json`. Paths are relative to the manifes
 manifest has two lists:
 
 - `catalog` is the fixed offline print catalog. Each print needs `name`, `set`,
-  `collectorNumber`, and `referenceImage`. Any extra card fields may be asserted through
+  `collectorNumber`, and `referenceImage`. Add `scryfallId` for exact-print fixtures; same-name,
+  same-set variants remain separate catalog entries. Any extra card fields may be asserted through
   `expected.metadata`.
 - `cases` labels an input image and its expected result. Case IDs must be unique.
 
@@ -228,6 +229,7 @@ Minimal example:
             "name": "Pacifism",
             "set": "BBD",
             "collectorNumber": "101",
+            "scryfallId": "reviewed-scryfall-print-id",
             "typeLine": "Enchantment — Aura",
             "referenceImage": "../../../test-images/Pacifism.jpg"
         }
@@ -241,6 +243,7 @@ Minimal example:
                 "name": "Pacifism",
                 "set": "BBD",
                 "collectorNumber": "101",
+                "scryfallId": "reviewed-scryfall-print-id",
                 "minNameScore": 0.7,
                 "maxNameCandidates": 5,
                 "maxPrintCandidates": 1,
@@ -256,10 +259,11 @@ Minimal example:
 }
 ```
 
-Only `name`, `set`, and `collectorNumber` are required inside `expected`. Optional thresholds
-let the suite catch candidate explosions, confidence changes, metadata regressions, and large
-runtime regressions without requiring an exact OCR string. Print selection uses normalized PDQ
-Hamming similarity and defaults to a minimum score of 0.75.
+Only `name`, `set`, and `collectorNumber` are required inside `expected`; together they define the
+reviewed printing for the exact-print metric. When `scryfallId` is present, the selected catalog entry
+must match it as well. Optional thresholds let the suite catch candidate explosions, confidence
+changes, metadata regressions, and large runtime regressions without requiring an exact OCR string.
+Print selection uses normalized PDQ Hamming similarity and defaults to a minimum score of 0.75.
 
 ## Quality labels and transformations
 

--- a/src/console/format-scan-results.mjs
+++ b/src/console/format-scan-results.mjs
@@ -1,3 +1,5 @@
+import { formatPrintLabel } from "../matcher/print-candidate.mjs";
+
 function formatScanResults(results = []) {
     if (!results.length) {
         return "No scan results.";
@@ -9,7 +11,16 @@ function formatScanResults(results = []) {
             Array.isArray(result?.sets) && result.sets.length
                 ? result.sets.join(", ")
                 : "No set match";
-        return `${index + 1}. ${name}\n   Sets: ${sets}`;
+        const printings = Array.isArray(result?.printings) ? result.printings : [];
+        const printingLine = printings.length
+            ? `\n   Printings: ${printings
+                  .map(
+                      (printing) =>
+                          `${formatPrintLabel(printing)}${printing.verified ? " (verified)" : " (unverified)"}`
+                  )
+                  .join(", ")}`
+            : "";
+        return `${index + 1}. ${name}\n   Sets: ${sets}${printingLine}`;
     });
 
     return `Scan results\n\n${rows.join("\n\n")}`;

--- a/src/db-local/card-hash-cache.mjs
+++ b/src/db-local/card-hash-cache.mjs
@@ -21,7 +21,13 @@ function toLookupKey(record) {
     const cardHash = String(record.cardHash || "").trim();
     const isFoil = Boolean(record.isFoil);
     const isPromo = Boolean(record.isPromo);
-    return `${cardName}::${setName}::${isFoil ? 1 : 0}::${isPromo ? 1 : 0}::${cardHash}`;
+    const printId = String(record.printId || "").trim();
+    const setCode = String(record.setCode || "").trim();
+    const collectorNumber = String(record.collectorNumber || "").trim();
+    const language = String(record.language || "en").trim();
+    const hashMode = String(record.hashMode || "full-card").trim();
+    const printIdentity = printId || `${setCode}:${collectorNumber}:${language}`;
+    return `${cardName}::${setName}::${printIdentity}::${isFoil ? 1 : 0}::${isPromo ? 1 : 0}::${hashMode}::${cardHash}`;
 }
 
 // Every current writer (back-filler.mjs, process-hashes.mjs) sends fully camelCase fields, but
@@ -33,11 +39,18 @@ function normalizeRecord(record = {}) {
     const cardHash = record.cardHash || record.CardHash || "";
     const isFoil = Boolean(record.isFoil || record.IsFoil);
     const isPromo = Boolean(record.isPromo || record.IsPromo);
-    const cardUrl = record.cardUrl || record.CardUrl || "";
+    const cardUrl = record.cardUrl || record.CardUrl || record.imageUrl || "";
     // Defaults to "full-card" for writers/legacy rows that predate this field -- matches
     // back-filler.mjs's real behavior (always full-card, never cropped) and process-hashes.mjs's
     // own joi default, so an untagged on-disk row is classified correctly with no migration.
     const hashMode = record.hashMode || record.HashMode || "full-card";
+    const printId = record.printId || record.PrintId || "";
+    const oracleId = record.oracleId || record.OracleId || "";
+    const setCode = record.setCode || record.SetCode || "";
+    const collectorNumber = record.collectorNumber || record.CollectorNumber || "";
+    const language = record.language || record.Language || "en";
+    const illustrationId = record.illustrationId || record.IllustrationId || "";
+    const scryfallUri = record.scryfallUri || record.ScryfallUri || "";
     const normalized = {
         cardName: String(cardName).trim(),
         setName: String(setName).trim(),
@@ -46,6 +59,13 @@ function normalizeRecord(record = {}) {
         isPromo,
         cardUrl: String(cardUrl).trim(),
         hashMode: String(hashMode).trim(),
+        printId: String(printId).trim(),
+        oracleId: String(oracleId).trim(),
+        setCode: String(setCode).trim().toUpperCase(),
+        collectorNumber: String(collectorNumber).trim(),
+        language: String(language).trim().toLowerCase(),
+        illustrationId: String(illustrationId).trim(),
+        scryfallUri: String(scryfallUri).trim(),
         updatedAt: new Date()
     };
     normalized.lookupKey = toLookupKey(normalized);

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -7,6 +7,7 @@ import imageHashing from "../image-hashing/index.mjs";
 import imageProcessing from "../image-processing/index.mjs";
 import FileIO from "../file-io.mjs";
 import { round, orderBy, omit } from "../util.mjs";
+import { normalizePrintCandidate } from "../matcher/print-candidate.mjs";
 
 const config = {
     remoteBestGuess: {
@@ -74,7 +75,16 @@ class ProcessHashes {
             if (compareResults.matches) {
                 matches.push(
                     Object.assign(compareResults, {
-                        setName: dbHash.setName
+                        ...normalizePrintCandidate(dbHash),
+                        setName: dbHash.setName,
+                        hashMode,
+                        matchKind:
+                            hashMode === "full-card"
+                                ? "cache-full-card-hash"
+                                : "cache-set-symbol-hash",
+                        // Legacy cache rows identify only a set name. They remain useful hints,
+                        // but cannot prove an exact printing until refreshed with a print ID.
+                        verified: Boolean(dbHash.printId) && hashMode === "full-card"
                     })
                 );
             }
@@ -95,10 +105,10 @@ class ProcessHashes {
             `Comparing ${this.cards.length} Scryfall ${imageLabel} for "${this.name}" (${this.hashMode})`
         );
         const cards = this.cards.map((card) => {
-            const images = card.image_uris || {};
+            const printing = normalizePrintCandidate(card);
             return {
-                imgUrl: images.normal || images.large,
-                setName: card.set_name
+                imgUrl: printing.imageUrl,
+                printing
             };
         });
         const comparisonResultsList = [];
@@ -111,20 +121,23 @@ class ProcessHashes {
                         tempDirectory
                     );
                     return {
-                        setName: card.setName,
+                        printing: card.printing,
                         remoteImageHash
                     };
                 })
             );
-            for (const { setName, remoteImageHash } of hashResults) {
+            for (const { printing, remoteImageHash } of hashResults) {
+                if (!remoteImageHash) {
+                    continue;
+                }
                 try {
-                    await this._insertCardHash(setName, remoteImageHash);
+                    await this._insertCardHash(printing, remoteImageHash);
                 } catch (err) {
                     // Hashes are a reusable cache, not collection truth. Wait for the
                     // attempted write so process exit cannot drop it, but keep a cache
                     // failure from failing an otherwise valid scan.
                     this.logger.error(
-                        `Card-hash cache write failed for "${this.name}" (${setName}): ${
+                        `Card-hash cache write failed for "${this.name}" (${printing.setName}): ${
                             err?.message || String(err)
                         }`
                     );
@@ -136,7 +149,14 @@ class ProcessHashes {
                 if (comparisonResults.comparable) {
                     comparisonResultsList.push(
                         Object.assign(comparisonResults, {
-                            setName
+                            ...printing,
+                            hashMode: this.hashMode,
+                            matchKind:
+                                this.hashMode === "full-card"
+                                    ? "remote-full-card-hash"
+                                    : "remote-set-symbol-hash",
+                            // A set symbol can verify a set, not a collector-number variant.
+                            verified: this.hashMode === "full-card"
                         })
                     );
                 }
@@ -173,7 +193,11 @@ class ProcessHashes {
                             config.remoteBestGuess.maxSimilarityDeltaFromTop
                     )
                     .slice(0, config.remoteBestGuess.maxCandidates)
-                    .map((match) => omit(match, ["confidenceScore"]));
+                    .map((match) => ({
+                        ...omit(match, ["confidenceScore"]),
+                        matchKind: "remote-image-best-guess",
+                        verified: false
+                    }));
                 this.logger.info(
                     `Using closest image matches for "${this.name}": ${bestMatches
                         .map((match) => match.setName)
@@ -257,13 +281,19 @@ class ProcessHashes {
         });
     }
 
-    async _insertCardHash(setName, hash) {
-        // isFoil/isPromo/cardUrl aren't tracked through the matcher pipeline yet, so they're
-        // left for the store's own defaults (false/"") -- same as before this was fixed to use
-        // the store's real field names instead of a PascalCase fallback chain.
+    async _insertCardHash(printing, hash) {
+        const candidate = normalizePrintCandidate(printing);
         return this.dependencies.CardHashes.upsert({
             cardName: this.name,
-            setName,
+            printId: candidate.printId,
+            oracleId: candidate.oracleId,
+            setCode: candidate.setCode,
+            setName: candidate.setName,
+            collectorNumber: candidate.collectorNumber,
+            language: candidate.language,
+            illustrationId: candidate.illustrationId,
+            cardUrl: candidate.imageUrl,
+            scryfallUri: candidate.scryfallUri,
             cardHash: hash,
             hashMode: this.hashMode
         });

--- a/src/matcher/index.mjs
+++ b/src/matcher/index.mjs
@@ -1,7 +1,9 @@
 import MatchingProcessor from "./matching-processor.mjs";
+import printCandidate from "./print-candidate.mjs";
 
-export { MatchingProcessor };
+export { MatchingProcessor, printCandidate };
 
 export default {
-    MatchingProcessor
+    MatchingProcessor,
+    printCandidate
 };

--- a/src/matcher/matching-processor.mjs
+++ b/src/matcher/matching-processor.mjs
@@ -6,6 +6,7 @@ import exportProcessor from "../export-processor/index.mjs";
 import imageHashing from "../image-hashing/index.mjs";
 import imageProcessing from "../image-processing/index.mjs";
 import FileIO from "../file-io.mjs";
+import { normalizePrintCandidate, printIdentityKey } from "./print-candidate.mjs";
 
 const defaultDependencies = Object.freeze({
     searchPrintings: scryfallApi.Search.searchList,
@@ -69,14 +70,15 @@ class MatcherProcessor {
 
         if (totalCards === 1) {
             const single = this.cards[0] || {};
-            const setName = single.set_name ?? "";
+            const printing = normalizePrintCandidate(single);
             this.matchResultDetails = [
                 {
-                    setName,
-                    scryfallUri: single.scryfall_uri || single.uri || ""
+                    ...printing,
+                    matchKind: "catalog-candidate-only",
+                    verified: false
                 }
             ];
-            return setName ? [setName] : [];
+            return printing.setName ? [printing.setName] : [];
         }
 
         await this._hashLocalCardAsync();
@@ -188,47 +190,60 @@ class MatcherProcessor {
             .compareRemoteImages()
             .then((results) => this._processHashResults(results));
         const [db, remote] = await Promise.all([dbPromise, remotePromise]);
-        const mergedResults = [...new Set((db || []).concat(remote || []))];
-        this.matchResults = mergedResults;
-        this.matchResultDetails = this._buildMatchDetails(mergedResults);
-        this.logger.info(`Print matches for "${this.name}": ${mergedResults.join(", ") || "none"}`);
-        return mergedResults;
+        const mergedDetails = this._mergeMatchDetails((db || []).concat(remote || []));
+        const setNames = [
+            ...new Set(mergedDetails.map((detail) => detail.setName).filter(Boolean))
+        ];
+        this.matchResults = mergedDetails;
+        this.matchResultDetails = mergedDetails;
+        this.logger.info(`Print matches for "${this.name}": ${setNames.join(", ") || "none"}`);
+        return setNames;
     }
 
-    _buildMatchDetails(setNames = []) {
-        const cardBySet = new Map();
-        (this.cards || []).forEach((card) => {
-            const setName = card.set_name ?? "";
-            if (!setName || cardBySet.has(setName)) {
-                return;
+    _mergeMatchDetails(details = []) {
+        const byPrint = new Map();
+        details.forEach((detail) => {
+            const key = printIdentityKey(detail);
+            const existing = byPrint.get(key);
+            if (!existing || (!existing.verified && detail.verified)) {
+                byPrint.set(key, detail);
             }
-            cardBySet.set(setName, {
-                setName,
-                scryfallUri: card.scryfall_uri || card.uri || ""
-            });
         });
-
-        return setNames.map((setName) => {
-            const matchDetail = cardBySet.get(setName);
-            return (
-                matchDetail || {
-                    setName,
-                    scryfallUri: ""
-                }
-            );
-        });
+        return [...byPrint.values()];
     }
 
     _processHashResults(hashResults) {
         if (!hashResults || hashResults.length === 0) {
-            return []; // No set to return
+            return [];
         }
-
-        if (hashResults.length > 1) {
-            return hashResults.map((result) => result.setName);
-        }
-        const matchObject = hashResults[0] || {};
-        return [matchObject.setName ?? ""];
+        return hashResults.map((result) => {
+            const printing = normalizePrintCandidate(result);
+            return {
+                ...printing,
+                comparison: {
+                    comparable: Boolean(result.comparable),
+                    algorithm: String(result.algorithm || ""),
+                    similarity: Number(result.similarity) || 0,
+                    distance: Number.isFinite(result.distance) ? Number(result.distance) : null,
+                    bitLength: Number(result.bitLength) || 0,
+                    leftQuality: Number.isFinite(result.leftQuality)
+                        ? Number(result.leftQuality)
+                        : null,
+                    rightQuality: Number.isFinite(result.rightQuality)
+                        ? Number(result.rightQuality)
+                        : null,
+                    minQuality: Number.isFinite(result.minQuality)
+                        ? Number(result.minQuality)
+                        : null,
+                    eligible: result.eligible !== false,
+                    matches: Boolean(result.matches),
+                    reason: String(result.reason || "")
+                },
+                hashMode: result.hashMode || this.hashMode || "full-card",
+                matchKind: result.matchKind || "legacy-set-hash",
+                verified: Boolean(result.verified)
+            };
+        });
     }
 }
 

--- a/src/matcher/print-candidate.mjs
+++ b/src/matcher/print-candidate.mjs
@@ -1,0 +1,115 @@
+// @ts-check
+
+/**
+ * @typedef {object} PrintCandidate
+ * @property {string} printId
+ * @property {string} oracleId
+ * @property {string} name
+ * @property {string} printedName
+ * @property {string} flavorName
+ * @property {string} setCode
+ * @property {string} setName
+ * @property {string} collectorNumber
+ * @property {string} language
+ * @property {string} illustrationId
+ * @property {string} layout
+ * @property {string} frame
+ * @property {string[]} frameEffects
+ * @property {string} borderColor
+ * @property {boolean} fullArt
+ * @property {boolean} textless
+ * @property {string[]} promoTypes
+ * @property {string[]} availableFinishes
+ * @property {string} imageUrl
+ * @property {string} scryfallUri
+ * @property {number | null} tcgplayerId
+ * @property {string} typeLine
+ * @property {number} priceUsd
+ */
+
+/** @param {unknown} value */
+function stringValue(value) {
+    return typeof value === "string" ? value.trim() : "";
+}
+
+/** @param {unknown} value */
+function stringList(value) {
+    return Array.isArray(value) ? value.map(stringValue).filter(Boolean) : [];
+}
+
+/** @param {any} card */
+function firstFace(card = {}) {
+    return Array.isArray(card.card_faces) ? card.card_faces.find(Boolean) || {} : {};
+}
+
+/** @param {any} card */
+function imageUris(card = {}) {
+    return card.image_uris || firstFace(card).image_uris || {};
+}
+
+/**
+ * @param {any} card
+ * @returns {PrintCandidate}
+ */
+function normalizePrintCandidate(card = {}) {
+    const face = firstFace(card);
+    const images = imageUris(card);
+    return {
+        printId: stringValue(card.id || card.printId),
+        oracleId: stringValue(card.oracle_id || card.oracleId),
+        name: stringValue(card.name),
+        printedName: stringValue(card.printed_name || card.printedName || face.printed_name),
+        flavorName: stringValue(card.flavor_name || card.flavorName),
+        setCode: stringValue(card.set || card.setCode).toUpperCase(),
+        setName: stringValue(card.set_name || card.setName),
+        collectorNumber: stringValue(card.collector_number || card.collectorNumber),
+        language: stringValue(card.lang || card.language || "en").toLowerCase(),
+        illustrationId: stringValue(
+            card.illustration_id || card.illustrationId || face.illustration_id
+        ),
+        layout: stringValue(card.layout),
+        frame: stringValue(card.frame),
+        frameEffects: stringList(card.frame_effects || card.frameEffects),
+        borderColor: stringValue(card.border_color || card.borderColor),
+        fullArt: Boolean(card.full_art ?? card.fullArt),
+        textless: Boolean(card.textless),
+        promoTypes: stringList(card.promo_types || card.promoTypes),
+        availableFinishes: stringList(card.finishes || card.availableFinishes),
+        imageUrl: stringValue(card.imageUrl || card.cardUrl || images.normal || images.large),
+        scryfallUri: stringValue(card.scryfall_uri || card.scryfallUri || card.uri),
+        tcgplayerId: Number(card.tcgplayer_id || card.tcgplayerId) || null,
+        typeLine: stringValue(card.type_line || card.typeLine || face.type_line),
+        priceUsd: Number(card.prices?.usd ?? card.priceUsd) || 0
+    };
+}
+
+/** @param {any} printing */
+function printIdentityKey(printing = {}) {
+    const candidate = normalizePrintCandidate(printing);
+    if (candidate.printId) {
+        return `id:${candidate.printId}`;
+    }
+    if (candidate.setCode && candidate.collectorNumber) {
+        return `print:${candidate.setCode}:${candidate.collectorNumber}:${candidate.language}`;
+    }
+    if (candidate.setName) {
+        return `set:${candidate.setName}`;
+    }
+    return "unknown";
+}
+
+/** @param {any} printing */
+function formatPrintLabel(printing = {}) {
+    const candidate = normalizePrintCandidate(printing);
+    const set = candidate.setCode || candidate.setName || "Unknown set";
+    const number = candidate.collectorNumber ? ` #${candidate.collectorNumber}` : "";
+    return `${set}${number}`;
+}
+
+export { formatPrintLabel, normalizePrintCandidate, printIdentityKey };
+
+export default {
+    formatPrintLabel,
+    normalizePrintCandidate,
+    printIdentityKey
+};

--- a/src/processor/processor.mjs
+++ b/src/processor/processor.mjs
@@ -12,6 +12,7 @@ import storage from "../storage/index.mjs";
 import { resolveCardName } from "./name-resolver.mjs";
 import { formatScanResults } from "../console/format-scan-results.mjs";
 import { round } from "../util.mjs";
+import { formatPrintLabel } from "../matcher/print-candidate.mjs";
 
 // Native fs.readFile + Buffer in place of image-to-base64.
 async function base64EncodeImage(imagePath) {
@@ -112,6 +113,7 @@ class ProcessorClass {
                         ? {
                               name: result.name,
                               sets: result.sets,
+                              printings: result.printings,
                               setVerificationLinks: result.setVerificationLinks
                           }
                         : { name: result.name, sets: result.sets }
@@ -217,8 +219,11 @@ class ProcessorClass {
             this.printResults();
             return;
         }
+        const selectedResult = this.matcherResults[0];
         const hasConfirmedPrinting =
-            this.matcherResults.length === 1 && this.matcherResults[0].sets.length === 1;
+            this.matcherResults.length === 1 &&
+            selectedResult.printings.length === 1 &&
+            selectedResult.printings[0].verified === true;
         if (hasConfirmedPrinting) {
             this.decision = "collection";
             await this.CreateCollectionsRecordAsync(this.matcherResults[0]);
@@ -245,10 +250,14 @@ class ProcessorClass {
             logger: this.logger
         });
         const results = await matchProcessor.executeAsync();
+        const printings = matchProcessor.matchResultDetails || [];
         return {
             name: match.name,
             sets: results,
-            setVerificationLinks: matchProcessor.matchResultDetails || []
+            printings,
+            // Retained for debug-log compatibility. New code should use `printings`, which
+            // preserves exact print IDs and collector numbers rather than only verification URLs.
+            setVerificationLinks: printings
         };
     }
 
@@ -259,7 +268,10 @@ class ProcessorClass {
             cardName: record.name,
             extractedText: this.nameExtractionResults.cleanText,
             dirtyExtractedText: this.nameExtractionResults.dirtyText,
-            possibleSets: record.sets.join(","),
+            possibleSets:
+                record.printings.length > 0
+                    ? record.printings.map(formatPrintLabel).join(",")
+                    : record.sets.join(","),
             nameImage: name64Image
         });
         await needsAttenionModel.insert();
@@ -267,13 +279,28 @@ class ProcessorClass {
 
     async CreateCollectionsRecordAsync(record) {
         this.logger.info(`Saving "${record.name}" to collection`);
-        const set = record.sets[0];
-        let additionalInfo;
-        try {
-            additionalInfo = await this.dependencies.cardSearch.searchByNameExact(record.name, "");
-        } catch (err) {
-            this.logger.error(err);
-            throw err;
+        const printing = record.printings[0];
+        const set = printing.setName || record.sets[0];
+        let additionalInfo = {
+            tcgplayer_id: printing.tcgplayerId,
+            image_uris: { normal: printing.imageUrl },
+            prices: { usd: printing.priceUsd },
+            type_line: printing.typeLine
+        };
+        if (
+            !additionalInfo.tcgplayer_id ||
+            !additionalInfo.image_uris.normal ||
+            !additionalInfo.type_line
+        ) {
+            try {
+                additionalInfo = await this.dependencies.cardSearch.searchByNameExact(
+                    record.name,
+                    ""
+                );
+            } catch (err) {
+                this.logger.error(err);
+                throw err;
+            }
         }
         // delta defaults to 1 (this scan found one more copy) -- the persistence layer
         // (nedb or rds, whichever is selected) owns adding that to whatever quantity

--- a/src/regression/manifest.mjs
+++ b/src/regression/manifest.mjs
@@ -30,6 +30,9 @@ function validateExpected(expected, label) {
     requireString(expected.name, `${label}.expected.name`);
     requireString(expected.set, `${label}.expected.set`);
     requireString(expected.collectorNumber, `${label}.expected.collectorNumber`);
+    if (expected.scryfallId !== undefined) {
+        requireString(expected.scryfallId, `${label}.expected.scryfallId`);
+    }
 }
 
 function validateManifest(rawManifest, manifestPath) {
@@ -53,6 +56,9 @@ function validateManifest(rawManifest, manifestPath) {
         requireString(card.name, `${label}.name`);
         requireString(card.set, `${label}.set`);
         requireString(card.collectorNumber, `${label}.collectorNumber`);
+        if (card.scryfallId !== undefined) {
+            requireString(card.scryfallId, `${label}.scryfallId`);
+        }
         return {
             ...card,
             referenceImagePath: resolveFixturePath(

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -146,6 +146,14 @@ function evaluateResult(fixture, result) {
             }`
         );
     }
+    if (
+        expected.scryfallId &&
+        String(selectedCard?.scryfallId || "") !== String(expected.scryfallId)
+    ) {
+        failures.push(
+            `Scryfall print ID: expected ${expected.scryfallId}, received ${selectedCard?.scryfallId || "no match"}`
+        );
+    }
     if ((result.selectedPrint?.score || 0) < minPrintScore) {
         failures.push(
             `print score: expected at least ${minPrintScore}, received ${result.selectedPrint?.score || 0}`
@@ -219,17 +227,24 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
             nameCandidateCount: nameMatches.length,
             printCandidateCount: printCandidates.length,
             selectedPrint: rankedPrints[0] || null,
+            exactPrintVerified: false,
             setVerified: false,
             timings,
             runtimeMs: elapsedSince(startedAt),
             failures: [],
             passed: false
         };
-        result.setVerified =
+        result.exactPrintVerified =
             normalized(result.selectedPrint?.card?.set) === normalized(fixture.expected.set) &&
             String(result.selectedPrint?.card?.collectorNumber || "") ===
                 String(fixture.expected.collectorNumber) &&
+            (!fixture.expected.scryfallId ||
+                String(result.selectedPrint?.card?.scryfallId || "") ===
+                    String(fixture.expected.scryfallId)) &&
             result.selectedPrint.score >= (fixture.expected.minPrintScore ?? 0.75);
+        // Backward-compatible report field for existing consumers. Exact print verification
+        // additionally checks Scryfall ID whenever a fixture supplies one.
+        result.setVerified = result.exactPrintVerified;
         result.failures = evaluateResult(fixture, result);
         result.passed = result.failures.length === 0;
         return result;
@@ -252,6 +267,7 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
             nameCandidateCount: 0,
             printCandidateCount: 0,
             selectedPrint: null,
+            exactPrintVerified: false,
             setVerified: false,
             timings,
             runtimeMs: elapsedSince(startedAt),
@@ -279,6 +295,10 @@ function summarize(results) {
             ];
         })
     );
+    // Every reviewed fixture identifies a printing by set + collector number. A supplied
+    // Scryfall ID strengthens that identity check, but is not required for the fixture to
+    // contribute to the exact-print metric.
+    const exactPrintResults = results;
     return {
         total: results.length,
         passed,
@@ -294,6 +314,10 @@ function summarize(results) {
               ) / 100
             : 0,
         p95RuntimeMs: runtimes[percentileIndex] || 0,
+        exactPrints: {
+            total: exactPrintResults.length,
+            verified: exactPrintResults.filter((result) => result.exactPrintVerified).length
+        },
         byQuality
     };
 }

--- a/src/regression/report.mjs
+++ b/src/regression/report.mjs
@@ -37,6 +37,7 @@ function formatBenchmarkReport(report) {
         `- Disabled fixtures: ${report.pending?.cases || 0}`,
         `- Undersized-input fixtures: ${report.summary.undersizedInputs || 0}`,
         `- Fixtures containing CHANGE_ME: ${report.pending?.placeholderCases || 0}`,
+        `- Exact-print fixtures: ${report.summary.exactPrints?.verified || 0}/${report.summary.exactPrints?.total || 0} verified`,
         `- Total runtime: ${report.summary.totalRuntimeMs} ms`,
         `- Wall runtime: ${report.summary.wallRuntimeMs ?? report.summary.totalRuntimeMs} ms`,
         `- Mean runtime: ${report.summary.meanRuntimeMs} ms`,
@@ -56,7 +57,7 @@ function formatBenchmarkReport(report) {
         "",
         "## Fixture results",
         "",
-        "| Fixture | Quality | OCR output | Name match | Name candidates | Print candidates | Set / collector | Print score | Set verified | Runtime | Result |",
+        "| Fixture | Quality | OCR output | Name match | Name candidates | Print candidates | Set / collector | Print score | Exact print verified | Runtime | Result |",
         "| --- | --- | --- | --- | ---: | ---: | --- | ---: | --- | ---: | --- |"
     );
 
@@ -78,7 +79,7 @@ function formatBenchmarkReport(report) {
                 nameMatch ? Math.round(nameMatch.percentage * 10000) / 100 : 0
             }%) | ${result.nameCandidateCount} | ${result.printCandidateCount} | ${markdownCell(
                 selectedCard ? `${selectedCard.set} #${selectedCard.collectorNumber}` : "—"
-            )} | ${result.selectedPrint ? Math.round(result.selectedPrint.score * 10000) / 100 : 0}% | ${result.setVerified ? "yes" : "no"} | ${result.runtimeMs} ms | ${resultLabel} |`
+            )} | ${result.selectedPrint ? Math.round(result.selectedPrint.score * 10000) / 100 : 0}% | ${(result.exactPrintVerified ?? result.setVerified) ? "yes" : "no"} | ${result.runtimeMs} ms | ${resultLabel} |`
         );
     });
 

--- a/src/scryfall-api/search-name.mjs
+++ b/src/scryfall-api/search-name.mjs
@@ -5,6 +5,15 @@ import { request, REQUEST_HEADERS } from "./http-client.mjs";
 const defaultLogger = log.create({
     isPretty: true
 });
+const MAX_PRINT_SEARCH_PAGES = 20;
+
+function assertScryfallPageUrl(value) {
+    const url = new URL(value);
+    if (url.origin !== apiConfig.base) {
+        throw new Error("Scryfall pagination returned an unapproved origin");
+    }
+    return url.toString();
+}
 
 export function createSearchApi({ request: sendRequest = request, logger = defaultLogger } = {}) {
     // These return a random/newest card if printed across sets.
@@ -51,18 +60,32 @@ export function createSearchApi({ request: sendRequest = request, logger = defau
     async function searchList(exact) {
         const name = exact.replace(/ /g, "%20");
         try {
-            const response = await sendRequest({
-                uri: `${apiConfig.templates.cardListExact}${name}&unique=prints`,
-                headers: REQUEST_HEADERS
-            });
-            if (response) {
+            let uri = `${apiConfig.templates.cardListExact}${name}&unique=prints`;
+            const cards = [];
+            for (let page = 0; page < MAX_PRINT_SEARCH_PAGES; page += 1) {
+                const response = await sendRequest({ uri, headers: REQUEST_HEADERS });
+                if (!response) {
+                    break;
+                }
                 const cardInfo = JSON.parse(response) || {};
                 if (Object.keys(cardInfo).length === 0) {
                     return [await searchByNameFuzzy(name)];
                 }
-                return cardInfo.data;
+                cards.push(...(Array.isArray(cardInfo.data) ? cardInfo.data : []));
+                if (!cardInfo.has_more) {
+                    return cards;
+                }
+                if (!cardInfo.next_page) {
+                    throw new Error("Scryfall pagination omitted next_page");
+                }
+                uri = assertScryfallPageUrl(cardInfo.next_page);
             }
-            return [];
+            if (cards.length > 0) {
+                throw new Error(
+                    `Scryfall print search exceeded ${MAX_PRINT_SEARCH_PAGES} pages for "${exact}"`
+                );
+            }
+            return cards;
         } catch (err) {
             logger.error(err);
             return [];

--- a/test/console/format-scan-results.spec.mjs
+++ b/test/console/format-scan-results.spec.mjs
@@ -36,4 +36,33 @@ describe("formatScanResults", () => {
     it("handles an empty result list", () => {
         assert.equal(formatScanResults([]), "No scan results.");
     });
+
+    it("distinguishes exact variants from the same set without exposing URLs", () => {
+        const output = formatScanResults([
+            {
+                name: "Example",
+                sets: ["Final Fantasy"],
+                printings: [
+                    {
+                        printId: "fin-1",
+                        setCode: "FIN",
+                        collectorNumber: "1",
+                        verified: true,
+                        scryfallUri: "https://scryfall.com/card/fin/1/example"
+                    },
+                    {
+                        printId: "fin-301",
+                        setCode: "FIN",
+                        collectorNumber: "301",
+                        verified: false,
+                        scryfallUri: "https://scryfall.com/card/fin/301/example"
+                    }
+                ]
+            }
+        ]);
+
+        assert.include(output, "Printings: FIN #1 (verified), FIN #301 (unverified)");
+        assert.notInclude(output, "scryfall.com");
+        assert.notInclude(output, "printId");
+    });
 });

--- a/test/db-local/card-hash-cache.spec.mjs
+++ b/test/db-local/card-hash-cache.spec.mjs
@@ -47,7 +47,7 @@ describe("db-local::card-hash-cache", () => {
             cardUrl: "https://example.test/card.jpg",
             hashMode: "full-card"
         });
-        assert.equal(hashes[0].lookupKey, "Pacifism::Core Set 2020::1::0::abc123");
+        assert.equal(hashes[0].lookupKey, "Pacifism::Core Set 2020::::en::1::0::full-card::abc123");
         assert.instanceOf(hashes[0].createdAt, Date);
         assert.instanceOf(hashes[0].updatedAt, Date);
     });
@@ -64,6 +64,35 @@ describe("db-local::card-hash-cache", () => {
         const [hash] = await cache.getHashes("Pacifism");
 
         assert.equal(hash.hashMode, "set-symbol");
+    });
+
+    it("addresses same-set variants by exact print identity", async () => {
+        const cache = await freshCache();
+
+        await cache.insertEntity({
+            cardName: "Example",
+            setName: "Final Fantasy",
+            setCode: "FIN",
+            collectorNumber: "1",
+            printId: "fin-1",
+            cardHash: "samehash"
+        });
+        await cache.insertEntity({
+            cardName: "Example",
+            setName: "Final Fantasy",
+            setCode: "FIN",
+            collectorNumber: "301",
+            printId: "fin-301",
+            cardHash: "samehash"
+        });
+
+        const hashes = await cache.getHashes("Example");
+        assert.lengthOf(hashes, 2);
+        assert.sameMembers(
+            hashes.map((hash) => hash.printId),
+            ["fin-1", "fin-301"]
+        );
+        assert.notEqual(hashes[0].lookupKey, hashes[1].lookupKey);
     });
 
     it("upserts the same printing/hash instead of duplicating it", async () => {

--- a/test/export-processor/process-hashes-fallback.spec.mjs
+++ b/test/export-processor/process-hashes-fallback.spec.mjs
@@ -57,6 +57,8 @@ describe("ProcessHashes fallback behavior", () => {
         assert.isTrue(hashImageStub.calledTwice);
         assert.isAtLeast(matches.length, 1);
         assert.isAtMost(matches.length, 2);
+        assert.isTrue(matches.every((match) => match.verified === false));
+        assert.isTrue(matches.every((match) => match.matchKind === "remote-image-best-guess"));
     });
 
     for (const example of [

--- a/test/export-processor/process-hashes.spec.mjs
+++ b/test/export-processor/process-hashes.spec.mjs
@@ -178,8 +178,11 @@ describe("Integration::", () => {
 
             assert.isFalse(settled);
             finishWrite();
-            await comparison;
+            const matches = await comparison;
             assert.isTrue(settled);
+            assert.lengthOf(matches, 1);
+            assert.isTrue(matches[0].verified);
+            assert.equal(matches[0].matchKind, "remote-full-card-hash");
         });
 
         it("Should return no results for compareRemoteHashes", async () => {
@@ -211,6 +214,13 @@ describe("Integration::", () => {
             let hasher = ProcessHashes.create({
                 cards: [
                     {
+                        id: "print-set-a-1",
+                        oracle_id: "oracle-test",
+                        set: "set",
+                        collector_number: "1",
+                        lang: "en",
+                        illustration_id: "art-test",
+                        scryfall_uri: "https://scryfall.com/card/set/1/test",
                         image_uris: {
                             normal: "http://www.fake.url/img"
                         },
@@ -227,7 +237,15 @@ describe("Integration::", () => {
             assert.isTrue(stubs.insertEntityStub.calledOnce);
             assert.deepEqual(stubs.insertEntityStub.firstCall.args[0], {
                 cardName: "Test",
+                printId: "print-set-a-1",
+                oracleId: "oracle-test",
+                setCode: "SET",
                 setName: "SET_A",
+                collectorNumber: "1",
+                language: "en",
+                illustrationId: "art-test",
+                cardUrl: "http://www.fake.url/img",
+                scryfallUri: "https://scryfall.com/card/set/1/test",
                 cardHash: FAKE_HASH,
                 hashMode: "full-card"
             });
@@ -304,8 +322,11 @@ describe("Integration::", () => {
 
             assert.isFalse(settled);
             finishCleanup();
-            await comparison;
+            const matches = await comparison;
             assert.isTrue(settled);
+            assert.lengthOf(matches, 1);
+            assert.isFalse(matches[0].verified);
+            assert.equal(matches[0].matchKind, "remote-set-symbol-hash");
         });
 
         it("does not mask a remote hash error when cleanup also fails", async () => {

--- a/test/matcher/matching-processor.spec.mjs
+++ b/test/matcher/matching-processor.spec.mjs
@@ -28,10 +28,13 @@ describe("MatcherProcessor::", () => {
         sandbox.restore();
     });
 
-    it("returns normalized set details when only one search result exists", (done) => {
+    it("returns one unverified exact-print candidate when only one search result exists", async () => {
         const info = sandbox.stub();
         const expectedCard = {
+            id: "print-m20-1",
+            set: "m20",
             set_name: "M20",
+            collector_number: "1",
             scryfall_uri: "https://scryfall.com/card/m20/1/example"
         };
         const searchStub = sandbox.stub(dependencies, "searchPrintings").resolves([expectedCard]);
@@ -42,23 +45,25 @@ describe("MatcherProcessor::", () => {
             logger: { info, error: sandbox.stub() }
         });
 
-        processor.execute((err, result) => {
-            assert.isNull(err);
-            assert.isTrue(searchStub.calledOnce);
-            assert.isTrue(hashStub.notCalled);
-            assert.deepEqual(result, ["M20"]);
-            assert.deepEqual(processor.matchResultDetails, [
-                {
-                    setName: "M20",
-                    scryfallUri: "https://scryfall.com/card/m20/1/example"
-                }
-            ]);
-            assert.deepEqual(
-                info.getCalls().map((call) => call.args[0]),
-                ['Searching Scryfall for "Pacifism"', 'Scryfall returned 1 printing for "Pacifism"']
-            );
-            done();
+        const result = await processor.executeAsync();
+
+        assert.isTrue(searchStub.calledOnce);
+        assert.isTrue(hashStub.notCalled);
+        assert.deepEqual(result, ["M20"]);
+        assert.lengthOf(processor.matchResultDetails, 1);
+        assert.include(processor.matchResultDetails[0], {
+            printId: "print-m20-1",
+            setCode: "M20",
+            setName: "M20",
+            collectorNumber: "1",
+            scryfallUri: "https://scryfall.com/card/m20/1/example",
+            matchKind: "catalog-candidate-only",
+            verified: false
         });
+        assert.deepEqual(
+            info.getCalls().map((call) => call.args[0]),
+            ['Searching Scryfall for "Pacifism"', 'Scryfall returned 1 printing for "Pacifism"']
+        );
     });
 
     it("errors when search results are not an array", (done) => {
@@ -83,19 +88,47 @@ describe("MatcherProcessor::", () => {
         });
     });
 
-    it("merges DB + remote set matches for multi-result searches", (done) => {
+    it("merges DB + remote exact-print matches for multi-result searches", async () => {
         const processHashesInstance = {
-            compareDbHashes: () => Promise.resolve([{ setName: "M20" }]),
-            compareRemoteImages: () => Promise.resolve([{ setName: "M21" }, { setName: "M20" }])
+            compareDbHashes: () =>
+                Promise.resolve([
+                    { printId: "m20-1", setCode: "M20", setName: "M20", verified: true }
+                ]),
+            compareRemoteImages: () =>
+                Promise.resolve([
+                    {
+                        printId: "m21-1",
+                        setCode: "M21",
+                        setName: "M21",
+                        verified: true,
+                        comparable: true,
+                        algorithm: "pdq-v1",
+                        similarity: 0.96,
+                        distance: 10,
+                        bitLength: 256,
+                        leftQuality: 100,
+                        rightQuality: 98,
+                        minQuality: 98,
+                        eligible: true,
+                        matches: true
+                    },
+                    { printId: "m20-1", setCode: "M20", setName: "M20", verified: true }
+                ])
         };
 
         const searchStub = sandbox.stub(dependencies, "searchPrintings").resolves([
             {
+                id: "m20-1",
+                set: "m20",
+                collector_number: "1",
                 set_name: "M20",
                 image_uris: { normal: "https://example.com/m20.jpg" },
                 scryfall_uri: "https://scryfall.com/card/m20/1/example"
             },
             {
+                id: "m21-1",
+                set: "m21",
+                collector_number: "1",
                 set_name: "M21",
                 image_uris: { normal: "https://example.com/m21.jpg" },
                 scryfall_uri: "https://scryfall.com/card/m21/1/example"
@@ -116,18 +149,74 @@ describe("MatcherProcessor::", () => {
             filePath: "/tmp/pacifism.jpg"
         });
 
-        processor.execute((err, result) => {
-            assert.isNull(err);
-            assert.isTrue(searchStub.calledOnce);
-            assert.isTrue(hashStub.calledOnce);
-            assert.isTrue(processHashesStub.calledOnce);
-            assert.sameMembers(result, ["M20", "M21"]);
-            assert.sameDeepMembers(processor.matchResultDetails, [
-                { setName: "M20", scryfallUri: "https://scryfall.com/card/m20/1/example" },
-                { setName: "M21", scryfallUri: "https://scryfall.com/card/m21/1/example" }
-            ]);
-            done();
-        });
+        const result = await processor.executeAsync();
+
+        assert.isTrue(searchStub.calledOnce);
+        assert.isTrue(hashStub.calledOnce);
+        assert.isTrue(processHashesStub.calledOnce);
+        assert.sameMembers(result, ["M20", "M21"]);
+        assert.sameMembers(
+            processor.matchResultDetails.map((printing) => printing.printId),
+            ["m20-1", "m21-1"]
+        );
+        assert.isTrue(processor.matchResultDetails.every((printing) => printing.verified));
+        assert.deepInclude(
+            processor.matchResultDetails.find((printing) => printing.printId === "m21-1")
+                .comparison,
+            {
+                comparable: true,
+                algorithm: "pdq-v1",
+                similarity: 0.96,
+                distance: 10,
+                bitLength: 256,
+                minQuality: 98,
+                eligible: true,
+                matches: true
+            }
+        );
+    });
+
+    it("preserves two verified variants from the same set", async () => {
+        const processHashesInstance = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().resolves([
+                {
+                    printId: "fin-1",
+                    setCode: "FIN",
+                    setName: "Final Fantasy",
+                    collectorNumber: "1",
+                    verified: true
+                },
+                {
+                    printId: "fin-301",
+                    setCode: "FIN",
+                    setName: "Final Fantasy",
+                    collectorNumber: "301",
+                    verified: true
+                }
+            ])
+        };
+        sandbox.stub(dependencies, "searchPrintings").resolves([
+            { id: "fin-1", set: "fin", set_name: "Final Fantasy", collector_number: "1" },
+            {
+                id: "fin-301",
+                set: "fin",
+                set_name: "Final Fantasy",
+                collector_number: "301"
+            }
+        ]);
+        sandbox.stub(dependencies, "hashImage").resolves("FAKE_LOCAL_HASH");
+        sandbox.stub(dependencies, "createDirectory").rejects(new Error("no temp dir"));
+        sandbox.stub(dependencies.processHashes, "create").returns(processHashesInstance);
+        const processor = create({ name: "Example", filePath: "/tmp/example.jpg" });
+
+        const result = await processor.executeAsync();
+
+        assert.deepEqual(result, ["Final Fantasy"]);
+        assert.sameMembers(
+            processor.matchResultDetails.map((printing) => printing.printId),
+            ["fin-1", "fin-301"]
+        );
     });
 
     it("still uses local hash cache lookup when querying is disabled", (done) => {

--- a/test/matcher/print-candidate.spec.mjs
+++ b/test/matcher/print-candidate.spec.mjs
@@ -1,0 +1,65 @@
+import { assert } from "chai";
+import {
+    formatPrintLabel,
+    normalizePrintCandidate,
+    printIdentityKey
+} from "../../src/matcher/print-candidate.mjs";
+
+describe("print candidate contract", () => {
+    it("preserves exact Scryfall printing and treatment metadata", () => {
+        const candidate = normalizePrintCandidate({
+            id: "print-123",
+            oracle_id: "oracle-123",
+            name: "Mothra, Supersonic Queen",
+            flavor_name: "Mothra, Supersonic Queen",
+            set: "iko",
+            set_name: "Ikoria: Lair of Behemoths",
+            collector_number: "66",
+            lang: "en",
+            illustration_id: "art-123",
+            frame_effects: ["showcase"],
+            full_art: true,
+            promo_types: ["godzillaseries"],
+            finishes: ["nonfoil", "foil"],
+            image_uris: { normal: "https://cards.scryfall.io/card.jpg" },
+            scryfall_uri: "https://scryfall.com/card/iko/66/example"
+        });
+
+        assert.include(candidate, {
+            printId: "print-123",
+            oracleId: "oracle-123",
+            setCode: "IKO",
+            setName: "Ikoria: Lair of Behemoths",
+            collectorNumber: "66",
+            illustrationId: "art-123",
+            fullArt: true,
+            imageUrl: "https://cards.scryfall.io/card.jpg"
+        });
+        assert.deepEqual(candidate.frameEffects, ["showcase"]);
+        assert.deepEqual(candidate.promoTypes, ["godzillaseries"]);
+        assert.equal(printIdentityKey(candidate), "id:print-123");
+        assert.equal(formatPrintLabel(candidate), "IKO #66");
+    });
+
+    it("keeps same-set collector variants as distinct identities without IDs", () => {
+        const regular = { setCode: "FIN", collectorNumber: "1", language: "en" };
+        const borderless = { setCode: "FIN", collectorNumber: "301", language: "en" };
+
+        assert.notEqual(printIdentityKey(regular), printIdentityKey(borderless));
+    });
+
+    it("uses front-face imagery when a double-faced card has no top-level image", () => {
+        const candidate = normalizePrintCandidate({
+            id: "dfc-1",
+            card_faces: [
+                {
+                    printed_name: "Front Face",
+                    image_uris: { normal: "https://cards.scryfall.io/front.jpg" }
+                }
+            ]
+        });
+
+        assert.equal(candidate.printedName, "Front Face");
+        assert.equal(candidate.imageUrl, "https://cards.scryfall.io/front.jpg");
+    });
+});

--- a/test/processing/processor.spec.mjs
+++ b/test/processing/processor.spec.mjs
@@ -26,7 +26,18 @@ describe("Integration::", () => {
         sandbox = sinon.createSandbox();
         ImageProcessorInstance = { extract() {} };
         MatchNameInstance = { match() {} };
-        MatchProcessorInstance = { executeAsync() {}, matchResultDetails: [] };
+        MatchProcessorInstance = {
+            executeAsync() {},
+            matchResultDetails: [
+                {
+                    printId: "spa-1",
+                    setCode: "SPA",
+                    setName: COLLECTION_NAME,
+                    collectorNumber: "1",
+                    verified: true
+                }
+            ]
+        };
         stubs.ImageProcessorCreateStub = sandbox.stub().returns(ImageProcessorInstance);
         ImageProcessorInstance.extract = new Function();
         stubs.ImageProcessorExtractStub = sandbox
@@ -292,6 +303,22 @@ describe("Integration::", () => {
 
         it("routes one name with multiple possible sets to needs attention", async () => {
             stubs.MatchProcessorExecuteStub.resolves([COLLECTION_NAME, COLLECTION_NAME_TWO]);
+            MatchProcessorInstance.matchResultDetails = [
+                {
+                    printId: "spa-1",
+                    setCode: "SPA",
+                    setName: COLLECTION_NAME,
+                    collectorNumber: "1",
+                    verified: true
+                },
+                {
+                    printId: "spa2-1",
+                    setCode: "SPA2",
+                    setName: COLLECTION_NAME_TWO,
+                    collectorNumber: "1",
+                    verified: true
+                }
+            ];
             const processorInstance = createProcessor({
                 filePath: FAKE_PATH,
                 queryingEnabled: true,
@@ -306,12 +333,51 @@ describe("Integration::", () => {
             assert.isTrue(stubs.NeedsAttentionInsertStub.calledOnce);
             assert.deepInclude(stubs.NeedsAttentionCreateStub.firstCall.args[0], {
                 cardName: "Pacifism",
-                possibleSets: `${COLLECTION_NAME},${COLLECTION_NAME_TWO}`
+                possibleSets: "SPA #1,SPA2 #1"
             });
+        });
+
+        it("routes an unverified single API candidate to needs attention", async () => {
+            MatchProcessorInstance.matchResultDetails = [
+                {
+                    printId: "spa-1",
+                    setCode: "SPA",
+                    setName: COLLECTION_NAME,
+                    collectorNumber: "1",
+                    verified: false
+                }
+            ];
+            const processorInstance = createProcessor({
+                filePath: FAKE_PATH,
+                queryingEnabled: true,
+                collectionEnabled: true
+            });
+
+            await processorInstance.execute();
+
+            assert.equal(processorInstance.decision, "needs-attention");
+            assert.isFalse(stubs.CollectionInsertStub.called);
+            assert.isTrue(stubs.NeedsAttentionInsertStub.calledOnce);
         });
 
         it("keeps an ambiguous printing result non-persistent during a dry run", async () => {
             stubs.MatchProcessorExecuteStub.resolves([COLLECTION_NAME, COLLECTION_NAME_TWO]);
+            MatchProcessorInstance.matchResultDetails = [
+                {
+                    printId: "spa-1",
+                    setCode: "SPA",
+                    setName: COLLECTION_NAME,
+                    collectorNumber: "1",
+                    verified: true
+                },
+                {
+                    printId: "spa2-1",
+                    setCode: "SPA2",
+                    setName: COLLECTION_NAME_TWO,
+                    collectorNumber: "1",
+                    verified: true
+                }
+            ];
             const processorInstance = createProcessor({
                 filePath: FAKE_PATH,
                 queryingEnabled: false,
@@ -361,7 +427,9 @@ describe("Integration::", () => {
             await processorInstance.execute();
 
             assert.isTrue(
-                output.calledOnceWithExactly("Scan results\n\n1. Pacifism\n   Sets: SPA")
+                output.calledOnceWithExactly(
+                    "Scan results\n\n1. Pacifism\n   Sets: SPA\n   Printings: SPA #1 (verified)"
+                )
             );
         });
 
@@ -488,7 +556,12 @@ describe("Integration::", () => {
                 assert.isArray(loggedRecord.matcherResults);
                 assert.isNotEmpty(loggedRecord.matcherResults);
                 loggedRecord.matcherResults.forEach((result) => {
-                    assert.hasAllKeys(result, ["name", "sets", "setVerificationLinks"]);
+                    assert.hasAllKeys(result, [
+                        "name",
+                        "sets",
+                        "printings",
+                        "setVerificationLinks"
+                    ]);
                 });
                 return done(err);
             });

--- a/test/regression/regression-runner.spec.mjs
+++ b/test/regression/regression-runner.spec.mjs
@@ -98,6 +98,7 @@ describe("Regression framework::", () => {
                     name: "Pacifism",
                     set: "BBD",
                     collectorNumber: "101",
+                    scryfallId: "bbd-101",
                     referenceImage: "pacifism.jpg"
                 }
             ],
@@ -122,14 +123,16 @@ describe("Regression framework::", () => {
                     name: "Pacifism",
                     set: "BBD",
                     collectorNumber: "101",
+                    scryfallId: "bbd-101",
                     typeLine: "Enchantment — Aura",
                     colors: ["W"],
                     referenceImagePath: "/fixtures/reference.jpg"
                 },
                 {
                     name: "Pacifism",
-                    set: "M20",
-                    collectorNumber: "32",
+                    set: "BBD",
+                    collectorNumber: "301",
+                    scryfallId: "bbd-301",
                     referenceImagePath: "/fixtures/alternative.jpg"
                 },
                 {
@@ -151,6 +154,7 @@ describe("Regression framework::", () => {
                         name: "Pacifism",
                         set: "BBD",
                         collectorNumber: "101",
+                        scryfallId: "bbd-101",
                         minNameScore: 0.7,
                         maxPrintCandidates: 2,
                         metadata: { typeLine: "Enchantment — Aura", colors: ["W"] }
@@ -224,7 +228,10 @@ describe("Regression framework::", () => {
         assert.equal(report.results[0].nameCandidateCount, 1);
         assert.equal(report.results[0].printCandidateCount, 2);
         assert.equal(report.results[0].selectedPrint.card.set, "BBD");
+        assert.equal(report.results[0].selectedPrint.card.scryfallId, "bbd-101");
+        assert.isTrue(report.results[0].exactPrintVerified);
         assert.isTrue(report.results[0].setVerified);
+        assert.deepEqual(report.summary.exactPrints, { total: 1, verified: 1 });
         assert.deepEqual(report.results[0].failures, []);
     });
 
@@ -689,7 +696,7 @@ describe("Regression framework::", () => {
         assert.include(markdown, "OCR output");
         assert.include(markdown, "Name candidates");
         assert.include(markdown, "Print candidates");
-        assert.include(markdown, "Set verified");
+        assert.include(markdown, "Exact print verified");
         assert.include(markdown, "OCR returned no normalized text");
         assert.include(markdown, "CI gate: PASS");
         assert.include(markdown, "NON-BLOCKING FAIL");

--- a/test/scryfall-api/api.spec.mjs
+++ b/test/scryfall-api/api.spec.mjs
@@ -24,7 +24,7 @@ describe("Scryfall Api::", () => {
         const json = {
             object: "list",
             total_cards: 445,
-            has_more: true,
+            has_more: false,
             next_page:
                 "https://api.scryfall.com/cards/search?format=json&include_extras=false&include_multilingual=false&order=cmc&page=2&q=c%3Ared+pow%3D3&unique=cards",
             data: [{}]
@@ -60,6 +60,53 @@ describe("Scryfall Api::", () => {
             assert.strictEqual(cards.length, 1);
             assert.deepStrictEqual(cards[0], {});
             assert.deepStrictEqual(cards, json.data);
+        });
+
+        it("searchList preserves exact print candidates across pages", async () => {
+            requestStub.onFirstCall().resolves(
+                JSON.stringify({
+                    object: "list",
+                    has_more: true,
+                    next_page: "https://api.scryfall.com/cards/search?page=2&q=name%3AFake",
+                    data: [{ id: "print-1" }]
+                })
+            );
+            requestStub.onSecondCall().resolves(
+                JSON.stringify({
+                    object: "list",
+                    has_more: false,
+                    data: [{ id: "print-2" }]
+                })
+            );
+
+            const cards = await api.searchList("Fake Name");
+
+            assert.isTrue(requestStub.calledTwice);
+            assert.deepEqual(
+                cards.map((card) => card.id),
+                ["print-1", "print-2"]
+            );
+            assert.equal(
+                requestStub.secondCall.args[0].uri,
+                "https://api.scryfall.com/cards/search?page=2&q=name%3AFake"
+            );
+        });
+
+        it("rejects pagination URLs outside the Scryfall API origin", async () => {
+            requestStub.resolves(
+                JSON.stringify({
+                    object: "list",
+                    has_more: true,
+                    next_page: "https://example.test/stolen",
+                    data: [{ id: "print-1" }]
+                })
+            );
+
+            const cards = await api.searchList("Fake Name");
+
+            assert.deepEqual(cards, []);
+            assert.isTrue(requestStub.calledOnce);
+            assert.isTrue(logger.error.calledOnce);
         });
 
         it("searchByNameExact returns empty object when request fails", async () => {

--- a/tsconfig.checked.json
+++ b/tsconfig.checked.json
@@ -7,6 +7,7 @@
         "src/config/json-file.mjs",
         "src/config/schema.mjs",
         "src/config/value-parsers.mjs",
-        "src/fuzzy-matching/match-policy.mjs"
+        "src/fuzzy-matching/match-policy.mjs",
+        "src/matcher/print-candidate.mjs"
     ]
 }


### PR DESCRIPTION
## Summary

- add an exact-print candidate contract that preserves Scryfall print IDs, set codes, collector numbers, language, artwork, frame, treatment, finish availability, and image metadata
- keep same-set variants distinct through matching, the hash cache, CLI output, and needs-attention records
- follow bounded same-origin Scryfall pagination so print searches do not silently omit later pages
- extend regression fixtures and reports with exact-print verification and document the research-backed detection roadmap

## Why

The previous pipeline reduced print matches to set names. That made collector-number variants, alternate art, promos, showcase treatments, and other same-set printings indistinguishable. It also treated a lone catalog result as confirmation and could compare a local set-symbol hash against a remote full-card hash when cropping failed.

## Behavior and impact

A collection write now requires one card-name result and one full-card image-verified exact printing. Lone API candidates, set-symbol-only matches, closest-image guesses, and ambiguous variants explicitly remain unverified and route to manual review when persistence is enabled.

Legacy set-only hash rows remain usable as hints, while refreshed cache rows use exact print identity. Existing set-name output remains available for compatibility, with exact printing labels added for users.

## Validation

- `pnpm check:fast`
- 462 unit tests passing
- coverage gate passing: 92.98% statements, 79.06% branches
- OCR/image regression: 156/158 overall
- blocking regression gate: 151/151 passing
- the two failures are the existing non-blocking vintage OCR fixtures documented in the spike
