### PR TITLE
fix: build GitHub Pages with Node 22

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

- build the Astro showcase with Node 22 in the GitHub Pages workflow
- align the Pages runtime with the repository engine requirement and existing CI jobs

## Root cause

The Pages workflow pinned Node 20 even though the project requires Node 22 or newer. Astro 7 rejects Node 20, so the showcase build failed before the artifact upload and deployment steps.

## Impact

GitHub Pages can build and deploy the showcase again using the supported runtime.

## Validation

- `pnpm exec prettier --check .github/workflows/pages.yml` under Node 22.22.1
- `pnpm site:build` under Node 22.22.1
- pre-commit `lint-staged` hook
