### PR TITLE
Prepare MTG Card Analyzer 0.2.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,11 @@ Releases are published on GitHub with the `npm pack` archive attached; this proj
 to the npm registry. Creating the release tag and publishing its archive remain explicit maintainer
 steps after the release commit has passed its gates.
 
+Each release-preparation change must add reviewed, versioned notes at
+`docs/releases/<version>.md`. Replace the generic Release Drafter body with those notes before
+publishing. Cover user-visible behavior, upgrade and compatibility guidance, benchmark or test
+evidence for matching changes, every included pull request, and the full comparison link.
+
 Type checking is being introduced incrementally for this ESM JavaScript codebase. The strict
 checked-module list lives in `tsconfig.checked.json`; add a touched production module there once its
 JSDoc contracts pass `pnpm typecheck`.

--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ You need:
   card-name seed
 
 ```bash
-npm install --global https://github.com/dills122/MTG-Card-Analyzer/releases/latest/download/mtg-card-analyzer-0.2.0.tgz
+npm install --global https://github.com/dills122/MTG-Card-Analyzer/releases/latest/download/mtg-card-analyzer-0.2.1.tgz
 mtg-card-analyzer names seed
 mtg-card-analyzer scan ./path/to/card.jpg
 ```

--- a/docs/releases/0.2.1.md
+++ b/docs/releases/0.2.1.md
@@ -1,0 +1,81 @@
+# MTG Card Analyzer 0.2.1
+
+MTG Card Analyzer 0.2.1 improves print identification by adopting the PDQ implementation from
+[`image-fingerprint`](https://github.com/dills122/image-fingerprint), adds a safer fallback when a
+set-symbol comparison is inconclusive, and makes the offline OCR regression suite faster to run.
+This release also adds the project's new Astro showcase and GitHub Pages deployment.
+
+## Highlights
+
+### Dogfooding `image-fingerprint` with PDQ
+
+Print matching now uses normalized, 256-bit PDQ v1 fingerprints from `image-fingerprint@0.1.1`
+instead of the previous Blockhash implementation. Fingerprints are stored as versioned records and
+compared with Hamming distance plus the library's quality-aware starting policy.
+
+The production choice is backed by a deterministic local benchmark over 151 reviewed reference
+prints. Across 272 transformed full-card queries, PDQ ranked the correct print first in all 272
+cases, compared with 270 for Blockhash, and increased the mean separation from the nearest wrong
+print from 0.1534 to 0.2702. See the
+[fingerprint benchmark](https://github.com/dills122/MTG-Card-Analyzer/blob/0.2.1/docs/image-fingerprint-benchmark.md)
+for the complete method, results, and limitations.
+
+Existing hash caches do not need a manual migration. Legacy raw Blockhash rows remain readable but
+are not compared with PDQ; the next remote comparison refreshes them with a current versioned
+fingerprint.
+
+### Better handling of uncertain set-symbol matches
+
+A high-confidence set-symbol result still wins immediately. When the symbol comparison is too weak,
+the matcher now abstains and retries against the full card instead of accepting an unbounded best
+guess.
+
+The bounded fallback requires fingerprint quality eligibility and at least 0.75 similarity. It
+keeps candidates within 0.03 of the top result and returns at most three. In the reviewed
+calibration corpus, this recovered all 272 full-card queries without an incorrect accepted cohort,
+while withholding the two known wrong cropped-symbol rankings.
+
+### Faster deterministic OCR regression runs
+
+The cold-cache regression runner now distributes cases deterministically across up to three OCR
+worker shards. The default is three workers, while `--workers 1`, `2`, or `3` supports constrained
+machines and controlled timing comparisons. Each shard remains sequential, resets adaptive OCR
+state for every crop, and replaces its worker after at most 40 cases. Reports preserve manifest
+ordering and now include elapsed wall runtime.
+
+## Also included
+
+- A new static Astro project showcase that visualizes the crop, OCR, fingerprint, and print-ranking
+  pipeline, with automated deployment to GitHub Pages.
+- Astro development tooling updated to 7.1.1.
+- Updated setup, diagnostics, security, configuration, and regression documentation for Node
+  22.14+, PDQ fingerprints, and parallel regression workers.
+- The fingerprint benchmark command, `pnpm benchmark:fingerprints`, for deterministic offline
+  comparison of the supported algorithms and application policy.
+
+The Astro site and its dependencies are development-only and are not included in the CLI release
+archive.
+
+## Upgrade
+
+MTG Card Analyzer is distributed through GitHub Releases rather than the npm registry. Node.js
+22.14 or newer is required.
+
+```bash
+npm install --global https://github.com/dills122/MTG-Card-Analyzer/releases/latest/download/mtg-card-analyzer-0.2.1.tgz
+```
+
+No configuration or database migration is required. Existing commands and configuration continue
+to work as before.
+
+## Changes since 0.2.0
+
+- [#212](https://github.com/dills122/MTG-Card-Analyzer/pull/212) Calibrate the PDQ print fallback.
+- [#211](https://github.com/dills122/MTG-Card-Analyzer/pull/211) Adopt PDQ image fingerprints.
+- [#210](https://github.com/dills122/MTG-Card-Analyzer/pull/210) Parallelize OCR fixture shards.
+- [#209](https://github.com/dills122/MTG-Card-Analyzer/pull/209) Update Astro from 5.18.2 to 7.1.1.
+- [#208](https://github.com/dills122/MTG-Card-Analyzer/pull/208) Add the Astro project showcase and
+  GitHub Pages deployment.
+
+**Full comparison:**
+[`0.2.0...0.2.1`](https://github.com/dills122/MTG-Card-Analyzer/compare/0.2.0...0.2.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mtg-card-analyzer",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "private": true,
     "description": "Local-first CLI for identifying Magic: The Gathering cards from images",
     "type": "module",


### PR DESCRIPTION
## Summary

- Prepare the GitHub-only `0.2.1` release.
- Provide reviewed release notes covering PDQ dogfooding, print-selection improvements, regression performance, compatibility, and upgrade guidance.

## What Changed

- Bumped the package version to `0.2.1`.
- Updated the README archive installation URL.
- Added versioned release notes with benchmark evidence and links to PRs #208–#212.
- Documented that reviewed notes must replace the generic Release Drafter body.

## Validation

- `fnm exec --using=22.22.1 -- pnpm check` — 459 tests passed.
- `fnm exec --using=22.22.1 -- pnpm coverage:check` — 92.9% statements/lines, 92.13% functions, 78.8% branches.
- `fnm exec --using=22.22.1 -- pnpm test:regression` — 151/151 blocking fixtures passed; 156/158 overall.
- `fnm exec --using=22.22.1 -- pnpm test:package` — packed-install smoke passed; 70 expected files.
- `npm pack --dry-run --json` — verified `mtg-card-analyzer-0.2.1.tgz`.
- `fnm exec --using=22.22.1 -- pnpm site:build` — production site build passed.
- `fnm exec --using=22.22.1 -- pnpm audit` — no known vulnerabilities.
- `git diff --check` and the final formatting check passed.

## Scope Notes

- The two regression misses are existing non-blocking vintage OCR fixtures; all 151 blocking fixtures passed.
- Existing Blockhash cache entries require no manual migration and refresh lazily as PDQ records.
- Creating tag `0.2.1`, attaching the archive, and publishing the GitHub release remain explicit maintainer actions.
