### PR TITLE
Complete the 0.2.1 release notes

### DIFF
--- a/docs/releases/0.2.1.md
+++ b/docs/releases/0.2.1.md
@@ -1,11 +1,26 @@
 # MTG Card Analyzer 0.2.1
 
-MTG Card Analyzer 0.2.1 improves print identification by adopting the PDQ implementation from
-[`image-fingerprint`](https://github.com/dills122/image-fingerprint), adds a safer fallback when a
-set-symbol comparison is inconclusive, and makes the offline OCR regression suite faster to run.
-This release also adds the project's new Astro showcase and GitHub Pages deployment.
+MTG Card Analyzer 0.2.1 improves print identification by preserving exact Scryfall printing
+identities, adopting the PDQ implementation from
+[`image-fingerprint`](https://github.com/dills122/image-fingerprint), and adding a safer fallback
+when a set-symbol comparison is inconclusive. It also makes the offline OCR regression suite faster
+to run and adds the project's new Astro showcase and GitHub Pages deployment.
 
 ## Highlights
+
+### Exact-print candidates and safer collection writes
+
+Print candidates now retain their Scryfall print ID, set code, collector number, language,
+illustration, frame, treatment, finish availability, and image metadata through matching, caching,
+CLI output, and needs-attention records. Same-set variants such as alternate art, promos, and
+showcase treatments are no longer collapsed into one set-name result.
+
+Scryfall print searches now follow bounded, same-origin pagination instead of silently omitting
+later pages. A collection write requires one card-name result and one exact printing verified with
+a full-card fingerprint. A lone API candidate, set-symbol-only match, closest-image guess, or
+ambiguous variant remains explicitly unverified and routes to needs-attention when persistence is
+enabled. Legacy set-only cache rows remain usable as hints, while refreshed rows use exact print
+identity.
 
 ### Dogfooding `image-fingerprint` with PDQ
 
@@ -48,6 +63,8 @@ ordering and now include elapsed wall runtime.
 - A new static Astro project showcase that visualizes the crop, OCR, fingerprint, and print-ranking
   pipeline, with automated deployment to GitHub Pages.
 - Astro development tooling updated to 7.1.1.
+- The GitHub Pages build now uses Node 22, matching the project engine requirement and restoring
+  Astro 7 deployment compatibility.
 - Updated setup, diagnostics, security, configuration, and regression documentation for Node
   22.14+, PDQ fingerprints, and parallel regression workers.
 - The fingerprint benchmark command, `pnpm benchmark:fingerprints`, for deterministic offline
@@ -70,6 +87,9 @@ to work as before.
 
 ## Changes since 0.2.0
 
+- [#214](https://github.com/dills122/MTG-Card-Analyzer/pull/214) Build GitHub Pages with Node 22.
+- [#213](https://github.com/dills122/MTG-Card-Analyzer/pull/213) Preserve and verify exact print
+  candidates.
 - [#212](https://github.com/dills122/MTG-Card-Analyzer/pull/212) Calibrate the PDQ print fallback.
 - [#211](https://github.com/dills122/MTG-Card-Analyzer/pull/211) Adopt PDQ image fingerprints.
 - [#210](https://github.com/dills122/MTG-Card-Analyzer/pull/210) Parallelize OCR fixture shards.


### PR DESCRIPTION
## Summary

- Complete the versioned `0.2.1` notes with PRs #213 and #214, which merged before the release-prep PR.
- Describe exact-print identity preservation, bounded Scryfall pagination, stricter collection confirmation, and the Node 22 Pages fix.

## Why

`master` advanced while PR #215 was open. The tagged release would include these user-visible changes, so the reviewed notes must cover them before publication.

## Validation

- `fnm exec --using=22.22.1 -- pnpm prettier:check`
- `git diff --check`
- pre-commit `lint-staged` hook

## Scope Notes

- Documentation-only follow-up; no runtime or dependency changes.
- Release publication remains pending until this correction is merged.
