### PR TITLE
Improve adaptive cropping and add local review workbench

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,6 +58,9 @@ jobs:
             - name: Build showcase
               run: pnpm site:build
 
+            - name: Verify local reviewer is excluded
+              run: test ! -e dist/crop-review
+
             - name: Configure GitHub Pages
               uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ lib-cov/
 # Generated OCR regression reports
 artifacts/regression/
 
+# Generated local crop-review site assets
+public/crop-review/generated/
+public/crop-review/generated.tmp-*/
+
 # Local OCR training review crops (unreviewed and potentially rights-restricted)
 artifacts/training-review/
 

--- a/.hallmark/log.json
+++ b/.hallmark/log.json
@@ -1,5 +1,14 @@
 [
     {
+        "date": "2026-08-15",
+        "macrostructure": "Catalogue",
+        "theme": "Coral",
+        "enrichment": "none",
+        "nav": "N9 Edge-aligned action bar",
+        "footer": "none (internal tool)",
+        "brief": "Internal crop QA route for approving, flagging, annotating, and exporting regression crop reviews"
+    },
+    {
         "date": "2026-08-09",
         "macrostructure": "Workbench",
         "theme": "Coral",

--- a/.hallmark/preflight.json
+++ b/.hallmark/preflight.json
@@ -4,12 +4,29 @@
     "palette": "Hallmark OKLCH tokens in tokens.css",
     "motion": "motion-cut",
     "spacing": "Hallmark 4-point semantic scale in tokens.css",
-    "framework": "Astro 5 static site alongside the Node.js ESM CLI",
-    "sources": ["package.json", "Readme.md", "tokens.css", "src/styles/site.css"],
+    "framework": "Astro 7 static site alongside the Node.js ESM CLI",
+    "sources": [
+        "package.json",
+        "Readme.md",
+        "tokens.css",
+        "src/styles/site.css",
+        "src/tools/crop-review.astro"
+    ],
     "preserve": [
         "existing CLI package contracts",
         "local-first product positioning",
-        "Workbench structure and responsive layout"
+        "Workbench structure and responsive layout",
+        "existing public project tour"
     ],
-    "introduce": ["single warm cream theme", "burnished terracotta accent"]
+    "introduce": [
+        "single warm cream theme",
+        "burnished terracotta accent",
+        "internal evidence-browser route for crop QA"
+    ],
+    "cropReview": {
+        "audience": "maintainers and contributors",
+        "primaryUse": "inspect, approve, flag, annotate, and export crop-review results",
+        "tone": "dense utilitarian workbench",
+        "publicFacing": false
+    }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -102,7 +102,8 @@ Run `mtg-card-analyzer --help` for the command list or see the
 
 ## How matching works
 
-1. The image is validated and likely title regions are cropped and enhanced.
+1. The image is validated, likely title regions are refined around detected text with padding, and
+   the resulting crops are enhanced. Ambiguous edge detection keeps the established bounded crop.
 2. Tesseract extracts bounded title candidates with the segmentation mode declared by each crop.
 3. All plausible OCR regions and lines are fuzzy-matched against the local card-name index;
    unambiguous individual face names resolve back to their canonical compound card name.
@@ -110,8 +111,9 @@ Run `mtg-card-analyzer --help` for the command list or see the
    finally supplemental rules text, avoiding the extra OCR work for ordinary successful scans.
 5. Candidate printings come from every page of the Scryfall print search and retain exact print IDs,
    set codes, collector numbers, and treatment metadata while cached or downloaded PDQ fingerprints
-   rank them. A high-confidence set-symbol result wins; an inconclusive symbol comparison is retried
-   with the full card instead of forcing a weak print guess.
+   rank them. Set-symbol crops search the type-line neighborhood, isolate the icon from frame rules,
+   and retain an even buffer. A high-confidence result wins; an inconclusive symbol comparison is
+   retried with the full card instead of forcing a weak print guess.
 6. Results are printed and, only when enabled, a single confirmed printing is written to the
    collection backend. A lone API candidate is not confirmation; unverified or multiple exact-print
    candidates are saved to needs-attention instead.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,8 +4,26 @@ const site = process.env.SITE_URL;
 const configuredBase = process.env.SITE_BASE ?? "/";
 const base = configuredBase.endsWith("/") ? configuredBase : `${configuredBase}/`;
 
+function localCropReviewIntegration() {
+    return {
+        name: "local-crop-review",
+        hooks: {
+            "astro:config:setup": ({ command, injectRoute }) => {
+                if (command !== "dev") return;
+                injectRoute({
+                    pattern: "/crop-review",
+                    entrypoint: new URL("./src/tools/crop-review.astro", import.meta.url)
+                });
+            }
+        }
+    };
+}
+
 export default defineConfig({
     output: "static",
     site,
-    base
+    base,
+    integrations: [localCropReviewIntegration()]
 });
+
+export { localCropReviewIntegration };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,8 @@ matching and an optional legacy MySQL backend.
 1. `index.mjs` parses the command and resolves configuration.
 2. `src/image-processing/` reads the local file once into a capped buffer, allowlists its magic
    signature, validates dimensions and decoded pixels, and only then passes those same bytes to
-   Jimp to produce bounded hard title crops.
+   Jimp. A bounded edge-analysis image refines expected title windows around detected text while
+   preserving padding; ambiguous analysis falls back to the original percentage window.
 3. `src/image-analysis/` runs Tesseract with each crop's declared segmentation mode and preserves
    plausible region and line candidates.
 4. `src/fuzzy-matching/` ranks all title candidates from the local card-name index and maps
@@ -23,6 +24,11 @@ matching and an optional legacy MySQL backend.
 
 The image, network, filesystem, and database boundaries remain outside the pure name-normalization
 and matching decisions so those decisions can be tested deterministically.
+
+Set-symbol extraction searches a bounded area around the expected type-line position. Local color
+contrast finds compact symbol-like components, long frame rules are suppressed, and the selected
+icon is centered in a square crop with padding. If no credible component is found, set-symbol
+hashing is marked low-confidence so matching can use the existing full-card fallback.
 
 Local image input is capped at 32 MiB, 12,000 pixels per axis, and 40 megapixels. JPEG decoding also
 uses a 256 MiB decoder allocation ceiling. Remote set-symbol images are limited to the approved
@@ -71,7 +77,8 @@ rather than confirmed.
 
 The hash cache keys refreshed rows by Scryfall print ID (falling back to set code, collector number,
 and language) plus hash mode and hash. Legacy set-only rows remain usable as unverified hints; they
-cannot confirm an exact printing.
+cannot confirm an exact printing. Set-symbol hash modes include a crop-algorithm version, so a crop
+geometry change skips incompatible cached fingerprints and refreshes them through the remote path.
 
 The processor owns one bounded OCR work directory per scan and removes it in a `finally` path on
 success and failure. Set-symbol hashing follows the same ownership rule for its local and remote

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -294,7 +294,7 @@ Minimal example:
                 "maxPrintCandidates": 1,
                 "minPrintScore": 0.75,
                 "minOcrConfidence": 50,
-                "maxRuntimeMs": 30000,
+                "maxRuntimeMs": 35000,
                 "metadata": {
                     "typeLine": "Enchantment — Aura"
                 }

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -96,6 +96,39 @@ the default bounded parallelism for the ordinary regression gate.
 
 The generated `artifacts/regression` directory is ignored by Git.
 
+## Review crop geometry visually
+
+Use the local crop-review workbench when refining OCR or set-symbol crop boundaries. It applies
+each regression fixture's deterministic transform and generates every production crop type without
+running OCR, Scryfall, a database, or any network request:
+
+```bash
+# Generate all enabled regression fixtures, then start the local Astro site
+pnpm crop-review
+
+# Or generate a smaller batch before running `pnpm site:dev`
+pnpm crop-review:generate --case pacifism-clean-scan --case platinum-angel-clean-scan
+pnpm crop-review:generate --quality cropping --region name --region set-symbol
+```
+
+Open `/crop-review/` in the local site. Select a crop to show its exact source-image bounds, mark
+individual crops as **Good** or **Needs attention**, and select every applicable observation chip.
+Progress is stored in the browser for that generated dataset. Existing free-text notes from earlier
+reviews remain preserved and visible. Use **Export review JSON** to share or retain the decisions;
+the same file can be imported into another browser viewing the identical dataset.
+
+The reviewer is intentionally local-only. Astro registers `/crop-review/` during the development
+server started by `pnpm crop-review`, but excludes it from `pnpm site:build` and the GitHub Pages
+route. Its generated source images and crops remain ignored by Git, and the Pages workflow fails
+closed if any `dist/crop-review` content is present in its clean build artifact.
+
+Generation replaces `public/crop-review/generated/`, which is ignored by Git. Review decisions are
+keyed to checksums of the generated crops: regenerating identical crops retains the active review,
+while changed crop pixels receive a fresh dataset identity so stale approvals are not reused. The
+default command generates all enabled fixtures and every fallback crop, so use repeatable `--case`,
+`--quality`, or `--region` filters for faster focused iterations. Add `--include-disabled` when
+inspecting pending fixtures.
+
 ## OCR model candidates
 
 The default run loads `test/regression/ocr-models/manifest.json` and verifies the bundled control

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
         "site:dev": "astro dev",
         "site:build": "astro build",
         "site:preview": "astro preview",
+        "crop-review": "pnpm crop-review:generate && astro dev",
+        "crop-review:generate": "node scripts/generate-crop-review.mjs",
         "test": "mocha \"./test/**/*.spec.mjs\"",
         "test:package": "node scripts/package-smoke.mjs",
         "test:regression": "node scripts/run-regression.mjs",

--- a/scripts/generate-crop-review.mjs
+++ b/scripts/generate-crop-review.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Command } from "commander";
+import { JimpMime } from "jimp";
+import { prepareOcrVariants } from "../src/image-processing/ocr-preprocessing.mjs";
+import smartCrop from "../src/image-processing/smart-crop.mjs";
+import { readImage } from "../src/image-processing/util.mjs";
+import { materializeFixture } from "../src/regression/image-fixture.mjs";
+import { QUALITY_LEVELS, loadManifest } from "../src/regression/manifest.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const defaultManifest = path.join(repositoryRoot, "test/regression/fixtures/manifest.json");
+const defaultOutput = path.join(repositoryRoot, "public/crop-review/generated");
+const cropTypes = ["name", "soft-name", "rotated-name", "type", "rules-name", "set-symbol"];
+const maximumCases = 500;
+const ownershipMarkerFile = ".mtg-crop-review-generated";
+const ownershipMarkerContent = "MTG Card Analyzer crop-review output\n";
+const quietLogger = Object.freeze({ info() {}, warn() {}, error() {} });
+
+class GenerationInterruptedError extends Error {
+    constructor(signal) {
+        super(`Crop review generation interrupted by ${signal}`);
+        this.name = "GenerationInterruptedError";
+        this.signal = signal;
+    }
+}
+
+function collect(value, previous) {
+    return previous.concat(value);
+}
+
+function buildProgram() {
+    return new Command()
+        .name("generate-crop-review")
+        .description("Generate local crop-review assets from deterministic regression fixtures")
+        .option("-m, --manifest <path>", "regression fixture manifest", defaultManifest)
+        .option("-o, --output <directory>", "generated public asset directory", defaultOutput)
+        .option("-c, --case <id>", "fixture ID to include (repeatable)", collect, [])
+        .option(
+            "-q, --quality <level>",
+            `quality level to include (repeatable: ${QUALITY_LEVELS.join(", ")})`,
+            collect,
+            []
+        )
+        .option(
+            "-r, --region <type>",
+            `crop type to generate (repeatable: ${cropTypes.join(", ")})`,
+            collect,
+            []
+        )
+        .option("--include-disabled", "include disabled regression fixtures", false);
+}
+
+function unique(values) {
+    return [...new Set(values)];
+}
+
+function validateFilters(options) {
+    const unknownQualities = unique(options.qualities || []).filter(
+        (quality) => !QUALITY_LEVELS.includes(quality)
+    );
+    if (unknownQualities.length > 0) {
+        throw new Error(`Unknown quality level(s): ${unknownQualities.join(", ")}`);
+    }
+    const unknownRegions = unique(options.regions || []).filter(
+        (region) => !cropTypes.includes(region)
+    );
+    if (unknownRegions.length > 0) {
+        throw new Error(`Unknown crop type(s): ${unknownRegions.join(", ")}`);
+    }
+}
+
+function selectReviewCases(manifest, options = {}) {
+    validateFilters(options);
+    const requestedIds = unique(options.caseIds || []);
+    const requestedQualities = new Set(options.qualities || []);
+    const casesById = new Map(manifest.cases.map((fixture) => [fixture.id, fixture]));
+    const unknownIds = requestedIds.filter((caseId) => !casesById.has(caseId));
+    if (unknownIds.length > 0) {
+        throw new Error(`Unknown regression fixture(s): ${unknownIds.join(", ")}`);
+    }
+
+    const sourceCases =
+        requestedIds.length > 0
+            ? requestedIds.map((caseId) => casesById.get(caseId))
+            : manifest.cases;
+    const fixtures = sourceCases.filter((fixture) => {
+        if (!options.includeDisabled && requestedIds.length === 0 && fixture.enabled === false) {
+            return false;
+        }
+        return requestedQualities.size === 0 || requestedQualities.has(fixture.quality);
+    });
+    if (fixtures.length === 0) {
+        throw new Error("No regression fixtures matched the crop-review filters");
+    }
+    if (fixtures.length > maximumCases) {
+        throw new Error(`Crop review generation is limited to ${maximumCases} fixtures`);
+    }
+    return fixtures;
+}
+
+function safeSegment(value) {
+    const normalized = String(value)
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]+/g, "-")
+        .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "")
+        .slice(0, 80);
+    const suffix = createHash("sha256").update(String(value)).digest("hex").slice(0, 8);
+    return `${normalized || "fixture"}-${suffix}`;
+}
+
+function sha256(value) {
+    return createHash("sha256").update(value).digest("hex");
+}
+
+async function pathExists(target) {
+    try {
+        await access(target);
+        return true;
+    } catch (error) {
+        if (error?.code === "ENOENT") return false;
+        throw error;
+    }
+}
+
+async function assertOutputDirectoryIsReplaceable(outputDirectory) {
+    if (!(await pathExists(outputDirectory)) || outputDirectory === defaultOutput) return;
+
+    let marker;
+    try {
+        marker = await readFile(path.join(outputDirectory, ownershipMarkerFile), "utf8");
+    } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+    }
+    if (marker !== ownershipMarkerContent) {
+        throw new Error(
+            `Refusing to replace output directory not created by crop review: ${outputDirectory}`
+        );
+    }
+}
+
+function publicAssetPath(...segments) {
+    return ["crop-review", "generated", ...segments].join("/");
+}
+
+function cropMetadata(result) {
+    return {
+        sourceRegion: result.region,
+        searchRegion: result.searchRegion,
+        contentDetected: result.contentDetected === true,
+        lowConfidence: result.lowConfidence === true,
+        ...(result.reason ? { reason: result.reason } : {})
+    };
+}
+
+function describeTextCrops(image, type) {
+    if (type === "rotated-name") return new Map();
+    return new Map(
+        smartCrop
+            .getRegionTemplates(type)
+            .map((template) => [
+                template.key,
+                cropMetadata(smartCrop.cropTextRegion(image, template))
+            ])
+    );
+}
+
+async function writeOcrCrops(fixturePath, sourceImage, type, caseDirectory, caseSlug) {
+    const prepared = await prepareOcrVariants(fixturePath, type, { logger: quietLogger });
+    const metadataByRegion = describeTextCrops(sourceImage, type);
+    const crops = [];
+    for (const variant of prepared.variants) {
+        const fileName = `${safeSegment(`${type}-${variant.region}`)}.png`;
+        await writeFile(path.join(caseDirectory, fileName), variant.buffer);
+        crops.push({
+            id: `${type}:${variant.region}`,
+            type,
+            region: variant.region,
+            psm: variant.psm,
+            src: publicAssetPath("cases", caseSlug, fileName),
+            sha256: sha256(variant.buffer),
+            width: variant.image.bitmap.width,
+            height: variant.image.bitmap.height,
+            ...(metadataByRegion.get(variant.region) || {}),
+            sourceUpscaled: prepared.sourceSizing.upscaled,
+            sourceUpscaleFactor: prepared.sourceSizing.upscaleFactor
+        });
+    }
+    return crops;
+}
+
+async function writeSetSymbolCrop(sourceImage, caseDirectory, caseSlug) {
+    const result = smartCrop.cropSetSymbolFromImage(sourceImage);
+    const fileName = `${safeSegment("set-symbol")}.png`;
+    const buffer = await result.image.getBuffer(JimpMime.png);
+    await writeFile(path.join(caseDirectory, fileName), buffer);
+    return {
+        id: "set-symbol:set-symbol",
+        type: "set-symbol",
+        region: "set-symbol",
+        psm: null,
+        src: publicAssetPath("cases", caseSlug, fileName),
+        sha256: sha256(buffer),
+        width: result.image.bitmap.width,
+        height: result.image.bitmap.height,
+        ...cropMetadata(result)
+    };
+}
+
+async function generateCase(fixture, selectedTypes, outputDirectory, workDirectory) {
+    const caseSlug = safeSegment(fixture.id);
+    const caseDirectory = path.join(outputDirectory, "cases", caseSlug);
+    await mkdir(caseDirectory, { recursive: true });
+    const fixturePath = await materializeFixture(fixture, workDirectory);
+    const sourceImage = await readImage(fixturePath);
+    const sourceFileName = "source.png";
+    await sourceImage.write(path.join(caseDirectory, sourceFileName));
+
+    const crops = [];
+    const errors = [];
+    for (const type of selectedTypes) {
+        try {
+            if (type === "set-symbol") {
+                crops.push(await writeSetSymbolCrop(sourceImage, caseDirectory, caseSlug));
+            } else {
+                crops.push(
+                    ...(await writeOcrCrops(
+                        fixturePath,
+                        sourceImage,
+                        type,
+                        caseDirectory,
+                        caseSlug
+                    ))
+                );
+            }
+        } catch (error) {
+            errors.push({ type, message: error?.message || String(error) });
+        }
+    }
+
+    return {
+        id: fixture.id,
+        quality: fixture.quality,
+        enabled: fixture.enabled !== false,
+        blocking: fixture.blocking !== false,
+        expected: {
+            name: fixture.expected.name,
+            set: fixture.expected.set,
+            collectorNumber: fixture.expected.collectorNumber,
+            ...(fixture.expected.metadata || {})
+        },
+        transform: fixture.transform,
+        source: {
+            src: publicAssetPath("cases", caseSlug, sourceFileName),
+            width: sourceImage.bitmap.width,
+            height: sourceImage.bitmap.height
+        },
+        crops,
+        errors
+    };
+}
+
+function datasetId(manifest, cases, selectedTypes) {
+    const identity = {
+        version: manifest.version,
+        cropTypes: selectedTypes,
+        setSymbolHashMode: smartCrop.setSymbolHashMode,
+        cases: cases.map((fixture) => ({
+            id: fixture.id,
+            crops: fixture.crops.map((crop) => ({ id: crop.id, sha256: crop.sha256 })),
+            errors: fixture.errors
+        }))
+    };
+    return createHash("sha256").update(JSON.stringify(identity)).digest("hex").slice(0, 16);
+}
+
+async function generateCropReview(manifest, options = {}) {
+    const fixtures = selectReviewCases(manifest, options);
+    const selectedTypes = unique(options.regions?.length ? options.regions : cropTypes);
+    const outputDirectory = path.resolve(options.outputDirectory || defaultOutput);
+    const parentDirectory = path.dirname(outputDirectory);
+    const temporaryDirectory = `${outputDirectory}.tmp-${process.pid}-${Date.now()}`;
+    const workDirectory = path.join(temporaryDirectory, ".work");
+    const now = options.now || (() => new Date());
+    const onProgress = options.onProgress || (() => {});
+    let interruptedBy;
+    const recordInterruption = (signal) => {
+        interruptedBy ||= signal;
+    };
+    const recordSigint = () => recordInterruption("SIGINT");
+    const recordSigterm = () => recordInterruption("SIGTERM");
+    const assertNotInterrupted = () => {
+        if (interruptedBy) throw new GenerationInterruptedError(interruptedBy);
+    };
+    try {
+        await assertOutputDirectoryIsReplaceable(outputDirectory);
+        await mkdir(parentDirectory, { recursive: true });
+        await mkdir(workDirectory, { recursive: true });
+        process.once("SIGINT", recordSigint);
+        process.once("SIGTERM", recordSigterm);
+        const cases = [];
+        for (let index = 0; index < fixtures.length; index++) {
+            assertNotInterrupted();
+            const fixture = fixtures[index];
+            onProgress({ index: index + 1, total: fixtures.length, fixture });
+            cases.push(
+                await generateCase(fixture, selectedTypes, temporaryDirectory, workDirectory)
+            );
+            assertNotInterrupted();
+        }
+        await rm(workDirectory, { recursive: true, force: true });
+        const report = {
+            version: 1,
+            datasetId: datasetId(manifest, cases, selectedTypes),
+            generatedAt: now().toISOString(),
+            sourceManifest: path.relative(repositoryRoot, manifest.path).split(path.sep).join("/"),
+            setSymbolHashMode: smartCrop.setSymbolHashMode,
+            cropTypes: selectedTypes,
+            summary: {
+                cases: cases.length,
+                crops: cases.reduce((total, fixture) => total + fixture.crops.length, 0),
+                errors: cases.reduce((total, fixture) => total + fixture.errors.length, 0)
+            },
+            cases
+        };
+        await writeFile(
+            path.join(temporaryDirectory, "review-data.json"),
+            `${JSON.stringify(report, null, 2)}\n`,
+            "utf8"
+        );
+        await writeFile(
+            path.join(temporaryDirectory, ownershipMarkerFile),
+            ownershipMarkerContent,
+            "utf8"
+        );
+        await rm(outputDirectory, { recursive: true, force: true });
+        await rename(temporaryDirectory, outputDirectory);
+        return report;
+    } catch (error) {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+        throw error;
+    } finally {
+        process.off("SIGINT", recordSigint);
+        process.off("SIGTERM", recordSigterm);
+    }
+}
+
+async function main(argv = process.argv, overrides = {}) {
+    const {
+        loadManifest: loadFixtureManifest = loadManifest,
+        generateCropReview: generate = generateCropReview,
+        writeLine = console.log
+    } = overrides;
+    const options = buildProgram().parse(argv).opts();
+    validateFilters({ qualities: options.quality, regions: options.region });
+    const manifest = await loadFixtureManifest(options.manifest);
+    const report = await generate(manifest, {
+        outputDirectory: options.output,
+        caseIds: options.case,
+        qualities: options.quality,
+        regions: options.region,
+        includeDisabled: options.includeDisabled,
+        onProgress: ({ index, total, fixture }) => writeLine(`[${index}/${total}] ${fixture.id}`)
+    });
+    writeLine(
+        `Crop review: ${report.summary.cases} fixture(s), ${report.summary.crops} crop(s), ${report.summary.errors} error(s)`
+    );
+    writeLine(`Review data: ${path.resolve(options.output, "review-data.json")}`);
+    return report;
+}
+
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error(error?.stack || error);
+        process.exitCode = error instanceof GenerationInterruptedError ? 130 : 1;
+    });
+}
+
+export {
+    buildProgram,
+    cropTypes,
+    GenerationInterruptedError,
+    generateCropReview,
+    main,
+    maximumCases,
+    ownershipMarkerContent,
+    ownershipMarkerFile,
+    safeSegment,
+    selectReviewCases,
+    validateFilters
+};

--- a/src/export-processor/process-hashes.mjs
+++ b/src/export-processor/process-hashes.mjs
@@ -17,6 +17,12 @@ const config = {
     }
 };
 
+const setSymbolHashModes = new Set(["set-symbol", imageProcessing.smartCrop.setSymbolHashMode]);
+
+function isSetSymbolHashMode(hashMode) {
+    return setSymbolHashModes.has(hashMode);
+}
+
 const defaultDependencies = {
     CardHashes: storage.hashes,
     Hash: imageHashing.Hash,
@@ -33,7 +39,11 @@ const schema = joi.object().keys({
     queryingEnabled: joi.boolean().optional().default(false),
     ignoreNoDbMatch: joi.boolean().optional().default(false),
     allowRemoteBestGuess: joi.boolean().optional().default(false),
-    hashMode: joi.string().optional().valid("full-card", "set-symbol").default("full-card")
+    hashMode: joi
+        .string()
+        .optional()
+        .valid("full-card", ...setSymbolHashModes)
+        .default("full-card")
 });
 
 class ProcessHashes {
@@ -214,7 +224,7 @@ class ProcessHashes {
     }
 
     async _withRemoteHashDirectory() {
-        if (this.hashMode !== "set-symbol") {
+        if (!isSetSymbolHashMode(this.hashMode)) {
             return {
                 tempDirectory: "",
                 done: () => {}
@@ -238,7 +248,7 @@ class ProcessHashes {
     }
 
     async _hashRemoteForComparison(url, tempDirectory) {
-        if (this.hashMode !== "set-symbol") {
+        if (!isSetSymbolHashMode(this.hashMode)) {
             return this._hashImage(url);
         }
         try {

--- a/src/image-processing/ocr-preprocessing.mjs
+++ b/src/image-processing/ocr-preprocessing.mjs
@@ -122,7 +122,7 @@ async function buildRotatedNameVariants(baseImage, options = {}) {
 }
 
 async function cropAndPreprocess(baseImage, template, options = {}) {
-    const { image: cropped } = smartCrop.cropRegion(baseImage, template);
+    const { image: cropped } = smartCrop.cropTextRegion(baseImage, template);
     if (template.mode === "soft-inverted") {
         return buildSoftOcrImage(cropped, true);
     }

--- a/src/image-processing/smart-crop.mjs
+++ b/src/image-processing/smart-crop.mjs
@@ -3,6 +3,10 @@ import path from "node:path";
 import { readImage } from "./util.mjs";
 import { round, clamp } from "../util.mjs";
 
+// Crop geometry is part of a fingerprint's meaning. Bump this value whenever set-symbol
+// normalization changes so cached hashes from incompatible crop algorithms are never compared.
+const setSymbolHashMode = "set-symbol-content-v1";
+
 // Reusable region registry -- the shared "layer" every crop spot plugs into. setSymbol feeds the
 // image-fingerprint path; name/type/rules-name/default feed OCR (region templates, one or more crop
 // candidates per type -- ocr-preprocessing.mjs runs each through its own pixel preprocessing and
@@ -13,6 +17,16 @@ const regions = {
         topPercent: 0.535,
         widthPercent: 0.13,
         heightPercent: 0.1
+    },
+    // The symbol detector searches a wider area than the legacy crop above, then reduces that
+    // search window to the detected icon plus an even buffer. Keeping the expected symbol region
+    // separate gives the detector a stable center to prefer without assuming every frame puts the
+    // icon at exactly the same pixels.
+    setSymbolSearch: {
+        leftPercent: 0.72,
+        topPercent: 0.515,
+        widthPercent: 0.24,
+        heightPercent: 0.14
     },
     name: [
         {
@@ -134,7 +148,13 @@ const config = {
     maxRecoverableUpscaleFactor: 2,
     // Greyscale luminance std-dev (0-255) below this reads as a near-uniform-color crop (solid
     // card border/background instead of a real set-symbol icon).
-    lowConfidenceStdDevThreshold: 10
+    lowConfidenceStdDevThreshold: 10,
+    // Edge detection always runs on a bounded analysis image, even for the maximum accepted input.
+    // The final crop still comes from the original-resolution source.
+    maxEdgeAnalysisWidth: 480,
+    maxEdgeAnalysisHeight: 240,
+    maxEdgeAnalysisPixels: 115_200,
+    minimumEdgeStrength: 18
 };
 
 function assertSourceSizeOk(dimensions) {
@@ -192,6 +212,486 @@ function cropRegion(img, percents) {
     };
 }
 
+function resizeForEdgeAnalysis(img) {
+    const { width, height } = img.bitmap;
+    const scale = Math.min(
+        1,
+        config.maxEdgeAnalysisWidth / width,
+        config.maxEdgeAnalysisHeight / height,
+        Math.sqrt(config.maxEdgeAnalysisPixels / (width * height))
+    );
+    if (scale >= 1) {
+        return img.clone();
+    }
+    return img.clone().resize({
+        w: Math.max(1, round(width * scale)),
+        h: Math.max(1, round(height * scale))
+    });
+}
+
+function percentileFromHistogram(histogram, total, percentile) {
+    const target = Math.max(1, Math.ceil(total * percentile));
+    let seen = 0;
+    for (let value = 0; value < histogram.length; value++) {
+        seen += histogram[value];
+        if (seen >= target) {
+            return value;
+        }
+    }
+    return histogram.length - 1;
+}
+
+/**
+ * Build a bounded high-contrast edge map. Normalizing only the analysis clone makes dim or washed
+ * out lettering detectable without modifying the pixels that are ultimately cropped for OCR/hash.
+ */
+function buildEdgeMap(img) {
+    const analysis = resizeForEdgeAnalysis(img).greyscale().normalize();
+    const { data, width, height } = analysis.bitmap;
+    const strengths = new Uint8Array(width * height);
+    const histogram = new Array(256).fill(0);
+    let nonZero = 0;
+
+    for (let y = 1; y < height - 1; y++) {
+        for (let x = 1; x < width - 1; x++) {
+            const index = y * width + x;
+            const dataIndex = index * 4;
+            const horizontal = Math.abs(data[dataIndex - 4] - data[dataIndex + 4]);
+            const vertical = Math.abs(data[dataIndex - width * 4] - data[dataIndex + width * 4]);
+            const strength = Math.min(255, Math.max(horizontal, vertical));
+            strengths[index] = strength;
+            if (strength > 0) {
+                histogram[strength] += 1;
+                nonZero += 1;
+            }
+        }
+    }
+
+    const adaptiveThreshold = nonZero > 0 ? percentileFromHistogram(histogram, nonZero, 0.72) : 255;
+    const threshold = Math.max(config.minimumEdgeStrength, adaptiveThreshold);
+    const edges = new Uint8Array(width * height);
+    for (let index = 0; index < strengths.length; index++) {
+        edges[index] = strengths[index] >= threshold ? 1 : 0;
+    }
+    return { edges, width, height, threshold };
+}
+
+function buildColorContrastMap(img) {
+    const analysis = resizeForEdgeAnalysis(img);
+    const { data, width, height } = analysis.bitmap;
+    const redHistogram = new Array(256).fill(0);
+    const greenHistogram = new Array(256).fill(0);
+    const blueHistogram = new Array(256).fill(0);
+    const insetX = Math.max(1, round(width * 0.05));
+    const insetY = Math.max(1, round(height * 0.05));
+    let sampled = 0;
+    for (let y = insetY; y < height - insetY; y++) {
+        for (let x = insetX; x < width - insetX; x++) {
+            const dataIndex = (y * width + x) * 4;
+            redHistogram[data[dataIndex]] += 1;
+            greenHistogram[data[dataIndex + 1]] += 1;
+            blueHistogram[data[dataIndex + 2]] += 1;
+            sampled += 1;
+        }
+    }
+    const medianRed = percentileFromHistogram(redHistogram, sampled, 0.5);
+    const medianGreen = percentileFromHistogram(greenHistogram, sampled, 0.5);
+    const medianBlue = percentileFromHistogram(blueHistogram, sampled, 0.5);
+    const distances = new Uint8Array(width * height);
+    const histogram = new Array(256).fill(0);
+    for (let index = 0; index < distances.length; index++) {
+        const dataIndex = index * 4;
+        const distance = Math.min(
+            255,
+            Math.max(
+                Math.abs(data[dataIndex] - medianRed),
+                Math.abs(data[dataIndex + 1] - medianGreen),
+                Math.abs(data[dataIndex + 2] - medianBlue)
+            )
+        );
+        distances[index] = distance;
+        histogram[distance] += 1;
+    }
+    const threshold = Math.max(24, percentileFromHistogram(histogram, distances.length, 0.78));
+    const edges = new Uint8Array(distances.length);
+    for (let index = 0; index < distances.length; index++) {
+        edges[index] = distances[index] >= threshold ? 1 : 0;
+    }
+    return { edges, width, height, threshold };
+}
+
+function groupActiveIndexes(values, minimum, maxGap = 0) {
+    const groups = [];
+    let start = -1;
+    let lastActive = -1;
+    let score = 0;
+
+    for (let index = 0; index < values.length; index++) {
+        if (values[index] >= minimum) {
+            if (start < 0) {
+                start = index;
+                score = 0;
+            }
+            lastActive = index;
+            score += values[index];
+            continue;
+        }
+        if (start >= 0 && index - lastActive > maxGap) {
+            groups.push({ start, end: lastActive, score });
+            start = -1;
+            lastActive = -1;
+            score = 0;
+        }
+    }
+    if (start >= 0) {
+        groups.push({ start, end: lastActive, score });
+    }
+    return groups;
+}
+
+function scaleBounds(bounds, analysisDimensions, sourceDimensions) {
+    const scaleX = sourceDimensions.width / analysisDimensions.width;
+    const scaleY = sourceDimensions.height / analysisDimensions.height;
+    const left = clamp(Math.floor(bounds.left * scaleX), 0, sourceDimensions.width - 1);
+    const top = clamp(Math.floor(bounds.top * scaleY), 0, sourceDimensions.height - 1);
+    const right = clamp(
+        Math.ceil((bounds.right + 1) * scaleX) - 1,
+        left,
+        sourceDimensions.width - 1
+    );
+    const bottom = clamp(
+        Math.ceil((bounds.bottom + 1) * scaleY) - 1,
+        top,
+        sourceDimensions.height - 1
+    );
+    return { left, top, right, bottom };
+}
+
+/**
+ * Locate the dominant text row(s) in an expected OCR window. Long frame rules are suppressed by
+ * rejecting rows/columns whose edges cover nearly the whole window. Ambiguous windows return null
+ * so the caller can preserve the established percentage crop.
+ */
+function detectTextContentBounds(img) {
+    const edgeMap = buildEdgeMap(img);
+    const { edges, width, height } = edgeMap;
+    if (width < 3 || height < 3) {
+        return null;
+    }
+
+    const rowScores = new Array(height).fill(0);
+    for (let y = 1; y < height - 1; y++) {
+        let score = 0;
+        for (let x = 1; x < width - 1; x++) {
+            score += edges[y * width + x];
+        }
+        // Frame/art-box dividers are wide, near-continuous edges rather than glyphs.
+        rowScores[y] = score > width * 0.72 ? 0 : score;
+    }
+
+    const rowGroups = groupActiveIndexes(
+        rowScores,
+        Math.max(2, width * 0.018),
+        Math.max(1, round(height * 0.035))
+    ).filter(
+        (group) =>
+            group.end - group.start + 1 >= Math.max(2, round(height * 0.07)) &&
+            group.end - group.start + 1 <= height * 0.82
+    );
+    if (rowGroups.length === 0) {
+        return null;
+    }
+
+    const centerY = (height - 1) / 2;
+    const selectedRows = rowGroups.reduce((best, candidate) => {
+        const candidateCenter = (candidate.start + candidate.end) / 2;
+        const centerWeight = 1 - (Math.abs(candidateCenter - centerY) / height) * 0.45;
+        const candidateRank = candidate.score * centerWeight;
+        return !best || candidateRank > best.rank ? { ...candidate, rank: candidateRank } : best;
+    }, null);
+
+    const bandHeight = selectedRows.end - selectedRows.start + 1;
+    const columnScores = new Array(width).fill(0);
+    for (let x = 1; x < width - 1; x++) {
+        let score = 0;
+        for (let y = selectedRows.start; y <= selectedRows.end; y++) {
+            score += edges[y * width + x];
+        }
+        columnScores[x] = score > bandHeight * 0.88 ? 0 : score;
+    }
+    const columnGroups = groupActiveIndexes(
+        columnScores,
+        Math.max(1, bandHeight * 0.055),
+        Math.max(1, round(width * 0.012))
+    );
+    if (columnGroups.length === 0) {
+        return null;
+    }
+
+    const firstColumn = columnGroups[0].start;
+    const lastColumn = columnGroups[columnGroups.length - 1].end;
+    if (
+        lastColumn - firstColumn + 1 < Math.max(3, width * 0.04) ||
+        selectedRows.score < width * 0.08
+    ) {
+        return null;
+    }
+
+    return scaleBounds(
+        {
+            left: firstColumn,
+            top: selectedRows.start,
+            right: lastColumn,
+            bottom: selectedRows.end
+        },
+        edgeMap,
+        img.bitmap
+    );
+}
+
+function dilateEdges(edges, width, height, radiusX, radiusY) {
+    const dilated = new Uint8Array(edges.length);
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            if (!edges[y * width + x]) continue;
+            for (let dy = -radiusY; dy <= radiusY; dy++) {
+                const targetY = y + dy;
+                if (targetY < 0 || targetY >= height) continue;
+                for (let dx = -radiusX; dx <= radiusX; dx++) {
+                    const targetX = x + dx;
+                    if (targetX >= 0 && targetX < width) {
+                        dilated[targetY * width + targetX] = 1;
+                    }
+                }
+            }
+        }
+    }
+    return dilated;
+}
+
+function findEdgeComponents(edgeMap) {
+    const { width, height } = edgeMap;
+    const edges = edgeMap.edges.slice();
+    // A set symbol may overlap a frame rule in the raw search window. Remove only near-continuous
+    // rows/columns before component grouping; the remaining outline still encloses the icon while
+    // the long rule can no longer pull the component out to the window edges.
+    for (let y = 0; y < height; y++) {
+        let active = 0;
+        for (let x = 0; x < width; x++) active += edges[y * width + x];
+        if (active > width * 0.58) {
+            for (let x = 0; x < width; x++) edges[y * width + x] = 0;
+        }
+    }
+    for (let x = 0; x < width; x++) {
+        let active = 0;
+        for (let y = 0; y < height; y++) active += edges[y * width + x];
+        if (active > height * 0.72) {
+            for (let y = 0; y < height; y++) edges[y * width + x] = 0;
+        }
+    }
+    const connected = dilateEdges(
+        edges,
+        width,
+        height,
+        Math.max(1, round(width * 0.008)),
+        Math.max(1, round(height * 0.008))
+    );
+    const visited = new Uint8Array(connected.length);
+    const components = [];
+
+    for (let start = 0; start < connected.length; start++) {
+        if (!connected[start] || visited[start]) continue;
+        const queue = [start];
+        visited[start] = 1;
+        let cursor = 0;
+        let left = start % width;
+        let right = left;
+        let top = Math.floor(start / width);
+        let bottom = top;
+        let area = 0;
+        while (cursor < queue.length) {
+            const index = queue[cursor++];
+            const x = index % width;
+            const y = Math.floor(index / width);
+            left = Math.min(left, x);
+            right = Math.max(right, x);
+            top = Math.min(top, y);
+            bottom = Math.max(bottom, y);
+            area += 1;
+            for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    if (dx === 0 && dy === 0) continue;
+                    const nextX = x + dx;
+                    const nextY = y + dy;
+                    if (nextX < 0 || nextX >= width || nextY < 0 || nextY >= height) continue;
+                    const next = nextY * width + nextX;
+                    if (connected[next] && !visited[next]) {
+                        visited[next] = 1;
+                        queue.push(next);
+                    }
+                }
+            }
+        }
+        components.push({ left, right, top, bottom, area });
+    }
+    return components;
+}
+
+/**
+ * Locate a compact symbol-like edge component near the established set-symbol position. The
+ * proximity preference lets older/newer frame offsets move naturally while rejecting type-line
+ * rules and unrelated artwork elsewhere in the wider search window.
+ */
+function detectSymbolContentBounds(img, expectedCenter = { x: 0.5, y: 0.5 }) {
+    const edgeMap = buildColorContrastMap(img);
+    const { width, height } = edgeMap;
+    const components = findEdgeComponents(edgeMap).filter((component) => {
+        const componentWidth = component.right - component.left + 1;
+        const componentHeight = component.bottom - component.top + 1;
+        const aspectRatio = componentWidth / componentHeight;
+        return (
+            componentWidth >= Math.max(6, width * 0.025) &&
+            componentHeight >= Math.max(6, height * 0.025) &&
+            componentWidth <= width * 0.58 &&
+            componentHeight <= height * 0.58 &&
+            aspectRatio >= 0.6 &&
+            aspectRatio <= 1.9
+        );
+    });
+    if (components.length === 0) {
+        return null;
+    }
+
+    const targetX = expectedCenter.x * width;
+    const targetY = expectedCenter.y * height;
+    const ranked = components
+        .map((component) => {
+            const componentWidth = component.right - component.left + 1;
+            const componentHeight = component.bottom - component.top + 1;
+            const centerX = (component.left + component.right) / 2;
+            const centerY = (component.top + component.bottom) / 2;
+            const distance = Math.hypot((centerX - targetX) / width, (centerY - targetY) / height);
+            const proximity = Math.max(0, 1 - distance / 0.42);
+            const shape = Math.max(0, 1 - Math.abs(Math.log(componentWidth / componentHeight)));
+            const fill = Math.min(1, component.area / (componentWidth * componentHeight * 0.55));
+            return { ...component, rank: proximity * 4 + shape + fill };
+        })
+        .sort((left, right) => right.rank - left.rank);
+    const selected = ranked[0];
+    if (selected.rank < 2.2) {
+        return null;
+    }
+    return scaleBounds(selected, edgeMap, img.bitmap);
+}
+
+function expandBounds(bounds, sourceDimensions, options = {}) {
+    const contentWidth = bounds.right - bounds.left + 1;
+    const contentHeight = bounds.bottom - bounds.top + 1;
+    const paddingX = Math.max(options.minimumPadding || 2, round(contentWidth * options.paddingX));
+    const paddingY = Math.max(options.minimumPadding || 2, round(contentHeight * options.paddingY));
+    let left = bounds.left - paddingX;
+    let right = bounds.right + paddingX;
+    let top = bounds.top - paddingY;
+    let bottom = bounds.bottom + paddingY;
+
+    if (options.square) {
+        const size = Math.max(right - left + 1, bottom - top + 1);
+        const centerX = (left + right) / 2;
+        const centerY = (top + bottom) / 2;
+        left = Math.floor(centerX - size / 2);
+        right = left + size - 1;
+        top = Math.floor(centerY - size / 2);
+        bottom = top + size - 1;
+    }
+
+    // Shift a padded crop back inside the source instead of clipping one side's buffer whenever
+    // there is room on the opposite side.
+    if (left < 0) {
+        right -= left;
+        left = 0;
+    }
+    if (top < 0) {
+        bottom -= top;
+        top = 0;
+    }
+    if (right >= sourceDimensions.width) {
+        left -= right - sourceDimensions.width + 1;
+        right = sourceDimensions.width - 1;
+    }
+    if (bottom >= sourceDimensions.height) {
+        top -= bottom - sourceDimensions.height + 1;
+        bottom = sourceDimensions.height - 1;
+    }
+
+    left = clamp(left, 0, sourceDimensions.width - 1);
+    right = clamp(right, left, sourceDimensions.width - 1);
+    top = clamp(top, 0, sourceDimensions.height - 1);
+    bottom = clamp(bottom, top, sourceDimensions.height - 1);
+    return { left, top, right, bottom };
+}
+
+function cropDetectedBounds(img, searchRegion, localBounds, options) {
+    const globalBounds = {
+        left: searchRegion.left + localBounds.left,
+        top: searchRegion.top + localBounds.top,
+        right: searchRegion.left + localBounds.right,
+        bottom: searchRegion.top + localBounds.bottom
+    };
+    const expanded = expandBounds(globalBounds, img.bitmap, options);
+    if (options.constrainToSearch) {
+        expanded.left = Math.max(expanded.left, searchRegion.left);
+        expanded.top = Math.max(expanded.top, searchRegion.top);
+        expanded.right = Math.min(expanded.right, searchRegion.left + searchRegion.width - 1);
+        expanded.bottom = Math.min(expanded.bottom, searchRegion.top + searchRegion.height - 1);
+    }
+    const region = {
+        left: expanded.left,
+        top: expanded.top,
+        width: expanded.right - expanded.left + 1,
+        height: expanded.bottom - expanded.top + 1
+    };
+    return {
+        image: img
+            .clone()
+            .crop({ x: region.left, y: region.top, w: region.width, h: region.height }),
+        region,
+        searchRegion,
+        contentDetected: true
+    };
+}
+
+/** Crop an OCR search template down to its dominant text, retaining a visible buffer. */
+function cropTextRegion(img, template) {
+    const search = cropRegion(img, template);
+    // A dominant-row crop is appropriate only when Tesseract expects one line. Block and sparse
+    // templates intentionally cover multiple possible rows; narrowing those would hide text that
+    // the fallback exists to recover.
+    if (template.psm && !["line", "raw-line"].includes(template.psm)) {
+        return { ...search, searchRegion: search.region, contentDetected: false };
+    }
+    const bounds = detectTextContentBounds(search.image);
+    if (!bounds) {
+        return { ...search, searchRegion: search.region, contentDetected: false };
+    }
+    // A component touching the analysis boundary may continue outside this template. Refining it
+    // would make an already-tight crop worse, so keep the broader search window for another OCR
+    // variant to evaluate.
+    if (
+        bounds.left <= 1 ||
+        bounds.top <= 1 ||
+        bounds.right >= search.region.width - 2 ||
+        bounds.bottom >= search.region.height - 2
+    ) {
+        return { ...search, searchRegion: search.region, contentDetected: false };
+    }
+    return cropDetectedBounds(img, search.region, bounds, {
+        paddingX: 0.04,
+        paddingY: 0.2,
+        minimumPadding: 3,
+        constrainToSearch: true
+    });
+}
+
 function computeGreyscaleStdDev(img) {
     const grey = img.clone().greyscale();
     const { data } = grey.bitmap;
@@ -229,8 +729,37 @@ function assessConfidence(croppedImg) {
  * have an in-memory image (e.g. remote Scryfall image comparison).
  */
 function cropSetSymbolFromImage(img) {
-    const { image, region } = cropRegion(img, regions.setSymbol);
-    return { image, region, ...assessConfidence(image) };
+    const search = cropRegion(img, regions.setSymbolSearch);
+    const expectedCenter = {
+        x:
+            (regions.setSymbol.leftPercent +
+                regions.setSymbol.widthPercent / 2 -
+                regions.setSymbolSearch.leftPercent) /
+            regions.setSymbolSearch.widthPercent,
+        y:
+            (regions.setSymbol.topPercent +
+                regions.setSymbol.heightPercent / 2 -
+                regions.setSymbolSearch.topPercent) /
+            regions.setSymbolSearch.heightPercent
+    };
+    const bounds = detectSymbolContentBounds(search.image, expectedCenter);
+    if (!bounds) {
+        const legacy = cropRegion(img, regions.setSymbol);
+        return {
+            ...legacy,
+            searchRegion: search.region,
+            contentDetected: false,
+            lowConfidence: true,
+            reason: "set symbol edges were not detected"
+        };
+    }
+    const result = cropDetectedBounds(img, search.region, bounds, {
+        paddingX: 0.2,
+        paddingY: 0.2,
+        minimumPadding: 3,
+        square: true
+    });
+    return { ...result, ...assessConfidence(result.image) };
 }
 
 /**
@@ -253,9 +782,13 @@ async function writeSetSymbolSnippet(imgPath, directory) {
 }
 
 export {
+    setSymbolHashMode,
     regions,
     getRegionTemplates,
     cropRegion,
+    detectTextContentBounds,
+    detectSymbolContentBounds,
+    cropTextRegion,
     computeGreyscaleStdDev,
     assessConfidence,
     assertSourceSizeOk,
@@ -265,9 +798,13 @@ export {
 };
 
 export default {
+    setSymbolHashMode,
     regions,
     getRegionTemplates,
     cropRegion,
+    detectTextContentBounds,
+    detectSymbolContentBounds,
+    cropTextRegion,
     computeGreyscaleStdDev,
     assessConfidence,
     assertSourceSizeOk,

--- a/src/matcher/matching-processor.mjs
+++ b/src/matcher/matching-processor.mjs
@@ -110,7 +110,7 @@ class MatcherProcessor {
             );
             this.setSymbolImagePath = setSymbolPath;
             const hash = await this.dependencies.hashImage(setSymbolPath);
-            this.hashMode = "set-symbol";
+            this.hashMode = imageProcessing.smartCrop.setSymbolHashMode;
             this.localHash = hash;
         } finally {
             await this._cleanupSetSymbolDirectoryAsync();
@@ -142,14 +142,17 @@ class MatcherProcessor {
         const initialHashMode = this.hashMode || "full-card";
         try {
             const initialMatches = await this._compareCurrentHashesAsync();
-            if (initialMatches.length > 0 || initialHashMode !== "set-symbol") {
+            if (
+                initialMatches.length > 0 ||
+                initialHashMode !== imageProcessing.smartCrop.setSymbolHashMode
+            ) {
                 return initialMatches;
             }
             this.logger.info(
                 `Set-symbol comparison was inconclusive for "${this.name}"; retrying full card`
             );
         } catch (error) {
-            if (initialHashMode !== "set-symbol") {
+            if (initialHashMode !== imageProcessing.smartCrop.setSymbolHashMode) {
                 throw error;
             }
             this.logger.error(

--- a/src/regression/scryfall-fixture-importer.mjs
+++ b/src/regression/scryfall-fixture-importer.mjs
@@ -253,7 +253,7 @@ function fixtureEntries(card, manifestPath, imagePath) {
                 },
                 minNameScore: 0.7,
                 maxPrintCandidates: 1,
-                maxRuntimeMs: 30000
+                maxRuntimeMs: 35000
             }
         }
     };

--- a/src/styles/crop-review.css
+++ b/src/styles/crop-review.css
@@ -1,0 +1,695 @@
+/* Hallmark · genre: modern-minimal · macrostructure: Catalogue · theme: Coral
+ * tone: dense-technical · anchor hue: burnished terracotta · enrichment: none
+ * nav: N9 edge-aligned action bar · footer: none (local testing tool) · studied: no
+ * pre-emit critique: P5 H5 E5 S5 R5 V4 · contrast: pass · slop: pass
+ * honest: pass · chrome: pass · tokens: pass · responsive: pass · icons: pass
+ */
+@import "../../tokens.css";
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+html {
+    min-width: 20rem;
+    background: var(--color-paper-2);
+}
+
+body {
+    margin: 0;
+    color: var(--color-ink-2);
+    font-family: var(--font-body);
+    line-height: 1.4;
+}
+
+button,
+input,
+select,
+textarea {
+    color: inherit;
+    font: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+    border: var(--rule-control) solid var(--color-rule-strong);
+    border-radius: var(--radius-xs);
+    background: var(--color-paper);
+}
+
+button {
+    min-height: var(--control-size);
+    padding: var(--space-xs) var(--space-sm);
+    cursor: pointer;
+    font-weight: 600;
+}
+
+button:hover {
+    border-color: var(--color-accent);
+}
+
+input:hover,
+select:hover,
+textarea:hover {
+    border-color: var(--color-ink-2);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 2px;
+}
+
+button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+    cursor: not-allowed;
+    background: var(--color-paper-2);
+    opacity: 0.55;
+}
+
+button:active:not(:disabled) {
+    transform: translateY(1px);
+}
+
+button[aria-busy="true"] {
+    cursor: progress;
+    opacity: 0.7;
+}
+
+button[data-state="error"],
+input[aria-invalid="true"],
+select[aria-invalid="true"],
+textarea[aria-invalid="true"] {
+    border-color: var(--color-error);
+}
+
+button[data-state="success"],
+input[data-state="success"],
+select[data-state="success"],
+textarea[data-state="success"] {
+    border-color: var(--color-success);
+}
+
+.primary,
+.decision-buttons button[aria-pressed="true"] {
+    border-color: var(--color-accent);
+    background: var(--color-accent);
+    color: var(--color-accent-ink);
+}
+
+.review-header {
+    position: sticky;
+    z-index: var(--z-sticky);
+    top: 0;
+    display: flex;
+    min-height: 4.5rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: var(--space-sm) var(--page-gutter);
+    border-bottom: var(--rule-hair) solid var(--color-rule-strong);
+    background: var(--color-paper);
+}
+
+.review-header h1,
+.review-header p,
+.fixture-nav h2,
+.fixture-nav p,
+.panel-heading h3,
+.panel-heading p,
+.crop-card p,
+.loading-state h2,
+.loading-state p {
+    margin: 0;
+}
+
+.review-header h1 {
+    min-width: 0;
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    line-height: 1;
+    overflow-wrap: anywhere;
+}
+
+.eyebrow,
+.fixture-nav p,
+.fixture-count,
+.field-label,
+.filter-row span,
+.note-field span,
+.crop-labels span,
+.panel-heading > span {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.045em;
+    text-transform: uppercase;
+}
+
+.header-actions,
+.crop-actions,
+.filter-row,
+.decision-buttons {
+    display: flex;
+    gap: var(--space-xs);
+}
+
+.header-actions button,
+.crop-actions button,
+.decision-buttons button,
+.fixture-nav button {
+    white-space: nowrap;
+}
+
+.review-shell {
+    display: grid;
+    min-height: calc(100vh - 4.5rem);
+    grid-template-columns: 19rem minmax(0, 1fr);
+}
+
+.loading-state {
+    grid-column: 1 / -1;
+    align-self: start;
+    max-width: 42rem;
+    margin: var(--space-2xl) auto;
+    padding: var(--space-lg);
+    border: var(--rule-hair) solid var(--color-rule-strong);
+    border-top: 0.3rem solid var(--color-accent);
+    background: var(--color-paper);
+}
+
+.loading-state.is-error {
+    border-top-color: var(--color-error);
+}
+
+.loading-state pre {
+    overflow: auto;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+}
+
+.fixture-sidebar {
+    position: sticky;
+    top: 4.5rem;
+    height: calc(100vh - 4.5rem);
+    overflow: auto;
+    padding: var(--space-md);
+    border-right: var(--rule-hair) solid var(--color-rule-strong);
+    background: var(--color-paper);
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    margin-bottom: var(--space-md);
+    border-top: var(--rule-hair) solid var(--color-rule);
+    border-left: var(--rule-hair) solid var(--color-rule);
+}
+
+.summary-grid div {
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-xs);
+    border-right: var(--rule-hair) solid var(--color-rule);
+    border-bottom: var(--rule-hair) solid var(--color-rule);
+}
+
+.summary-grid strong {
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+}
+
+.summary-grid span {
+    color: var(--color-muted);
+    font-size: var(--text-xs);
+}
+
+.field-label {
+    display: block;
+    margin-bottom: var(--space-2xs);
+}
+
+#fixture-search,
+.filter-row select,
+.crop-actions select {
+    width: 100%;
+    min-height: var(--control-size);
+    padding: var(--space-xs);
+}
+
+.filter-row {
+    margin-top: var(--space-xs);
+}
+
+.filter-row label {
+    flex: 1;
+}
+
+.filter-row span {
+    display: block;
+    margin-bottom: var(--space-2xs);
+}
+
+.fixture-count {
+    margin: var(--space-md) 0 var(--space-xs);
+}
+
+.fixture-list {
+    display: grid;
+    gap: var(--space-3xs);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.fixture-list li {
+    min-width: 0;
+    border: var(--rule-control) solid transparent;
+    border-radius: var(--radius-xs);
+}
+
+.fixture-list li.is-active {
+    border-color: var(--color-accent);
+    background: var(--color-paper-2);
+}
+
+.fixture-list button {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-xs);
+    border: 0;
+    background: transparent;
+    text-align: left;
+}
+
+.fixture-list button:hover {
+    background: var(--color-paper-2);
+}
+
+.fixture-list strong,
+.fixture-list small {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fixture-list small {
+    padding: 0 var(--space-sm) var(--space-xs);
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-weight: 400;
+}
+
+.status-dot {
+    width: 0.7rem;
+    height: 0.7rem;
+    flex: 0 0 auto;
+    border: var(--rule-hair) solid var(--color-rule-strong);
+    border-radius: var(--radius-round);
+}
+
+.status-dot.approved {
+    border-color: var(--color-success);
+    background: var(--color-success);
+}
+
+.status-dot.needs-attention {
+    border-color: var(--color-error);
+    background: var(--color-error);
+}
+
+.status-dot.partial {
+    border-color: var(--color-accent);
+    background: var(--color-accent);
+}
+
+.fixture-workspace {
+    min-width: 0;
+}
+
+.fixture-nav {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-md) var(--space-lg);
+    border-bottom: var(--rule-hair) solid var(--color-rule);
+    background: var(--color-paper);
+}
+
+.fixture-nav h2 {
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    line-height: 1.1;
+}
+
+.workspace-grid {
+    display: grid;
+    grid-template-columns: minmax(18rem, 30rem) minmax(0, 1fr);
+    align-items: start;
+}
+
+.source-panel,
+.crops-panel {
+    min-width: 0;
+    padding: var(--space-lg);
+}
+
+.source-panel {
+    position: sticky;
+    top: 10rem;
+}
+
+.crops-panel {
+    border-left: var(--rule-hair) solid var(--color-rule);
+}
+
+.panel-heading {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+}
+
+.panel-heading h3 {
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+}
+
+.source-stage {
+    position: relative;
+    width: min(100%, 26rem);
+    margin-inline: auto;
+    border: var(--rule-hair) solid var(--color-rule-strong);
+    background: var(--color-graphite);
+}
+
+.source-stage img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.crop-overlay {
+    position: absolute;
+    border: 2px solid var(--color-error);
+    background: color-mix(in oklch, var(--color-error) 16%, transparent);
+    box-shadow: 0 0 0 1px var(--color-error-ink);
+    pointer-events: none;
+}
+
+.source-details {
+    display: grid;
+    gap: var(--space-xs);
+    margin: var(--space-md) 0 0;
+    font-size: var(--text-sm);
+}
+
+.source-details div {
+    display: grid;
+    grid-template-columns: 7rem minmax(0, 1fr);
+    gap: var(--space-xs);
+}
+
+.source-details dt {
+    color: var(--color-muted);
+}
+
+.source-details dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.fixture-errors {
+    margin-top: var(--space-md);
+    padding: var(--space-sm);
+    border: var(--rule-hair) solid var(--color-error);
+    background: color-mix(in oklch, var(--color-error) 7%, var(--color-paper));
+    font-size: var(--text-sm);
+}
+
+.crop-toolbar {
+    align-items: center;
+}
+
+.crop-toolbar p {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+}
+
+.crop-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 18rem), 1fr));
+    gap: var(--space-md);
+}
+
+.crop-card {
+    min-width: 0;
+    border: var(--rule-hair) solid var(--color-rule-strong);
+    background: var(--color-paper);
+    box-shadow: var(--shadow-whisper);
+}
+
+.crop-card.is-selected {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+
+.crop-card[data-status="approved"] {
+    border-color: var(--color-success);
+}
+
+.crop-card[data-status="needs-attention"] {
+    border-color: var(--color-error);
+}
+
+.crop-image-button {
+    display: grid;
+    width: 100%;
+    min-height: 10rem;
+    place-items: center;
+    overflow: hidden;
+    padding: var(--space-xs);
+    border: 0;
+    border-bottom: var(--rule-hair) solid var(--color-rule);
+    border-radius: 0;
+    background: var(--color-graphite);
+}
+
+.crop-image-button img {
+    display: block;
+    max-width: 100%;
+    max-height: 18rem;
+    object-fit: contain;
+}
+
+.crop-card-body {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+}
+
+.crop-labels {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-xs);
+}
+
+.crop-labels strong {
+    overflow-wrap: anywhere;
+}
+
+.decision-buttons button {
+    flex: 1;
+    min-height: 2.25rem;
+    padding: var(--space-2xs) var(--space-xs);
+    font-size: var(--text-sm);
+}
+
+.mark-attention[aria-pressed="true"] {
+    border-color: var(--color-error) !important;
+    background: var(--color-error) !important;
+}
+
+.observation-field {
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+
+.observation-field legend,
+.legacy-note strong {
+    margin-bottom: var(--space-2xs);
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.045em;
+    text-transform: uppercase;
+}
+
+.observation-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
+}
+
+.observation-chip {
+    min-height: 2rem;
+    padding: var(--space-2xs) var(--space-xs);
+    border-radius: 999px;
+    font-size: var(--text-xs);
+    white-space: nowrap;
+}
+
+.observation-chip[aria-pressed="true"][data-tone="positive"] {
+    border-color: var(--color-success);
+    background: var(--color-success);
+    color: var(--color-success-ink);
+}
+
+.observation-chip[aria-pressed="true"][data-tone="issue"] {
+    border-color: var(--color-error);
+    background: var(--color-error);
+    color: var(--color-error-ink);
+}
+
+.legacy-note {
+    display: grid;
+    gap: var(--space-2xs);
+    margin: 0;
+    padding: var(--space-xs);
+    border: var(--rule-hair) solid var(--color-rule);
+    background: var(--color-paper-2);
+    font-size: var(--text-sm);
+}
+
+.legacy-note span {
+    overflow-wrap: anywhere;
+}
+
+.crop-diagnostic {
+    min-height: 1.1rem;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    overflow-wrap: anywhere;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
+@media (max-width: 68rem) {
+    .workspace-grid {
+        grid-template-columns: 21rem minmax(0, 1fr);
+    }
+}
+
+@media (max-width: 52rem) {
+    .review-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .fixture-sidebar,
+    .source-panel {
+        position: static;
+        height: auto;
+    }
+
+    .fixture-sidebar {
+        border-right: 0;
+        border-bottom: var(--rule-hair) solid var(--color-rule-strong);
+    }
+
+    .fixture-list {
+        max-height: 16rem;
+        overflow: auto;
+    }
+
+    .workspace-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .crops-panel {
+        border-top: var(--rule-hair) solid var(--color-rule);
+        border-left: 0;
+    }
+}
+
+@media (max-width: 32rem) {
+    .review-header,
+    .header-actions,
+    .crop-toolbar,
+    .crop-actions,
+    .filter-row {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .review-header {
+        position: static;
+    }
+
+    .header-actions button,
+    .crop-actions > * {
+        width: 100%;
+    }
+
+    .fixture-nav,
+    .source-panel,
+    .crops-panel {
+        padding: var(--space-md);
+    }
+
+    .fixture-nav {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+    }
+
+    .fixture-nav h2 {
+        font-size: var(--text-md);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+    }
+}

--- a/src/tools/crop-review.astro
+++ b/src/tools/crop-review.astro
@@ -1,0 +1,626 @@
+---
+// This page is registered only by the local development integration in astro.config.mjs.
+import "../styles/crop-review.css";
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex, nofollow" />
+        <link rel="icon" href={`${baseUrl}favicon.svg`} type="image/svg+xml" />
+        <title>Crop review · MTG Card Analyzer</title>
+    </head>
+    <body>
+        <header class="review-header">
+            <div>
+                <p class="eyebrow">LOCAL TEST TOOL</p>
+                <h1>Crop review</h1>
+            </div>
+            <div class="header-actions">
+                <button id="import-button" type="button">Import review</button>
+                <input id="import-file" type="file" accept="application/json" hidden />
+                <button id="export-button" class="primary" type="button">Export review JSON</button>
+            </div>
+        </header>
+
+        <main class="review-shell" id="review-app" aria-live="polite">
+            <section class="loading-state" id="loading-state">
+                <h2>Loading generated crops…</h2>
+                <p>If generation has not run yet, use <code>pnpm crop-review:generate</code>.</p>
+            </section>
+
+            <aside class="fixture-sidebar" id="fixture-sidebar" hidden>
+                <div class="summary-grid" id="summary-grid"></div>
+                <label class="field-label" for="fixture-search">Find fixture</label>
+                <input id="fixture-search" type="search" placeholder="Card, ID, set…" />
+                <div class="filter-row">
+                    <label>
+                        <span>Status</span>
+                        <select id="status-filter">
+                            <option value="all">All</option>
+                            <option value="needs-attention">Needs attention</option>
+                            <option value="partial">In progress</option>
+                            <option value="approved">Approved</option>
+                            <option value="unreviewed">Unreviewed</option>
+                        </select>
+                    </label>
+                    <label>
+                        <span>Quality</span>
+                        <select id="quality-filter"><option value="all">All</option></select>
+                    </label>
+                </div>
+                <p class="fixture-count" id="fixture-count"></p>
+                <ol class="fixture-list" id="fixture-list"></ol>
+            </aside>
+
+            <section class="fixture-workspace" id="fixture-workspace" hidden>
+                <nav class="fixture-nav" aria-label="Fixture navigation">
+                    <button id="previous-fixture" type="button" aria-label="Previous fixture">←</button>
+                    <div>
+                        <p id="fixture-position"></p>
+                        <h2 id="fixture-title"></h2>
+                        <p id="fixture-meta"></p>
+                    </div>
+                    <button id="next-fixture" type="button" aria-label="Next fixture">→</button>
+                </nav>
+
+                <div class="workspace-grid">
+                    <section class="source-panel" aria-labelledby="source-heading">
+                        <div class="panel-heading">
+                            <h3 id="source-heading">Fixture source</h3>
+                            <span id="source-size"></span>
+                        </div>
+                        <div class="source-stage" id="source-stage">
+                            <img id="source-image" alt="" />
+                            <div class="crop-overlay" id="crop-overlay" hidden></div>
+                        </div>
+                        <dl class="source-details" id="source-details"></dl>
+                        <div class="fixture-errors" id="fixture-errors" hidden></div>
+                    </section>
+
+                    <section class="crops-panel" aria-labelledby="crops-heading">
+                        <div class="panel-heading crop-toolbar">
+                            <div>
+                                <h3 id="crops-heading">Production crops</h3>
+                                <p id="crop-progress"></p>
+                            </div>
+                            <div class="crop-actions">
+                                <label>
+                                    <span class="visually-hidden">Crop type</span>
+                                    <select id="region-filter"><option value="all">All crop types</option></select>
+                                </label>
+                                <button id="approve-visible" type="button">Approve visible</button>
+                            </div>
+                        </div>
+                        <div class="crop-grid" id="crop-grid"></div>
+                    </section>
+                </div>
+            </section>
+        </main>
+
+        <template id="crop-template">
+            <article class="crop-card">
+                <button class="crop-image-button" type="button">
+                    <img alt="" loading="lazy" />
+                </button>
+                <div class="crop-card-body">
+                    <div class="crop-labels">
+                        <strong></strong>
+                        <span></span>
+                    </div>
+                    <div class="decision-buttons" role="group" aria-label="Crop decision">
+                        <button class="mark-good" type="button">Good</button>
+                        <button class="mark-attention" type="button">Needs attention</button>
+                    </div>
+                    <fieldset class="observation-field">
+                        <legend>Observations</legend>
+                        <div class="observation-chips"></div>
+                    </fieldset>
+                    <p class="legacy-note" hidden>
+                        <strong>Previous note</strong>
+                        <span></span>
+                    </p>
+                    <p class="crop-diagnostic"></p>
+                </div>
+            </article>
+        </template>
+
+        <script define:vars={{ baseUrl }}>
+            const dataUrl = `${baseUrl}crop-review/generated/review-data.json`;
+            const observationOptions = Object.freeze([
+                { id: "clear-text", label: "Clear text", tone: "positive" },
+                { id: "has-artifacting", label: "Has artifacting", tone: "issue" },
+                { id: "text-blurry", label: "Text blurry", tone: "issue" },
+                {
+                    id: "too-much-height",
+                    label: "Too much height (extra space)",
+                    tone: "issue"
+                },
+                {
+                    id: "too-much-width",
+                    label: "Too much width (extra space)",
+                    tone: "issue"
+                },
+                { id: "cutting-text-off", label: "Cutting text off", tone: "issue" },
+                { id: "off-center", label: "Off-center", tone: "issue" },
+                { id: "low-contrast", label: "Low contrast", tone: "issue" },
+                { id: "frame-included", label: "Background/frame included", tone: "issue" },
+                { id: "buffer-too-tight", label: "Buffer too tight", tone: "issue" },
+                { id: "wrong-region", label: "Wrong region", tone: "issue" },
+                { id: "set-icon-incomplete", label: "Set icon incomplete", tone: "issue" }
+            ]);
+            const elements = Object.fromEntries(
+                [
+                    "loading-state",
+                    "fixture-sidebar",
+                    "fixture-workspace",
+                    "summary-grid",
+                    "fixture-search",
+                    "status-filter",
+                    "quality-filter",
+                    "fixture-count",
+                    "fixture-list",
+                    "previous-fixture",
+                    "next-fixture",
+                    "fixture-position",
+                    "fixture-title",
+                    "fixture-meta",
+                    "source-size",
+                    "source-stage",
+                    "source-image",
+                    "source-details",
+                    "crop-overlay",
+                    "fixture-errors",
+                    "crop-progress",
+                    "region-filter",
+                    "approve-visible",
+                    "crop-grid",
+                    "crop-template",
+                    "import-button",
+                    "import-file",
+                    "export-button"
+                ].map((id) => [id, document.getElementById(id)])
+            );
+
+            let dataset;
+            let reviews = { version: 1, entries: {} };
+            let activeCaseId;
+            let activeCropId;
+
+            function assetUrl(src) {
+                return `${baseUrl}${src}`;
+            }
+
+            function storageKey() {
+                return `mtg-crop-review:v1:${dataset.datasetId}`;
+            }
+
+            function loadReviews() {
+                try {
+                    const saved = JSON.parse(localStorage.getItem(storageKey()));
+                    if (saved?.version === 1 && saved.entries) reviews = saved;
+                } catch {
+                    reviews = { version: 1, entries: {} };
+                }
+            }
+
+            function saveReviews() {
+                localStorage.setItem(storageKey(), JSON.stringify(reviews));
+            }
+
+            function cropReview(caseId, cropId) {
+                return (
+                    reviews.entries[caseId]?.crops?.[cropId] || {
+                        status: "unreviewed",
+                        note: "",
+                        tags: []
+                    }
+                );
+            }
+
+            function observationTags(review) {
+                return Array.isArray(review.tags)
+                    ? review.tags.filter((tag) => typeof tag === "string")
+                    : [];
+            }
+
+            function updateObservationTag(caseId, cropId, tag, selected) {
+                const current = cropReview(caseId, cropId);
+                const tags = new Set(observationTags(current));
+                if (selected) tags.add(tag);
+                else tags.delete(tag);
+                reviews.entries[caseId] ||= { crops: {} };
+                reviews.entries[caseId].crops[cropId] = {
+                    ...current,
+                    tags: [...tags],
+                    updatedAt: new Date().toISOString()
+                };
+                saveReviews();
+            }
+
+            function updateCropReview(caseId, cropId, patch) {
+                reviews.entries[caseId] ||= { crops: {} };
+                reviews.entries[caseId].crops[cropId] = {
+                    ...cropReview(caseId, cropId),
+                    ...patch,
+                    updatedAt: new Date().toISOString()
+                };
+                saveReviews();
+                renderAll();
+            }
+
+            function caseStatus(fixture) {
+                const statuses = fixture.crops.map((crop) => cropReview(fixture.id, crop.id).status);
+                if (statuses.includes("needs-attention")) return "needs-attention";
+                if (statuses.length > 0 && statuses.every((status) => status === "approved")) {
+                    return "approved";
+                }
+                if (statuses.some((status) => status === "approved")) return "partial";
+                return "unreviewed";
+            }
+
+            function filteredCases() {
+                const query = elements["fixture-search"].value.trim().toLowerCase();
+                const status = elements["status-filter"].value;
+                const quality = elements["quality-filter"].value;
+                return dataset.cases.filter((fixture) => {
+                    const haystack = [
+                        fixture.id,
+                        fixture.expected.name,
+                        fixture.expected.set,
+                        fixture.expected.collectorNumber
+                    ]
+                        .join(" ")
+                        .toLowerCase();
+                    return (
+                        (!query || haystack.includes(query)) &&
+                        (status === "all" || caseStatus(fixture) === status) &&
+                        (quality === "all" || fixture.quality === quality)
+                    );
+                });
+            }
+
+            function statusLabel(status) {
+                return {
+                    approved: "Approved",
+                    "needs-attention": "Needs attention",
+                    partial: "In progress",
+                    unreviewed: "Unreviewed"
+                }[status];
+            }
+
+            function renderSummary() {
+                const counts = { approved: 0, "needs-attention": 0, partial: 0, unreviewed: 0 };
+                dataset.cases.forEach((fixture) => (counts[caseStatus(fixture)] += 1));
+                elements["summary-grid"].innerHTML = [
+                    [dataset.cases.length, "Fixtures"],
+                    [counts["needs-attention"], "Flagged"],
+                    [counts.approved, "Approved"],
+                    [counts.unreviewed + counts.partial, "Remaining"]
+                ]
+                    .map(([value, label]) => `<div><strong>${value}</strong><span>${label}</span></div>`)
+                    .join("");
+            }
+
+            function renderFixtureList() {
+                const fixtures = filteredCases();
+                elements["fixture-count"].textContent = `${fixtures.length} of ${dataset.cases.length} fixtures`;
+                elements["fixture-list"].replaceChildren(
+                    ...fixtures.map((fixture) => {
+                        const item = document.createElement("li");
+                        const button = document.createElement("button");
+                        const status = caseStatus(fixture);
+                        const name = document.createElement("strong");
+                        const id = document.createElement("small");
+                        const dot = document.createElement("i");
+                        button.type = "button";
+                        item.className = fixture.id === activeCaseId ? "is-active" : "";
+                        button.setAttribute(
+                            "aria-label",
+                            `${fixture.expected.name}, ${fixture.id}, ${statusLabel(status)}`
+                        );
+                        name.textContent = fixture.expected.name;
+                        id.textContent = fixture.id;
+                        dot.className = `status-dot ${status}`;
+                        dot.title = statusLabel(status);
+                        button.append(name, dot);
+                        button.addEventListener("click", () => {
+                            activeCaseId = fixture.id;
+                            activeCropId = undefined;
+                            renderAll();
+                        });
+                        item.append(button, id);
+                        return item;
+                    })
+                );
+            }
+
+            function activeFixture() {
+                return dataset.cases.find((fixture) => fixture.id === activeCaseId) || dataset.cases[0];
+            }
+
+            function visibleCrops(fixture) {
+                const type = elements["region-filter"].value;
+                return fixture.crops.filter((crop) => type === "all" || crop.type === type);
+            }
+
+            function showOverlay(crop, fixture) {
+                const region = crop?.sourceRegion;
+                if (!region) {
+                    elements["crop-overlay"].hidden = true;
+                    return;
+                }
+                Object.assign(elements["crop-overlay"].style, {
+                    left: `${(region.left / fixture.source.width) * 100}%`,
+                    top: `${(region.top / fixture.source.height) * 100}%`,
+                    width: `${(region.width / fixture.source.width) * 100}%`,
+                    height: `${(region.height / fixture.source.height) * 100}%`
+                });
+                elements["crop-overlay"].hidden = false;
+            }
+
+            function renderCropCard(fixture, crop) {
+                const fragment = elements["crop-template"].content.cloneNode(true);
+                const card = fragment.querySelector(".crop-card");
+                const imageButton = fragment.querySelector(".crop-image-button");
+                const image = fragment.querySelector("img");
+                const labels = fragment.querySelector(".crop-labels");
+                const goodButton = fragment.querySelector(".mark-good");
+                const attentionButton = fragment.querySelector(".mark-attention");
+                const observationChips = fragment.querySelector(".observation-chips");
+                const legacyNote = fragment.querySelector(".legacy-note");
+                const diagnostic = fragment.querySelector(".crop-diagnostic");
+                const review = cropReview(fixture.id, crop.id);
+                card.dataset.status = review.status;
+                card.classList.toggle("is-selected", crop.id === activeCropId);
+                image.src = assetUrl(crop.src);
+                image.alt = `${fixture.expected.name} ${crop.region} crop`;
+                labels.querySelector("strong").textContent = crop.region;
+                labels.querySelector("span").textContent = crop.psm ? `${crop.type} · ${crop.psm}` : crop.type;
+                goodButton.setAttribute("aria-pressed", review.status === "approved");
+                attentionButton.setAttribute("aria-pressed", review.status === "needs-attention");
+                const selectedTags = new Set(observationTags(review));
+                observationChips.replaceChildren(
+                    ...observationOptions.map((option) => {
+                        const chip = document.createElement("button");
+                        chip.type = "button";
+                        chip.className = "observation-chip";
+                        chip.dataset.tone = option.tone;
+                        chip.textContent = option.label;
+                        chip.setAttribute("aria-pressed", selectedTags.has(option.id));
+                        chip.addEventListener("click", () => {
+                            const selected = chip.getAttribute("aria-pressed") !== "true";
+                            chip.setAttribute("aria-pressed", selected);
+                            updateObservationTag(fixture.id, crop.id, option.id, selected);
+                        });
+                        return chip;
+                    })
+                );
+                const previousNote = typeof review.note === "string" ? review.note.trim() : "";
+                legacyNote.hidden = previousNote.length === 0;
+                legacyNote.querySelector("span").textContent = previousNote;
+                const diagnostics = [];
+                if (crop.contentDetected) diagnostics.push("content-refined");
+                if (crop.lowConfidence) diagnostics.push("low confidence");
+                if (crop.sourceUpscaled) diagnostics.push(`${crop.sourceUpscaleFactor.toFixed(2)}× source upscale`);
+                if (crop.reason) diagnostics.push(crop.reason);
+                diagnostic.textContent = diagnostics.join(" · ") || "template crop";
+                imageButton.addEventListener("click", () => {
+                    activeCropId = crop.id;
+                    renderWorkspace();
+                });
+                goodButton.addEventListener("click", () =>
+                    updateCropReview(fixture.id, crop.id, {
+                        status: review.status === "approved" ? "unreviewed" : "approved"
+                    })
+                );
+                attentionButton.addEventListener("click", () =>
+                    updateCropReview(fixture.id, crop.id, {
+                        status: review.status === "needs-attention" ? "unreviewed" : "needs-attention"
+                    })
+                );
+                return fragment;
+            }
+
+            function renderWorkspace() {
+                const fixture = activeFixture();
+                activeCaseId = fixture.id;
+                const navigationFixtures = filteredCases();
+                const position = navigationFixtures.findIndex((item) => item.id === fixture.id);
+                const crops = visibleCrops(fixture);
+                if (!activeCropId || !fixture.crops.some((crop) => crop.id === activeCropId)) {
+                    activeCropId = crops[0]?.id;
+                }
+                const selectedCrop = fixture.crops.find((crop) => crop.id === activeCropId);
+                elements["fixture-position"].textContent =
+                    position === -1
+                        ? `FIXTURE ${dataset.cases.findIndex((item) => item.id === fixture.id) + 1} / ${dataset.cases.length}`
+                        : `FIXTURE ${position + 1} / ${navigationFixtures.length}`;
+                elements["fixture-title"].textContent = fixture.expected.name;
+                elements["fixture-meta"].textContent = `${fixture.id} · ${fixture.quality} · ${fixture.expected.set} #${fixture.expected.collectorNumber}`;
+                elements["source-size"].textContent = `${fixture.source.width} × ${fixture.source.height}`;
+                elements["source-image"].src = assetUrl(fixture.source.src);
+                elements["source-image"].alt = `${fixture.expected.name} regression fixture`;
+                showOverlay(selectedCrop, fixture);
+                const details = [
+                    ["Expected type", fixture.expected.typeLine || "Not specified", false],
+                    [
+                        "Transform",
+                        Object.keys(fixture.transform).length
+                            ? JSON.stringify(fixture.transform)
+                            : "none",
+                        true
+                    ],
+                    ["Gate", fixture.blocking ? "Blocking" : "Non-blocking", false]
+                ].map(([term, value, isCode]) => {
+                    const row = document.createElement("div");
+                    const dt = document.createElement("dt");
+                    const dd = document.createElement("dd");
+                    const content = document.createElement(isCode ? "code" : "span");
+                    dt.textContent = term;
+                    content.textContent = value;
+                    dd.append(content);
+                    row.append(dt, dd);
+                    return row;
+                });
+                elements["source-details"].replaceChildren(...details);
+                elements["fixture-errors"].hidden = fixture.errors.length === 0;
+                elements["fixture-errors"].replaceChildren(
+                    ...fixture.errors.map((error) => {
+                        const message = document.createElement("p");
+                        const type = document.createElement("strong");
+                        type.textContent = error.type;
+                        message.append(type, `: ${error.message}`);
+                        return message;
+                    })
+                );
+                const reviewed = fixture.crops.filter(
+                    (crop) => cropReview(fixture.id, crop.id).status !== "unreviewed"
+                ).length;
+                elements["crop-progress"].textContent = `${reviewed} / ${fixture.crops.length} reviewed`;
+                elements["crop-grid"].replaceChildren(
+                    ...crops.map((crop) => renderCropCard(fixture, crop))
+                );
+                elements["previous-fixture"].disabled =
+                    navigationFixtures.length === 0 || position === 0;
+                elements["next-fixture"].disabled =
+                    navigationFixtures.length === 0 || position === navigationFixtures.length - 1;
+            }
+
+            function renderAll() {
+                renderSummary();
+                renderFixtureList();
+                renderWorkspace();
+            }
+
+            function moveFixture(direction) {
+                const fixtures = filteredCases();
+                const index = fixtures.findIndex((fixture) => fixture.id === activeCaseId);
+                const nextIndex =
+                    index === -1 ? (direction > 0 ? 0 : fixtures.length - 1) : index + direction;
+                const next = fixtures[nextIndex];
+                if (!next) return;
+                activeCaseId = next.id;
+                activeCropId = undefined;
+                renderAll();
+            }
+
+            function exportReviews() {
+                const report = {
+                    version: 1,
+                    datasetId: dataset.datasetId,
+                    sourceManifest: dataset.sourceManifest,
+                    generatedAt: dataset.generatedAt,
+                    exportedAt: new Date().toISOString(),
+                    entries: reviews.entries
+                };
+                const blob = new Blob([`${JSON.stringify(report, null, 2)}\n`], {
+                    type: "application/json"
+                });
+                const link = document.createElement("a");
+                link.href = URL.createObjectURL(blob);
+                link.download = `crop-review-${dataset.datasetId}.json`;
+                link.click();
+                URL.revokeObjectURL(link.href);
+            }
+
+            async function importReviews(file) {
+                const imported = JSON.parse(await file.text());
+                if (imported.version !== 1 || imported.datasetId !== dataset.datasetId || !imported.entries) {
+                    throw new Error("Review JSON does not match this generated crop dataset");
+                }
+                reviews = { version: 1, entries: imported.entries };
+                saveReviews();
+                renderAll();
+            }
+
+            async function initialize() {
+                try {
+                    const response = await fetch(dataUrl, { cache: "no-store" });
+                    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                    dataset = await response.json();
+                    loadReviews();
+                    activeCaseId = dataset.cases[0]?.id;
+                    if (!activeCaseId) throw new Error("The generated dataset contains no fixtures");
+                    [...new Set(dataset.cases.map((fixture) => fixture.quality))]
+                        .sort()
+                        .forEach((quality) => elements["quality-filter"].add(new Option(quality, quality)));
+                    dataset.cropTypes.forEach((type) =>
+                        elements["region-filter"].add(new Option(type, type))
+                    );
+                    elements["loading-state"].hidden = true;
+                    elements["fixture-sidebar"].hidden = false;
+                    elements["fixture-workspace"].hidden = false;
+                    renderAll();
+                } catch (error) {
+                    elements["loading-state"].classList.add("is-error");
+                    const heading = document.createElement("h2");
+                    const instruction = document.createElement("p");
+                    const command = document.createElement("code");
+                    const detail = document.createElement("pre");
+                    heading.textContent = "Crop data is unavailable";
+                    command.textContent = "pnpm crop-review:generate";
+                    instruction.append("Run ", command, ", then reload this page.");
+                    detail.textContent = error.message;
+                    elements["loading-state"].replaceChildren(heading, instruction, detail);
+                }
+            }
+
+            elements["fixture-search"].addEventListener("input", renderFixtureList);
+            elements["status-filter"].addEventListener("change", renderFixtureList);
+            elements["quality-filter"].addEventListener("change", renderFixtureList);
+            elements["region-filter"].addEventListener("change", () => {
+                activeCropId = undefined;
+                renderWorkspace();
+            });
+            elements["previous-fixture"].addEventListener("click", () => moveFixture(-1));
+            elements["next-fixture"].addEventListener("click", () => moveFixture(1));
+            elements["approve-visible"].addEventListener("click", () => {
+                const fixture = activeFixture();
+                visibleCrops(fixture).forEach((crop) => {
+                    reviews.entries[fixture.id] ||= { crops: {} };
+                    reviews.entries[fixture.id].crops[crop.id] = {
+                        ...cropReview(fixture.id, crop.id),
+                        status: "approved",
+                        updatedAt: new Date().toISOString()
+                    };
+                });
+                saveReviews();
+                renderAll();
+            });
+            elements["export-button"].addEventListener("click", exportReviews);
+            elements["import-button"].addEventListener("click", () => elements["import-file"].click());
+            elements["import-file"].addEventListener("change", async (event) => {
+                try {
+                    if (event.target.files[0]) await importReviews(event.target.files[0]);
+                } catch (error) {
+                    window.alert(error.message);
+                } finally {
+                    event.target.value = "";
+                }
+            });
+            document.addEventListener("keydown", (event) => {
+                if (["INPUT", "TEXTAREA", "SELECT"].includes(document.activeElement?.tagName)) return;
+                if (event.altKey || event.ctrlKey || event.metaKey) return;
+                if (["ArrowRight", "ArrowLeft"].includes(event.key)) event.preventDefault();
+                if (event.key === "ArrowRight" || event.key.toLowerCase() === "j") moveFixture(1);
+                if (event.key === "ArrowLeft" || event.key.toLowerCase() === "k") moveFixture(-1);
+                const fixture = activeFixture();
+                const crop = fixture?.crops.find((candidate) => candidate.id === activeCropId);
+                if (!crop) return;
+                if (event.key.toLowerCase() === "g") {
+                    updateCropReview(fixture.id, crop.id, { status: "approved" });
+                }
+                if (event.key.toLowerCase() === "f") {
+                    updateCropReview(fixture.id, crop.id, { status: "needs-attention" });
+                }
+            });
+
+            initialize();
+        </script>
+    </body>
+</html>

--- a/test/image-processing/smart-crop.spec.mjs
+++ b/test/image-processing/smart-crop.spec.mjs
@@ -8,6 +8,7 @@ import {
     regions,
     getRegionTemplates,
     cropRegion,
+    cropTextRegion,
     computeGreyscaleStdDev,
     assessConfidence,
     assertOcrSourceSizeOk,
@@ -41,6 +42,14 @@ async function checkerboardImage(width, height) {
         }
     }
     return img;
+}
+
+function fillRectangle(img, left, top, width, height, color) {
+    for (let y = top; y < top + height; y++) {
+        for (let x = left; x < left + width; x++) {
+            img.setPixelColor(color, x, y);
+        }
+    }
 }
 
 describe("Smart crop::", () => {
@@ -103,16 +112,71 @@ describe("Smart crop::", () => {
             assert.property(result, "lowConfidence");
         });
 
-        it("crops a real card fixture to the expected proportions", async () => {
+        it("centers a real set icon in a bounded square crop with padding", async () => {
             const baseImage = await Jimp.read(FIXTURE_PATH);
-            const { width, height } = baseImage.bitmap;
+            const { image, region, searchRegion, contentDetected, lowConfidence } =
+                cropSetSymbolFromImage(baseImage);
 
-            const { image, region } = cropSetSymbolFromImage(baseImage);
-
-            assert.approximately(region.width / width, regions.setSymbol.widthPercent, 0.01);
-            assert.approximately(region.height / height, regions.setSymbol.heightPercent, 0.01);
+            assert.isTrue(contentDetected);
+            assert.isFalse(lowConfidence);
+            assert.equal(region.width, region.height);
+            assert.isBelow(region.width * region.height, searchRegion.width * searchRegion.height);
+            assert.isAtLeast(region.left, 0);
+            assert.isAtMost(region.left + region.width, baseImage.bitmap.width);
+            assert.isAtLeast(region.top, 0);
+            assert.isAtMost(region.top + region.height, baseImage.bitmap.height);
             assert.equal(image.bitmap.width, region.width);
             assert.equal(image.bitmap.height, region.height);
+        });
+
+        it("keeps an off-center symbol whole with buffer on every side", () => {
+            const img = new Jimp({ width: 600, height: 800, color: 0xb8b8b8ff });
+            const search = cropRegion(img, regions.setSymbolSearch).region;
+            fillRectangle(img, search.left, search.top + 15, search.width, 2, 0x202020ff);
+            fillRectangle(
+                img,
+                search.left,
+                search.top + search.height - 16,
+                search.width,
+                2,
+                0x202020ff
+            );
+            const icon = {
+                left: search.left + 80,
+                top: search.top + 38,
+                width: 30,
+                height: 34
+            };
+            fillRectangle(img, icon.left, icon.top, icon.width, icon.height, 0x151515ff);
+            fillRectangle(
+                img,
+                icon.left + 5,
+                icon.top + 5,
+                icon.width - 10,
+                icon.height - 10,
+                0xe07020ff
+            );
+
+            const result = cropSetSymbolFromImage(img);
+
+            assert.isTrue(result.contentDetected);
+            assert.isFalse(result.lowConfidence);
+            assert.isBelow(result.region.left, icon.left);
+            assert.isBelow(result.region.top, icon.top);
+            assert.isAbove(result.region.left + result.region.width, icon.left + icon.width);
+            assert.isAbove(result.region.top + result.region.height, icon.top + icon.height);
+            assert.equal(result.region.width, result.region.height);
+            assert.isBelow(result.region.width, search.width / 2);
+        });
+
+        it("marks an ambiguous symbol search as low confidence", () => {
+            const img = new Jimp({ width: 600, height: 800, color: 0x808080ff });
+
+            const result = cropSetSymbolFromImage(img);
+
+            assert.isFalse(result.contentDetected);
+            assert.isTrue(result.lowConfidence);
+            assert.match(result.reason, /edges were not detected/);
         });
     });
 
@@ -147,6 +211,91 @@ describe("Smart crop::", () => {
             );
             assert.equal(image.bitmap.width, region.width);
             assert.equal(image.bitmap.height, region.height);
+        });
+
+        it("trims an oversized text window while preserving every glyph and padding", () => {
+            const img = new Jimp({ width: 400, height: 120, color: 0xd8d8d8ff });
+            const glyphs = [90, 112, 138, 165, 205, 230].map((left) => ({
+                left,
+                top: 42,
+                width: 12,
+                height: 30
+            }));
+            glyphs.forEach((glyph) =>
+                fillRectangle(img, glyph.left, glyph.top, glyph.width, glyph.height, 0x101010ff)
+            );
+
+            const result = cropTextRegion(img, {
+                leftPercent: 0,
+                topPercent: 0,
+                widthPercent: 1,
+                heightPercent: 1
+            });
+            const lastGlyph = glyphs[glyphs.length - 1];
+
+            assert.isTrue(result.contentDetected);
+            assert.isBelow(result.region.width, img.bitmap.width / 2);
+            assert.isBelow(result.region.height, img.bitmap.height / 2);
+            assert.isBelow(result.region.left, glyphs[0].left);
+            assert.isBelow(result.region.top, glyphs[0].top);
+            assert.isAbove(
+                result.region.left + result.region.width,
+                lastGlyph.left + lastGlyph.width
+            );
+            assert.isAbove(
+                result.region.top + result.region.height,
+                lastGlyph.top + lastGlyph.height
+            );
+        });
+
+        it("falls back to the template when no text edges are detectable", () => {
+            const img = new Jimp({ width: 400, height: 120, color: 0xd8d8d8ff });
+            const template = {
+                leftPercent: 0.1,
+                topPercent: 0.2,
+                widthPercent: 0.8,
+                heightPercent: 0.5
+            };
+
+            const result = cropTextRegion(img, template);
+            const expected = cropRegion(img, template);
+
+            assert.isFalse(result.contentDetected);
+            assert.deepEqual(result.region, expected.region);
+        });
+
+        it("preserves the full template for multi-line OCR blocks", () => {
+            const img = new Jimp({ width: 400, height: 120, color: 0xd8d8d8ff });
+            fillRectangle(img, 90, 20, 120, 20, 0x101010ff);
+            fillRectangle(img, 150, 75, 140, 20, 0x101010ff);
+            const template = {
+                leftPercent: 0,
+                topPercent: 0,
+                widthPercent: 1,
+                heightPercent: 1,
+                psm: "block"
+            };
+
+            const result = cropTextRegion(img, template);
+
+            assert.isFalse(result.contentDetected);
+            assert.deepEqual(result.region, { left: 0, top: 0, width: 400, height: 120 });
+        });
+
+        it("preserves the template when detected text touches its search boundary", () => {
+            const img = new Jimp({ width: 400, height: 120, color: 0xd8d8d8ff });
+            fillRectangle(img, 0, 0, 180, 30, 0x101010ff);
+
+            const result = cropTextRegion(img, {
+                leftPercent: 0,
+                topPercent: 0,
+                widthPercent: 1,
+                heightPercent: 1,
+                psm: "line"
+            });
+
+            assert.isFalse(result.contentDetected);
+            assert.deepEqual(result.region, { left: 0, top: 0, width: 400, height: 120 });
         });
     });
 

--- a/test/matcher/matching-processor.spec.mjs
+++ b/test/matcher/matching-processor.spec.mjs
@@ -352,7 +352,7 @@ describe("MatcherProcessor::", () => {
         assert.deepEqual(result, ["M21"]);
         assert.isTrue(hashStub.calledTwice);
         assert.equal(hashStub.secondCall.args[0], "/tmp/pacifism.jpg");
-        assert.equal(processHashesStub.firstCall.args[0].hashMode, "set-symbol");
+        assert.equal(processHashesStub.firstCall.args[0].hashMode, "set-symbol-content-v1");
         assert.equal(processHashesStub.secondCall.args[0].hashMode, "full-card");
         assert.equal(processHashesStub.secondCall.args[0].localHash, "FULL_CARD_HASH");
     });

--- a/test/regression/fixtures/manifest.json
+++ b/test/regression/fixtures/manifest.json
@@ -7626,7 +7626,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {

--- a/test/regression/fixtures/manifest.json
+++ b/test/regression/fixtures/manifest.json
@@ -3398,7 +3398,7 @@
                 "minNameScore": 0.7,
                 "maxNameCandidates": 5,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000,
+                "maxRuntimeMs": 35000,
                 "metadata": {
                     "typeLine": "Enchantment — Aura",
                     "rarity": "common"
@@ -3419,7 +3419,7 @@
                 "collectorNumber": "101",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3437,7 +3437,7 @@
                 "collectorNumber": "101",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3454,7 +3454,7 @@
                 "collectorNumber": "101",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3470,7 +3470,7 @@
                 "collectorNumber": "101",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3486,7 +3486,7 @@
                 "collectorNumber": "101",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3508,7 +3508,7 @@
                 "minNameScore": 0.7,
                 "minPrintScore": 0.65,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3527,7 +3527,7 @@
                 "collectorNumber": "101",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3540,7 +3540,7 @@
                 "collectorNumber": "128",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3553,7 +3553,7 @@
                 "collectorNumber": "214",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3566,7 +3566,7 @@
                 "collectorNumber": "300",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3579,7 +3579,7 @@
                 "collectorNumber": "13",
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 2,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3598,7 +3598,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3617,7 +3617,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3636,7 +3636,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3655,7 +3655,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3674,7 +3674,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3693,7 +3693,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3712,7 +3712,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3731,7 +3731,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3750,7 +3750,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3769,7 +3769,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3788,7 +3788,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3807,7 +3807,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3826,7 +3826,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3845,7 +3845,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3864,7 +3864,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3883,7 +3883,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3902,7 +3902,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3921,7 +3921,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3940,7 +3940,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 2,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3959,7 +3959,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3978,7 +3978,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -3997,7 +3997,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4016,7 +4016,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4036,7 +4036,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4056,7 +4056,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4076,7 +4076,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4096,7 +4096,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4116,7 +4116,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4136,7 +4136,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4156,7 +4156,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4175,7 +4175,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4194,7 +4194,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4216,7 +4216,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4238,7 +4238,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4260,7 +4260,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4282,7 +4282,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4304,7 +4304,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4326,7 +4326,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 2,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4348,7 +4348,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4370,7 +4370,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4392,7 +4392,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4414,7 +4414,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4436,7 +4436,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4458,7 +4458,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4480,7 +4480,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4502,7 +4502,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4524,7 +4524,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4546,7 +4546,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4568,7 +4568,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4590,7 +4590,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4612,7 +4612,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4634,7 +4634,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4656,7 +4656,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4678,7 +4678,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4700,7 +4700,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4722,7 +4722,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4744,7 +4744,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4766,7 +4766,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4788,7 +4788,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4810,7 +4810,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4832,7 +4832,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4854,7 +4854,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4876,7 +4876,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4898,7 +4898,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4920,7 +4920,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4942,7 +4942,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4964,7 +4964,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -4986,7 +4986,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5008,7 +5008,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5030,7 +5030,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5052,7 +5052,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5074,7 +5074,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5096,7 +5096,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5118,7 +5118,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5140,7 +5140,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5162,7 +5162,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5184,7 +5184,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5206,7 +5206,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5228,7 +5228,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5250,7 +5250,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5272,7 +5272,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5294,7 +5294,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5316,7 +5316,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5338,7 +5338,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5360,7 +5360,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5382,7 +5382,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5404,7 +5404,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5426,7 +5426,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5448,7 +5448,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5470,7 +5470,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5492,7 +5492,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5514,7 +5514,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5536,7 +5536,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5558,7 +5558,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5580,7 +5580,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5602,7 +5602,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5624,7 +5624,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5646,7 +5646,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5668,7 +5668,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5690,7 +5690,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5712,7 +5712,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5734,7 +5734,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5756,7 +5756,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5778,7 +5778,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5800,7 +5800,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5822,7 +5822,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5844,7 +5844,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5866,7 +5866,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5888,7 +5888,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5910,7 +5910,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5932,7 +5932,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5954,7 +5954,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5976,7 +5976,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -5998,7 +5998,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6020,7 +6020,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6042,7 +6042,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6064,7 +6064,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6086,7 +6086,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6108,7 +6108,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6130,7 +6130,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6152,7 +6152,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6174,7 +6174,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6196,7 +6196,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6218,7 +6218,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6240,7 +6240,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6262,7 +6262,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6284,7 +6284,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6306,7 +6306,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6328,7 +6328,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6350,7 +6350,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6372,7 +6372,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6394,7 +6394,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6416,7 +6416,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6438,7 +6438,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6460,7 +6460,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6482,7 +6482,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6504,7 +6504,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6526,7 +6526,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6548,7 +6548,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6570,7 +6570,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6592,7 +6592,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6614,7 +6614,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6636,7 +6636,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6658,7 +6658,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6680,7 +6680,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6702,7 +6702,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6724,7 +6724,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6746,7 +6746,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6768,7 +6768,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6790,7 +6790,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6812,7 +6812,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6834,7 +6834,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6856,7 +6856,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6878,7 +6878,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6900,7 +6900,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6922,7 +6922,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6944,7 +6944,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6966,7 +6966,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -6988,7 +6988,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7010,7 +7010,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7032,7 +7032,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7054,7 +7054,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7076,7 +7076,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7098,7 +7098,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7120,7 +7120,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7142,7 +7142,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7164,7 +7164,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7186,7 +7186,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7208,7 +7208,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7230,7 +7230,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7252,7 +7252,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7274,7 +7274,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7296,7 +7296,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7318,7 +7318,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7340,7 +7340,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7362,7 +7362,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7384,7 +7384,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7406,7 +7406,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7428,7 +7428,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7450,7 +7450,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7472,7 +7472,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7494,7 +7494,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7516,7 +7516,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7538,7 +7538,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7560,7 +7560,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7582,7 +7582,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7604,7 +7604,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7648,7 +7648,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7670,7 +7670,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7692,7 +7692,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7714,7 +7714,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7736,7 +7736,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7758,7 +7758,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7780,7 +7780,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7802,7 +7802,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7824,7 +7824,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7846,7 +7846,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7868,7 +7868,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7890,7 +7890,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7912,7 +7912,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7934,7 +7934,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7956,7 +7956,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -7978,7 +7978,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8000,7 +8000,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8022,7 +8022,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8044,7 +8044,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8066,7 +8066,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8088,7 +8088,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8110,7 +8110,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8132,7 +8132,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8154,7 +8154,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8176,7 +8176,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8198,7 +8198,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8220,7 +8220,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8242,7 +8242,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8264,7 +8264,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8286,7 +8286,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8308,7 +8308,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8330,7 +8330,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8352,7 +8352,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8374,7 +8374,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8396,7 +8396,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8418,7 +8418,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8440,7 +8440,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8462,7 +8462,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8484,7 +8484,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8506,7 +8506,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8528,7 +8528,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8550,7 +8550,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         },
         {
@@ -8572,7 +8572,7 @@
                 },
                 "minNameScore": 0.7,
                 "maxPrintCandidates": 1,
-                "maxRuntimeMs": 30000
+                "maxRuntimeMs": 35000
             }
         }
     ]

--- a/test/regression/scryfall-fixture-importer.spec.mjs
+++ b/test/regression/scryfall-fixture-importer.spec.mjs
@@ -474,7 +474,8 @@ describe("Scryfall regression fixture importer", () => {
             assert.deepInclude(manifest.cases[1].expected, {
                 name: "Fresh Card",
                 set: "FIN",
-                collectorNumber: "42"
+                collectorNumber: "42",
+                maxRuntimeMs: 35000
             });
             assert.deepEqual(manifest.cases[1].expected.metadata, {
                 typeLine: "Creature — Test",

--- a/test/scripts/generate-crop-review.spec.mjs
+++ b/test/scripts/generate-crop-review.spec.mjs
@@ -1,0 +1,181 @@
+import { rejects } from "node:assert/strict";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { assert } from "chai";
+import { loadManifest } from "../../src/regression/manifest.mjs";
+import {
+    buildProgram,
+    generateCropReview,
+    main,
+    ownershipMarkerContent,
+    ownershipMarkerFile,
+    safeSegment,
+    selectReviewCases
+} from "../../scripts/generate-crop-review.mjs";
+
+const manifestPath = new URL("../regression/fixtures/manifest.json", import.meta.url).pathname;
+
+describe("generate-crop-review::", () => {
+    let directory;
+
+    beforeEach(async () => {
+        directory = await mkdtemp(path.join(os.tmpdir(), "mtg-crop-review-"));
+    });
+
+    afterEach(async () => {
+        await rm(directory, { recursive: true, force: true });
+    });
+
+    it("selects enabled fixtures by default and supports explicit disabled cases", () => {
+        const manifest = {
+            cases: [
+                { id: "enabled", quality: "clean-scan" },
+                { id: "disabled", quality: "blur", enabled: false }
+            ]
+        };
+
+        assert.deepEqual(
+            selectReviewCases(manifest).map((fixture) => fixture.id),
+            ["enabled"]
+        );
+        assert.deepEqual(
+            selectReviewCases(manifest, { caseIds: ["disabled"] }).map((fixture) => fixture.id),
+            ["disabled"]
+        );
+        assert.throws(
+            () => selectReviewCases(manifest, { regions: ["unknown"] }),
+            "Unknown crop type(s): unknown"
+        );
+    });
+
+    it("creates stable, traversal-safe asset segments", () => {
+        assert.match(safeSegment("../../Pacifism Clean"), /^pacifism-clean-[a-f0-9]{8}$/);
+        assert.notEqual(safeSegment("same value"), safeSegment("same-value"));
+    });
+
+    it("generates review JSON and production set-symbol assets for a fixture", async () => {
+        const manifest = await loadManifest(manifestPath);
+        const outputDirectory = path.join(directory, "generated");
+        const report = await generateCropReview(manifest, {
+            outputDirectory,
+            caseIds: ["pacifism-clean-scan"],
+            regions: ["set-symbol"],
+            now: () => new Date("2026-08-15T12:00:00.000Z")
+        });
+
+        assert.deepInclude(report.summary, { cases: 1, crops: 1, errors: 0 });
+        assert.equal(report.generatedAt, "2026-08-15T12:00:00.000Z");
+        assert.equal(report.cases[0].crops[0].type, "set-symbol");
+        assert.match(report.cases[0].crops[0].sha256, /^[a-f0-9]{64}$/);
+        const written = JSON.parse(
+            await readFile(path.join(outputDirectory, "review-data.json"), "utf8")
+        );
+        assert.equal(written.datasetId, report.datasetId);
+        assert.match(written.cases[0].source.src, /^crop-review\/generated\/cases\//);
+        await readFile(
+            path.join(
+                outputDirectory,
+                written.cases[0].crops[0].src.replace("crop-review/generated/", "")
+            )
+        );
+    });
+
+    it("removes staging output when generation is interrupted", async () => {
+        const manifest = await loadManifest(manifestPath);
+        const outputDirectory = path.join(directory, "interrupted");
+
+        await rejects(
+            generateCropReview(manifest, {
+                outputDirectory,
+                caseIds: ["pacifism-clean-scan"],
+                regions: ["set-symbol"],
+                onProgress: () => process.emit("SIGINT")
+            }),
+            /Crop review generation interrupted by SIGINT/
+        );
+        await rejects(access(outputDirectory), /ENOENT/);
+    });
+
+    it("refuses to replace an output directory it does not own", async () => {
+        const manifest = await loadManifest(manifestPath);
+        const outputDirectory = path.join(directory, "unrelated");
+        const existingFile = path.join(outputDirectory, "keep.txt");
+        await mkdir(outputDirectory);
+        await writeFile(existingFile, "keep me", "utf8");
+
+        await rejects(
+            generateCropReview(manifest, {
+                outputDirectory,
+                caseIds: ["pacifism-clean-scan"],
+                regions: ["set-symbol"]
+            }),
+            /Refusing to replace output directory not created by crop review/
+        );
+        assert.equal(await readFile(existingFile, "utf8"), "keep me");
+    });
+
+    it("replaces output carrying its ownership marker", async () => {
+        const manifest = await loadManifest(manifestPath);
+        const outputDirectory = path.join(directory, "owned");
+        await mkdir(outputDirectory);
+        await writeFile(
+            path.join(outputDirectory, ownershipMarkerFile),
+            ownershipMarkerContent,
+            "utf8"
+        );
+
+        await generateCropReview(manifest, {
+            outputDirectory,
+            caseIds: ["pacifism-clean-scan"],
+            regions: ["set-symbol"]
+        });
+
+        assert.equal(
+            await readFile(path.join(outputDirectory, ownershipMarkerFile), "utf8"),
+            ownershipMarkerContent
+        );
+    });
+
+    it("parses filters and delegates CLI generation", async () => {
+        const options = buildProgram()
+            .parse([
+                "node",
+                "generate-crop-review.mjs",
+                "--case",
+                "pacifism-clean-scan",
+                "--region",
+                "name",
+                "--output",
+                directory
+            ])
+            .opts();
+        assert.deepEqual(options.case, ["pacifism-clean-scan"]);
+        assert.deepEqual(options.region, ["name"]);
+
+        const manifest = { cases: [] };
+        const lines = [];
+        let received;
+        await main(
+            [
+                "node",
+                "generate-crop-review.mjs",
+                "--case",
+                "pacifism-clean-scan",
+                "--output",
+                directory
+            ],
+            {
+                loadManifest: async () => manifest,
+                generateCropReview: async (input, generationOptions) => {
+                    received = { input, generationOptions };
+                    return { summary: { cases: 1, crops: 21, errors: 0 } };
+                },
+                writeLine: (line) => lines.push(line)
+            }
+        );
+        assert.strictEqual(received.input, manifest);
+        assert.deepEqual(received.generationOptions.caseIds, ["pacifism-clean-scan"]);
+        assert.include(lines[0], "21 crop(s)");
+    });
+});

--- a/test/site/local-crop-review.spec.mjs
+++ b/test/site/local-crop-review.spec.mjs
@@ -1,0 +1,30 @@
+import { assert } from "chai";
+import { localCropReviewIntegration } from "../../astro.config.mjs";
+
+describe("local crop-review route::", () => {
+    it("registers the reviewer for local development", () => {
+        const routes = [];
+        const integration = localCropReviewIntegration();
+
+        integration.hooks["astro:config:setup"]({
+            command: "dev",
+            injectRoute: (route) => routes.push(route)
+        });
+
+        assert.lengthOf(routes, 1);
+        assert.equal(routes[0].pattern, "/crop-review");
+        assert.equal(routes[0].entrypoint.pathname.endsWith("/src/tools/crop-review.astro"), true);
+    });
+
+    it("does not register the reviewer for production builds", () => {
+        const routes = [];
+        const integration = localCropReviewIntegration();
+
+        integration.hooks["astro:config:setup"]({
+            command: "build",
+            injectRoute: (route) => routes.push(route)
+        });
+
+        assert.deepEqual(routes, []);
+    });
+});


### PR DESCRIPTION
## Summary

- refine single-line OCR title crops around detected text while preserving padding and falling back to the established bounded template when detection is ambiguous
- locate set symbols inside a bounded type-line search area, center detected icons in square buffered crops, and fall back to full-card matching for low-confidence or inconclusive results
- version the set-symbol hash mode so incompatible cached crop fingerprints are not compared
- add a deterministic crop generator and local review workbench with status filters, observation chips, import/export, filtered keyboard navigation, and source overlays
- keep the reviewer and generated images local-only; production Pages builds exclude the route and fail closed if review artifacts enter the deploy output
- protect custom generator output paths with an ownership marker before replacing existing directories

## Why

Fixed percentage crops can include excessive frame area, clip text or symbols, and become misaligned across vintage and alternate card layouts. We also lacked a repeatable way to inspect every production crop, preserve human decisions, and identify which strategies need further tuning.

This change makes conservative content refinement available in production and adds the local evidence workflow needed to calibrate it safely. Ambiguous detection retains the prior bounded crop or existing full-card matching fallback.

## Manual review evidence

The current review export covers 151 of 158 set-symbol crops:

- 105 approved
- 46 need attention
- 25 tagged as wrong region
- 22 tagged as set icon incomplete

The strongest failure correlation is structural layout: all reviewed split, saga, flip, and planar examples need attention, while full-art treatments alone generally perform well. This PR is intentionally a draft so those observations remain visible inputs to the follow-up layout-specific tuning work rather than being mistaken for a completed accuracy claim.

Review exports and generated crop images are not committed.

## Validation

- `pnpm check` — 483 tests passed; lint, formatting, and typecheck passed
- `pnpm test:regression` — 156/158 overall; all 151 blocking fixtures passed; the two failures are existing non-blocking vintage fixtures (`vtg-5`, `vtg-7`)
- post-rebase regression against the 16 newly added upstream fixtures — 16/16 passed
- `pnpm test:package` — package smoke passed (71 files)
- `pnpm site:build` — production build passed with only the public homepage route
- local reviewer page and generated dataset returned HTTP 200; filtered Left/Right navigation stayed within all seven vintage fixtures

`pnpm coverage:check` could not collect coverage on this execution host because its Node inspector is disabled, producing an artificial 0% report. The complete underlying test suite passed twice; CI should perform the authoritative coverage collection.
