### PR TITLE
Stabilize cold-cache OCR regression gating

### DIFF
--- a/.github/workflows/ci.action.yml
+++ b/.github/workflows/ci.action.yml
@@ -95,10 +95,14 @@ jobs:
 
             - run: chmod +x "${GITHUB_WORKSPACE}/.github/scripts/dot-only-test-linter.sh"
             - run: '"${GITHUB_WORKSPACE}/.github/scripts/dot-only-test-linter.sh"'
-    regression_job:
-        name: Cold-cache OCR regression
+    regression_shards:
+        name: OCR correctness (shard ${{ matrix.shard }}/3)
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 12
+        strategy:
+            fail-fast: false
+            matrix:
+                shard: [1, 2, 3]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -118,19 +122,80 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Run cold-cache regression gate
-              run: pnpm test:regression
+            - name: Run cold-cache correctness shard
+              run: >-
+                  pnpm test:regression
+                  --shard "${{ matrix.shard }}/3"
+                  --workers 2
+                  --runtime-policy report-only
+                  --output "artifacts/regression/shard-${{ matrix.shard }}"
 
             - name: Upload regression benchmark
               if: always()
               uses: actions/upload-artifact@v4
               with:
-                  name: mtg-regression-${{ github.run_id }}
-                  path: artifacts/regression/
+                  name: mtg-regression-${{ github.run_id }}-shard-${{ matrix.shard }}
+                  path: artifacts/regression/shard-${{ matrix.shard }}/
+                  if-no-files-found: warn
+                  retention-days: 14
+    regression_job:
+        name: Cold-cache OCR regression
+        needs: regression_shards
+        if: always()
+        runs-on: ubuntu-latest
+        timeout-minutes: 1
+        steps:
+            - name: Require every correctness shard
+              env:
+                  REGRESSION_SHARDS_RESULT: ${{ needs.regression_shards.result }}
+              run: |
+                  if [ "$REGRESSION_SHARDS_RESULT" != "success" ]; then
+                    echo "::error::OCR correctness shards result: $REGRESSION_SHARDS_RESULT"
+                    exit 1
+                  fi
+    performance_job:
+        name: OCR performance smoke
+        runs-on: ubuntu-latest
+        timeout-minutes: 8
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.13.1
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Run isolated OCR performance gate
+              run: >-
+                  pnpm test:regression
+                  --workers 1
+                  --runtime-policy strict
+                  --case mmq-99-saprazzan-heir-0e3d913d-scryfall
+                  --case dmu-382-yavimaya-coast-79aa9c09-scryfall
+                  --case plc-114-rough-tumble-0c93c9a0-scryfall
+                  --output artifacts/regression/performance
+
+            - name: Upload performance benchmark
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: mtg-regression-performance-${{ github.run_id }}
+                  path: artifacts/regression/performance/
                   if-no-files-found: warn
                   retention-days: 14
     automerge:
-        needs: [pr_job, dot_only_linter_job, regression_job]
+        needs: [pr_job, dot_only_linter_job, regression_job, performance_job]
         if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
         runs-on: ubuntu-latest
         permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,15 @@ pnpm coverage:check
 pnpm test:regression
 ```
 
-`coverage:check` runs the unit suite, so the three commands above are the complete CI-equivalent
-sequence. The OCR regression run is especially important for changes to image preprocessing,
-OCR, fuzzy matching, hashing, or print selection.
+`coverage:check` runs the unit suite. The full local OCR command is stricter than the parallel CI
+correctness shards because it also enforces runtime thresholds. CI separately enforces those
+thresholds on a representative single-worker performance smoke. The OCR regression run is
+especially important for changes to image preprocessing, OCR, fuzzy matching, hashing, or print
+selection.
 
-CI runs `check:fast`, the coverage-enforced unit suite, and the cold-cache OCR regression on
-Node 22.
+CI runs `check:fast`, the coverage-enforced unit suite, three cold-cache correctness shards, and an
+isolated OCR performance smoke on Node 22. See `docs/regression-testing.md` for the exact runtime
+policy and sharding behavior.
 
 Distribution changes must also inspect and execute the packed artifact:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,15 +57,16 @@ pnpm coverage:check
 pnpm test:regression
 ```
 
-`coverage:check` runs the unit suite. The full local OCR command is stricter than the parallel CI
-correctness shards because it also enforces runtime thresholds. CI separately enforces those
-thresholds on a representative single-worker performance smoke. The OCR regression run is
-especially important for changes to image preprocessing, OCR, fuzzy matching, hashing, or print
-selection.
+`coverage:check` runs the unit suite. The full local OCR command is stricter
+than the parallel CI correctness shards because it also enforces runtime
+thresholds.
+CI separately enforces those thresholds on a representative single-worker
+performance smoke. The OCR regression run is especially important for changes
+to image preprocessing, OCR, fuzzy matching, hashing, or print selection.
 
-CI runs `check:fast`, the coverage-enforced unit suite, three cold-cache correctness shards, and an
-isolated OCR performance smoke on Node 22. See `docs/regression-testing.md` for the exact runtime
-policy and sharding behavior.
+CI runs `check:fast`, the coverage-enforced unit suite, three cold-cache
+correctness shards, and an isolated OCR performance smoke on Node 22. See
+`docs/regression-testing.md` for the exact runtime policy and sharding behavior.
 
 Distribution changes must also inspect and execute the packed artifact:
 

--- a/Readme.md
+++ b/Readme.md
@@ -167,8 +167,8 @@ pnpm test:regression
 ```
 
 The unit suite is deterministic, ignores machine-local configuration and credentials, and does not
-require live Scryfall or MySQL access. CI runs the fast/unit/coverage gate and the separate
-cold-cache OCR regression on Node 22. See
+require live Scryfall or MySQL access. CI runs the fast/unit/coverage gate, sharded cold-cache OCR
+correctness checks, and an isolated single-worker OCR performance smoke on Node 22. See
 [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## License

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -39,7 +39,8 @@ both the fixture and every candidate reference image; the runner has no in-memor
 hash cache. Fixture names are injected before the fuzzy matcher can initialize NeDB. Tesseract
 runs with `cacheMethod: none` and reads the bundled `eng.traineddata`, so it neither reads nor writes
 an OCR cache. The selected cases are distributed deterministically across a bounded pool of one to
-three shards. Each shard owns an initialized Tesseract worker, processes its cases sequentially,
+three worker shards. Each worker shard owns an initialized Tesseract worker, processes its cases
+sequentially,
 and replaces its worker after at most 40 cases. This bounds each Tesseract 3 WASM heap during the
 expanded corpus without loading the OCR engine and language model for every crop. Each worker's
 adaptive recognition state is reset before every crop. OCR results remain independent of earlier
@@ -74,6 +75,12 @@ pnpm test:regression --quality clean-scan --quality low-resolution
 pnpm test:regression --workers 1
 pnpm test:regression --workers 3
 
+# Run one deterministic third of the filtered manifest
+pnpm test:regression --shard 2/3
+
+# Keep runtime threshold violations in the report without failing correctness
+pnpm test:regression --runtime-policy report-only
+
 # Use another manifest or output directory
 pnpm test:regression --manifest ./path/manifest.json --output ./path/reports
 
@@ -93,6 +100,16 @@ of per-case runtimes and elapsed wall runtime so speed comparisons can use the l
 Run multiple fixture IDs or quality groups in one command to reuse the worker pool. Each separate
 command starts a new pool. Use one worker when collecting controlled model-comparison timings; use
 the default bounded parallelism for the ordinary regression gate.
+
+The default `strict` runtime policy preserves the local all-in-one gate: correctness failures and
+per-fixture `maxRuntimeMs` violations both fail blocking fixtures. `--runtime-policy report-only`
+still records every runtime violation, but only correctness affects the command exit code. This is
+useful when several OCR workers share a CI host, where per-case wall time includes scheduler and CPU
+contention. It does not suppress OCR, name, print, metadata, or confidence failures.
+
+`--shard INDEX/COUNT` applies after case and quality filters and selects cases by stable manifest
+order. Shards can therefore run independently and their reports can be compared or combined without
+changing fixture ownership.
 
 The generated `artifacts/regression` directory is ignored by Git.
 
@@ -450,13 +467,24 @@ the regression suite repeatable and independent of API availability or Scryfall 
 Each case records the raw and normalized OCR text promoted from the title candidate that produced
 the selected name match, Tesseract confidence and region, fuzzy name matches, name-candidate count,
 print-candidate count, the selected print, its PDQ similarity, Hamming distance, bit length, and
-input quality, set/collector verification, failures, per-stage timing, and total runtime. The
-summary includes pass rate, the blocking CI-gate result, non-blocking failure counts,
-disabled and placeholder fixture counts, totals by quality, total/mean runtime, and p95 runtime.
+input quality, set/collector verification, separate correctness and runtime failures, per-stage
+timing, and total runtime. Name-matching time contains only matcher work; primary OCR, fallback OCR,
+total name resolution, and print matching are reported separately. The summary includes pass rate,
+the active gate, dedicated correctness and performance gate summaries, runtime violation count,
+non-blocking failure counts, disabled and placeholder fixture counts, totals by quality,
+total/mean runtime, and p95 runtime.
 
 ## Pull request gate
 
-The `regression_job` in `.github/workflows/ci.action.yml` runs the full cold-cache suite for every
-pull request targeting `master` or `main`. It uploads `benchmark.md` and `benchmark.json` as a
-GitHub Actions artifact even when the gate fails. Application persistence, image-hash caching,
-and OCR caching remain disabled in CI exactly as they are locally.
+The CI workflow runs the full cold-cache correctness corpus as three independent manifest shards
+for every pull request targeting `master` or `main`. Each shard uses two OCR workers and the
+`report-only` runtime policy, so all correctness expectations remain blocking without treating
+shared-runner CPU contention as a performance regression. A separate single-worker performance
+smoke runs representative standard, full-art, and rotated/fallback-heavy fixtures with the strict
+runtime policy. This makes threshold failures comparable between runs while keeping a bounded
+slowdown signal.
+
+Every correctness shard and the performance smoke upload their own `benchmark.md` and
+`benchmark.json` artifacts even when a gate fails. Application persistence, image-hash caching,
+and OCR caching remain disabled in CI exactly as they are locally. The aggregate
+`Cold-cache OCR regression` job retains the existing stable required-check name.

--- a/scripts/run-regression.mjs
+++ b/scripts/run-regression.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command, InvalidArgumentError } from "commander";
 import { loadOcrModelManifest } from "../src/regression/ocr-model-candidate.mjs";
 import { QUALITY_LEVELS, loadManifest } from "../src/regression/manifest.mjs";
-import { runRegression } from "../src/regression/regression-runner.mjs";
+import { maximumRegressionShards, runRegression } from "../src/regression/regression-runner.mjs";
 import { writeBenchmarkReport } from "../src/regression/report.mjs";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -18,6 +18,7 @@ const defaultOcrModelManifest = path.join(
 );
 const defaultOcrModel = "bundled-eng-control";
 const defaultWorkers = 3;
+const defaultRuntimePolicy = "strict";
 
 function collect(value, previous) {
     return previous.concat(value);
@@ -28,6 +29,25 @@ function parseWorkerCount(value) {
         throw new InvalidArgumentError("must be an integer from 1 to 3");
     }
     return Number(value);
+}
+
+function parseRuntimePolicy(value) {
+    if (!["strict", "report-only"].includes(value)) {
+        throw new InvalidArgumentError('must be either "strict" or "report-only"');
+    }
+    return value;
+}
+
+function parseShard(value) {
+    const match = /^(\d+)\/(\d+)$/.exec(value);
+    const index = Number(match?.[1]);
+    const count = Number(match?.[2]);
+    if (!match || count < 1 || count > maximumRegressionShards || index < 1 || index > count) {
+        throw new InvalidArgumentError(
+            `must use INDEX/COUNT with a 1-based index and count 1-${maximumRegressionShards}`
+        );
+    }
+    return { index, count };
 }
 
 function buildProgram() {
@@ -48,6 +68,13 @@ function buildProgram() {
             parseWorkerCount,
             defaultWorkers
         )
+        .option(
+            "--runtime-policy <policy>",
+            "runtime threshold handling: strict or report-only",
+            parseRuntimePolicy,
+            defaultRuntimePolicy
+        )
+        .option("--shard <index/count>", "run one deterministic manifest shard", parseShard)
         .option("-c, --case <id>", "run a fixture id (repeatable)", collect, [])
         .option(
             "-q, --quality <level>",
@@ -84,7 +111,9 @@ async function main(argv = process.argv, overrides = {}) {
         caseIds: options.case,
         qualities: options.quality,
         ocrModel,
-        workers: options.workers
+        workers: options.workers,
+        runtimePolicy: options.runtimePolicy,
+        shard: options.shard
     });
     const paths = await writeBenchmarkReportFn(report, options.output);
     writeLine(`OCR model: ${ocrModel.id}`);
@@ -94,6 +123,14 @@ async function main(argv = process.argv, overrides = {}) {
     writeLine(
         `CI gate: ${report.gate.passed}/${report.gate.total} blocking fixtures passed; ${report.gate.nonBlockingFailed}/${report.gate.nonBlocking} non-blocking fixtures failed`
     );
+    writeLine(
+        `Runtime policy: ${report.runtimePolicy}; ${report.performanceGate.failed} blocking runtime violation(s)`
+    );
+    if (report.selection.shard) {
+        writeLine(
+            `Manifest shard: ${report.selection.shard.index}/${report.selection.shard.count} (${report.selection.selectedCases}/${report.selection.matchedCases} matching fixtures)`
+        );
+    }
     writeLine("Application persistence, image-hash cache, and OCR cache: disabled");
     writeLine(`Tesseract worker: ${report.isolation.ocrWorkerLifecycle}`);
     writeLine(`Wall runtime: ${report.summary.wallRuntimeMs} ms`);
@@ -122,4 +159,12 @@ if (isDirectRun) {
     });
 }
 
-export { buildProgram, defaultWorkers, main, parseWorkerCount };
+export {
+    buildProgram,
+    defaultRuntimePolicy,
+    defaultWorkers,
+    main,
+    parseRuntimePolicy,
+    parseShard,
+    parseWorkerCount
+};

--- a/src/processor/name-resolver.mjs
+++ b/src/processor/name-resolver.mjs
@@ -1,4 +1,19 @@
+import { performance } from "node:perf_hooks";
 import { promisify } from "node:util";
+
+function elapsedSince(startedAt) {
+    return Math.round((performance.now() - startedAt) * 100) / 100;
+}
+
+function roundMs(value) {
+    return Math.round(value * 100) / 100;
+}
+
+async function measure(operation) {
+    const startedAt = performance.now();
+    const value = await operation();
+    return { value, elapsedMs: elapsedSince(startedAt) };
+}
 
 async function extractText({
     filePath,
@@ -40,46 +55,88 @@ async function matchName({
 }
 
 async function resolveCardName(options) {
-    const title = options.titleExtractionResults
-        ? {
-              results: options.titleExtractionResults,
-              imagePath: options.titleExtractionImagePath
-          }
-        : await extractText({ ...options, type: "name" });
+    const timings = {
+        titleOcrMs: 0,
+        initialMatchMs: 0,
+        fallbackTitleOcrMs: 0,
+        fallbackMatchMs: 0,
+        supplementalOcrMs: 0,
+        supplementalMatchMs: 0,
+        totalMatchMs: 0,
+        totalFallbackOcrMs: 0
+    };
+    let title;
+    if (options.titleExtractionResults) {
+        title = {
+            results: options.titleExtractionResults,
+            imagePath: options.titleExtractionImagePath
+        };
+    } else {
+        const measuredTitle = await measure(() => extractText({ ...options, type: "name" }));
+        title = measuredTitle.value;
+        timings.titleOcrMs = measuredTitle.elapsedMs;
+    }
     const titleStages = [title];
     let combinedTitleResults = combineExtractionResults(titleStages);
-    let resolution = await matchName({
-        extractionResults: combinedTitleResults,
-        MatchName: options.MatchName,
-        matchDependencies: options.matchDependencies,
-        logger: options.logger
-    });
+    const measuredInitialMatch = await measure(() =>
+        matchName({
+            extractionResults: combinedTitleResults,
+            MatchName: options.MatchName,
+            matchDependencies: options.matchDependencies,
+            logger: options.logger
+        })
+    );
+    let resolution = measuredInitialMatch.value;
+    timings.initialMatchMs = measuredInitialMatch.elapsedMs;
     let selectedTitle = title;
     let supplemental;
 
     for (const type of ["soft-name", "rotated-name"]) {
         if (resolution.matches.length > 0) break;
-        const fallback = await extractText({ ...options, type });
+        const measuredFallback = await measure(() => extractText({ ...options, type }));
+        const fallback = measuredFallback.value;
+        timings.fallbackTitleOcrMs = roundMs(
+            timings.fallbackTitleOcrMs + measuredFallback.elapsedMs
+        );
         titleStages.push(fallback);
         combinedTitleResults = combineExtractionResults(titleStages);
-        resolution = await matchName({
-            extractionResults: combinedTitleResults,
-            MatchName: options.MatchName,
-            matchDependencies: options.matchDependencies,
-            logger: options.logger
-        });
+        const measuredFallbackMatch = await measure(() =>
+            matchName({
+                extractionResults: combinedTitleResults,
+                MatchName: options.MatchName,
+                matchDependencies: options.matchDependencies,
+                logger: options.logger
+            })
+        );
+        resolution = measuredFallbackMatch.value;
+        timings.fallbackMatchMs = roundMs(
+            timings.fallbackMatchMs + measuredFallbackMatch.elapsedMs
+        );
     }
 
     if (resolution.matches.length === 0) {
-        supplemental = await extractText({ ...options, type: "rules-name" });
-        resolution = await matchName({
-            extractionResults: combinedTitleResults,
-            supplementalText: supplemental.results.dirtyText,
-            MatchName: options.MatchName,
-            matchDependencies: options.matchDependencies,
-            logger: options.logger
-        });
+        const measuredSupplemental = await measure(() =>
+            extractText({ ...options, type: "rules-name" })
+        );
+        supplemental = measuredSupplemental.value;
+        timings.supplementalOcrMs = measuredSupplemental.elapsedMs;
+        const measuredSupplementalMatch = await measure(() =>
+            matchName({
+                extractionResults: combinedTitleResults,
+                supplementalText: supplemental.results.dirtyText,
+                MatchName: options.MatchName,
+                matchDependencies: options.matchDependencies,
+                logger: options.logger
+            })
+        );
+        resolution = measuredSupplementalMatch.value;
+        timings.supplementalMatchMs = measuredSupplementalMatch.elapsedMs;
     }
+
+    timings.totalMatchMs = roundMs(
+        timings.initialMatchMs + timings.fallbackMatchMs + timings.supplementalMatchMs
+    );
+    timings.totalFallbackOcrMs = roundMs(timings.fallbackTitleOcrMs + timings.supplementalOcrMs);
 
     const promoted = promoteMatchedExtraction(titleStages, resolution.matchedText);
     if (promoted) {
@@ -90,7 +147,8 @@ async function resolveCardName(options) {
         extractionResults: selectedTitle.results,
         extractionImagePath: selectedTitle.imagePath,
         matches: resolution.matches,
-        supplementalExtractionResults: supplemental?.results
+        supplementalExtractionResults: supplemental?.results,
+        timings
     };
 }
 

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -177,6 +177,31 @@ function evaluateRuntime(fixture, result) {
     return [];
 }
 
+function isExactPrintVerified(fixture, selectedPrint) {
+    if (!selectedPrint?.card) return false;
+    return (
+        normalized(selectedPrint.card.set) === normalized(fixture.expected.set) &&
+        String(selectedPrint.card.collectorNumber || "") ===
+            String(fixture.expected.collectorNumber) &&
+        (!fixture.expected.scryfallId ||
+            String(selectedPrint.card.scryfallId || "") === String(fixture.expected.scryfallId)) &&
+        selectedPrint.score >= (fixture.expected.minPrintScore ?? 0.75)
+    );
+}
+
+function finalizeResult(fixture, result, runtimePolicy, correctnessFailures) {
+    result.correctnessFailures = correctnessFailures || evaluateResult(fixture, result);
+    result.runtimeFailures = evaluateRuntime(fixture, result);
+    result.correctnessPassed = result.correctnessFailures.length === 0;
+    result.performancePassed = result.runtimeFailures.length === 0;
+    result.failures = [
+        ...result.correctnessFailures,
+        ...(runtimePolicy === "strict" ? result.runtimeFailures : [])
+    ];
+    result.passed = result.failures.length === 0;
+    return result;
+}
+
 async function analyzeFixture(fixture, manifest, context, dependencies) {
     const startedAt = performance.now();
     const timings = {};
@@ -251,64 +276,46 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
             failures: [],
             passed: false
         };
-        result.exactPrintVerified =
-            normalized(result.selectedPrint?.card?.set) === normalized(fixture.expected.set) &&
-            String(result.selectedPrint?.card?.collectorNumber || "") ===
-                String(fixture.expected.collectorNumber) &&
-            (!fixture.expected.scryfallId ||
-                String(result.selectedPrint?.card?.scryfallId || "") ===
-                    String(fixture.expected.scryfallId)) &&
-            result.selectedPrint.score >= (fixture.expected.minPrintScore ?? 0.75);
+        result.exactPrintVerified = isExactPrintVerified(fixture, result.selectedPrint);
         // Backward-compatible report field for existing consumers. Exact print verification
         // additionally checks Scryfall ID whenever a fixture supplies one.
         result.setVerified = result.exactPrintVerified;
-        result.correctnessFailures = evaluateResult(fixture, result);
-        result.runtimeFailures = evaluateRuntime(fixture, result);
-        result.correctnessPassed = result.correctnessFailures.length === 0;
-        result.performancePassed = result.runtimeFailures.length === 0;
-        result.failures = [
-            ...result.correctnessFailures,
-            ...(context.runtimePolicy === "strict" ? result.runtimeFailures : [])
-        ];
-        result.passed = result.failures.length === 0;
-        return result;
+        return finalizeResult(fixture, result, context.runtimePolicy);
     } catch (err) {
-        const result = {
-            id: fixture.id,
-            quality: fixture.quality,
-            blocking: fixture.blocking !== false,
-            sourceImage: fixture.image,
-            expected: fixture.expected,
-            ocr: {
-                cleanText: "",
-                dirtyText: "",
-                confidence: 0,
-                variant: "",
-                upscaled: false,
-                upscaleFactor: 1
+        return finalizeResult(
+            fixture,
+            {
+                id: fixture.id,
+                quality: fixture.quality,
+                blocking: fixture.blocking !== false,
+                sourceImage: fixture.image,
+                expected: fixture.expected,
+                ocr: {
+                    cleanText: "",
+                    dirtyText: "",
+                    confidence: 0,
+                    variant: "",
+                    upscaled: false,
+                    upscaleFactor: 1
+                },
+                nameMatches: [],
+                nameCandidateCount: 0,
+                printCandidateCount: 0,
+                selectedPrint: null,
+                exactPrintVerified: false,
+                setVerified: false,
+                timings,
+                runtimeMs: elapsedSince(startedAt),
+                correctnessFailures: [err?.message || String(err)],
+                runtimeFailures: [],
+                correctnessPassed: false,
+                performancePassed: false,
+                failures: [],
+                passed: false
             },
-            nameMatches: [],
-            nameCandidateCount: 0,
-            printCandidateCount: 0,
-            selectedPrint: null,
-            exactPrintVerified: false,
-            setVerified: false,
-            timings,
-            runtimeMs: elapsedSince(startedAt),
-            correctnessFailures: [err?.message || String(err)],
-            runtimeFailures: [],
-            correctnessPassed: false,
-            performancePassed: false,
-            failures: [],
-            passed: false
-        };
-        result.runtimeFailures = evaluateRuntime(fixture, result);
-        result.performancePassed = result.runtimeFailures.length === 0;
-        result.failures = [
-            ...result.correctnessFailures,
-            ...(context.runtimePolicy === "strict" ? result.runtimeFailures : [])
-        ];
-        return result;
+            context.runtimePolicy,
+            [err?.message || String(err)]
+        );
     } finally {
         await rm(directory, { recursive: true, force: true });
     }

--- a/src/regression/regression-runner.mjs
+++ b/src/regression/regression-runner.mjs
@@ -15,6 +15,8 @@ const noCacheOcrOptions = Object.freeze({
 });
 const maximumCasesPerOcrSession = 40;
 const maximumOcrWorkers = 3;
+const maximumRegressionShards = 16;
+const runtimePolicies = Object.freeze(["strict", "report-only"]);
 
 const silentLogger = {
     info: () => {},
@@ -160,12 +162,19 @@ function evaluateResult(fixture, result) {
         );
     }
     failures.push(...compareMetadata(selectedCard, expected.metadata));
-    if (typeof expected.maxRuntimeMs === "number" && result.runtimeMs > expected.maxRuntimeMs) {
-        failures.push(
-            `runtime: expected at most ${expected.maxRuntimeMs}ms, received ${result.runtimeMs}ms`
-        );
-    }
     return failures;
+}
+
+function evaluateRuntime(fixture, result) {
+    if (
+        typeof fixture.expected.maxRuntimeMs === "number" &&
+        result.runtimeMs > fixture.expected.maxRuntimeMs
+    ) {
+        return [
+            `runtime: expected at most ${fixture.expected.maxRuntimeMs}ms, received ${result.runtimeMs}ms`
+        ];
+    }
+    return [];
 }
 
 async function analyzeFixture(fixture, manifest, context, dependencies) {
@@ -197,7 +206,11 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
         });
         const nameMatches = nameResolution.matches;
         const resolvedOcr = nameResolution.extractionResults || ocr;
-        timings.nameMatchMs = elapsedSince(stageStartedAt);
+        timings.nameResolutionMs = elapsedSince(stageStartedAt);
+        timings.nameMatchMs = nameResolution.timings?.totalMatchMs ?? timings.nameResolutionMs;
+        timings.fallbackOcrMs = nameResolution.timings?.totalFallbackOcrMs ?? 0;
+        timings.fallbackTitleOcrMs = nameResolution.timings?.fallbackTitleOcrMs ?? 0;
+        timings.supplementalOcrMs = nameResolution.timings?.supplementalOcrMs ?? 0;
 
         const topName = nameMatches[0]?.name;
         const printCandidates = topName
@@ -231,6 +244,10 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
             setVerified: false,
             timings,
             runtimeMs: elapsedSince(startedAt),
+            correctnessFailures: [],
+            runtimeFailures: [],
+            correctnessPassed: false,
+            performancePassed: false,
             failures: [],
             passed: false
         };
@@ -245,11 +262,18 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
         // Backward-compatible report field for existing consumers. Exact print verification
         // additionally checks Scryfall ID whenever a fixture supplies one.
         result.setVerified = result.exactPrintVerified;
-        result.failures = evaluateResult(fixture, result);
+        result.correctnessFailures = evaluateResult(fixture, result);
+        result.runtimeFailures = evaluateRuntime(fixture, result);
+        result.correctnessPassed = result.correctnessFailures.length === 0;
+        result.performancePassed = result.runtimeFailures.length === 0;
+        result.failures = [
+            ...result.correctnessFailures,
+            ...(context.runtimePolicy === "strict" ? result.runtimeFailures : [])
+        ];
         result.passed = result.failures.length === 0;
         return result;
     } catch (err) {
-        return {
+        const result = {
             id: fixture.id,
             quality: fixture.quality,
             blocking: fixture.blocking !== false,
@@ -271,9 +295,20 @@ async function analyzeFixture(fixture, manifest, context, dependencies) {
             setVerified: false,
             timings,
             runtimeMs: elapsedSince(startedAt),
-            failures: [err?.message || String(err)],
+            correctnessFailures: [err?.message || String(err)],
+            runtimeFailures: [],
+            correctnessPassed: false,
+            performancePassed: false,
+            failures: [],
             passed: false
         };
+        result.runtimeFailures = evaluateRuntime(fixture, result);
+        result.performancePassed = result.runtimeFailures.length === 0;
+        result.failures = [
+            ...result.correctnessFailures,
+            ...(context.runtimePolicy === "strict" ? result.runtimeFailures : [])
+        ];
+        return result;
     } finally {
         await rm(directory, { recursive: true, force: true });
     }
@@ -318,21 +353,52 @@ function summarize(results) {
             total: exactPrintResults.length,
             verified: exactPrintResults.filter((result) => result.exactPrintVerified).length
         },
+        runtimeViolations: results.filter((result) => result.runtimeFailures?.length > 0).length,
         byQuality
     };
 }
 
-function summarizeGate(results) {
+function summarizeGate(results, passedProperty = "passed") {
     const blockingResults = results.filter((result) => result.blocking !== false);
-    const passed = blockingResults.filter((result) => result.passed).length;
+    const passed = blockingResults.filter((result) => result[passedProperty]).length;
     const nonBlockingResults = results.filter((result) => result.blocking === false);
     return {
         total: blockingResults.length,
         passed,
         failed: blockingResults.length - passed,
         nonBlocking: nonBlockingResults.length,
-        nonBlockingFailed: nonBlockingResults.filter((result) => !result.passed).length
+        nonBlockingFailed: nonBlockingResults.filter((result) => !result[passedProperty]).length
     };
+}
+
+function resolveRuntimePolicy(value) {
+    const policy = value ?? "strict";
+    if (!runtimePolicies.includes(policy)) {
+        throw new Error(`Runtime policy must be one of: ${runtimePolicies.join(", ")}`);
+    }
+    return policy;
+}
+
+function resolveRegressionShard(value) {
+    if (value == null) return null;
+    if (
+        !Number.isInteger(value.index) ||
+        !Number.isInteger(value.count) ||
+        value.count < 1 ||
+        value.count > maximumRegressionShards ||
+        value.index < 1 ||
+        value.index > value.count
+    ) {
+        throw new Error(
+            `Regression shard must use a 1-based index and a count from 1 to ${maximumRegressionShards}`
+        );
+    }
+    return { index: value.index, count: value.count };
+}
+
+function selectRegressionShard(cases, shard) {
+    if (!shard) return cases;
+    return cases.filter((_fixture, index) => index % shard.count === shard.index - 1);
 }
 
 function resolveOcrWorkerCount(value) {
@@ -354,6 +420,8 @@ function shardCases(cases, workerCount) {
 
 async function runRegression(manifest, options = {}) {
     const workerCount = resolveOcrWorkerCount(options.workers);
+    const runtimePolicy = resolveRuntimePolicy(options.runtimePolicy);
+    const regressionShard = resolveRegressionShard(options.shard);
     const ocrOptions = options.ocrModel
         ? {
               ...noCacheOcrOptions,
@@ -373,11 +441,12 @@ async function runRegression(manifest, options = {}) {
     };
     const activeCatalog = manifest.catalog.filter((card) => card.enabled !== false);
     const activeCases = manifest.cases.filter((fixture) => fixture.enabled !== false);
-    const selectedCases = activeCases.filter((fixture) => {
+    const matchingCases = activeCases.filter((fixture) => {
         if (options.caseIds?.length && !options.caseIds.includes(fixture.id)) return false;
         if (options.qualities?.length && !options.qualities.includes(fixture.quality)) return false;
         return true;
     });
+    const selectedCases = selectRegressionShard(matchingCases, regressionShard);
     if (selectedCases.length === 0) {
         throw new Error("No regression cases matched the requested filters");
     }
@@ -385,7 +454,7 @@ async function runRegression(manifest, options = {}) {
     const cardNames = [...new Set(activeCatalog.map((card) => card.name))].map((name) => ({
         name
     }));
-    const context = { cardNames, catalog: activeCatalog };
+    const context = { cardNames, catalog: activeCatalog, runtimePolicy };
     const managesOcrSession =
         dependencies.ImageProcessor === imageProcessorModule ||
         typeof options.dependencies?.createOcrSession === "function";
@@ -439,10 +508,16 @@ async function runRegression(manifest, options = {}) {
             ? "shared sequentially"
             : `${shards.length} parallel shards; each shared`;
     return {
-        schemaVersion: 1,
+        schemaVersion: 2,
         generatedAt: new Date().toISOString(),
         manifest: manifest.path,
         offline: true,
+        runtimePolicy,
+        selection: {
+            matchedCases: matchingCases.length,
+            selectedCases: selectedCases.length,
+            shard: regressionShard
+        },
         ocrModel: reportOcrModel(options.ocrModel),
         isolation: {
             applicationPersistence: "disabled",
@@ -469,6 +544,8 @@ async function runRegression(manifest, options = {}) {
             wallRuntimeMs: elapsedSince(startedAt)
         },
         gate: summarizeGate(results),
+        correctnessGate: summarizeGate(results, "correctnessPassed"),
+        performanceGate: summarizeGate(results, "performancePassed"),
         results
     };
 }
@@ -477,11 +554,16 @@ export {
     analyzeFixture,
     comparisonScore,
     evaluateResult,
+    evaluateRuntime,
     maximumCasesPerOcrSession,
     maximumOcrWorkers,
+    maximumRegressionShards,
     rankPrintCandidates,
+    resolveRegressionShard,
     resolveOcrWorkerCount,
+    resolveRuntimePolicy,
     runRegression,
+    selectRegressionShard,
     shardCases,
     summarize,
     summarizeGate
@@ -491,11 +573,16 @@ export default {
     analyzeFixture,
     comparisonScore,
     evaluateResult,
+    evaluateRuntime,
     maximumCasesPerOcrSession,
     maximumOcrWorkers,
+    maximumRegressionShards,
     rankPrintCandidates,
+    resolveRegressionShard,
     resolveOcrWorkerCount,
+    resolveRuntimePolicy,
     runRegression,
+    selectRegressionShard,
     shardCases,
     summarize,
     summarizeGate

--- a/src/regression/report.mjs
+++ b/src/regression/report.mjs
@@ -28,11 +28,21 @@ function formatBenchmarkReport(report) {
         "",
         `Isolation: application persistence ${report.isolation?.applicationPersistence || "unknown"}; image-hash cache ${report.isolation?.imageHashCache || "unknown"}; OCR cache ${report.isolation?.ocrCache || "unknown"}`,
         "",
+        `Runtime policy: ${report.runtimePolicy || "strict"}`,
+        ...(report.selection?.shard
+            ? [
+                  "",
+                  `Manifest shard: ${report.selection.shard.index}/${report.selection.shard.count} (${report.selection.selectedCases}/${report.selection.matchedCases} matching fixtures)`
+              ]
+            : []),
+        "",
         "## Summary",
         "",
         `- Passed: ${report.summary.passed}/${report.summary.total} (${report.summary.passRate}%)`,
         `- Failed: ${report.summary.failed}`,
         `- CI gate: ${report.gate?.failed === 0 ? "PASS" : "FAIL"} (${report.gate?.passed || 0}/${report.gate?.total || 0} blocking fixtures passed)`,
+        `- Correctness gate: ${(report.correctnessGate || report.gate)?.failed === 0 ? "PASS" : "FAIL"} (${(report.correctnessGate || report.gate)?.passed || 0}/${(report.correctnessGate || report.gate)?.total || 0} blocking fixtures passed)`,
+        `- Performance gate: ${report.performanceGate?.failed === 0 ? "PASS" : "FAIL"} (${report.summary.runtimeViolations || 0} total threshold violations)`,
         `- Non-blocking fixtures: ${report.gate?.nonBlocking || 0} (${report.gate?.nonBlockingFailed || 0} failed)`,
         `- Disabled fixtures: ${report.pending?.cases || 0}`,
         `- Undersized-input fixtures: ${report.summary.undersizedInputs || 0}`,
@@ -65,7 +75,9 @@ function formatBenchmarkReport(report) {
         const nameMatch = result.nameMatches[0];
         const selectedCard = result.selectedPrint?.card;
         const resultLabel = result.passed
-            ? "PASS"
+            ? result.runtimeFailures?.length
+                ? `PASS WITH RUNTIME WARNING: ${result.runtimeFailures.map(markdownCell).join("; ")}`
+                : "PASS"
             : `${result.blocking === false ? "NON-BLOCKING FAIL" : "FAIL"}: ${result.failures
                   .map(markdownCell)
                   .join("; ")}`;
@@ -86,11 +98,11 @@ function formatBenchmarkReport(report) {
     lines.push("", "## Stage timings", "");
     report.results.forEach((result) => {
         lines.push(
-            `- ${markdownCell(result.id)}: fixture ${result.timings.fixtureMs || 0} ms; OCR ${
+            `- ${markdownCell(result.id)}: fixture ${result.timings.fixtureMs || 0} ms; primary OCR ${
                 result.timings.ocrMs || 0
-            } ms; name matching ${result.timings.nameMatchMs || 0} ms; print matching ${
-                result.timings.printMatchMs || 0
-            } ms.`
+            } ms; fallback OCR ${result.timings.fallbackOcrMs || 0} ms; name matching ${
+                result.timings.nameMatchMs || 0
+            } ms; total name resolution ${result.timings.nameResolutionMs || result.timings.nameMatchMs || 0} ms; print matching ${result.timings.printMatchMs || 0} ms.`
         );
     });
 

--- a/test/processing/name-resolver.spec.mjs
+++ b/test/processing/name-resolver.spec.mjs
@@ -28,6 +28,11 @@ describe("Name resolver::", () => {
         assert.equal(ImageProcessor.create.firstCall.args[0].type, "name");
         assert.equal(result.matches[0].name, "Pacifism");
         assert.isUndefined(result.supplementalExtractionResults);
+        assert.isAtLeast(result.timings.titleOcrMs, 0);
+        assert.isAtLeast(result.timings.initialMatchMs, 0);
+        assert.equal(result.timings.fallbackTitleOcrMs, 0);
+        assert.equal(result.timings.supplementalOcrMs, 0);
+        assert.equal(result.timings.totalFallbackOcrMs, 0);
     });
 
     it("uses rules-text evidence only after title matching fails", async () => {
@@ -85,6 +90,10 @@ describe("Name resolver::", () => {
         assert.equal(MatchName.create.getCall(3).args[0].supplementalText, rulesResults.dirtyText);
         assert.equal(result.matches[0].name, "Yuna, Hope of Spira");
         assert.equal(result.supplementalExtractionResults, rulesResults);
+        assert.isAtLeast(result.timings.fallbackTitleOcrMs, 0);
+        assert.isAtLeast(result.timings.supplementalOcrMs, 0);
+        assert.isAtLeast(result.timings.totalFallbackOcrMs, 0);
+        assert.isAtLeast(result.timings.totalMatchMs, 0);
     });
 
     it("matches an alternate OCR line and promotes its source region", async () => {

--- a/test/regression/regression-runner.spec.mjs
+++ b/test/regression/regression-runner.spec.mjs
@@ -6,10 +6,15 @@ import matchNameModule from "../../src/fuzzy-matching/match-name.mjs";
 import { QUALITY_LEVELS, loadManifest, validateManifest } from "../../src/regression/manifest.mjs";
 import { formatBenchmarkReport } from "../../src/regression/report.mjs";
 import {
+    evaluateRuntime,
     maximumCasesPerOcrSession,
     maximumOcrWorkers,
+    maximumRegressionShards,
+    resolveRegressionShard,
     resolveOcrWorkerCount,
+    resolveRuntimePolicy,
     runRegression,
+    selectRegressionShard,
     shardCases,
     summarize,
     summarizeGate
@@ -58,6 +63,30 @@ describe("Regression framework::", () => {
                 ]
             ]
         );
+    });
+
+    it("validates runtime policies and deterministic manifest shards", () => {
+        const fixtures = Array.from({ length: 7 }, (_, index) => ({ id: `case-${index}` }));
+
+        assert.equal(resolveRuntimePolicy(undefined), "strict");
+        assert.equal(resolveRuntimePolicy("report-only"), "report-only");
+        assert.throws(() => resolveRuntimePolicy("ignore"), "strict, report-only");
+        assert.deepEqual(resolveRegressionShard({ index: 2, count: 3 }), {
+            index: 2,
+            count: 3
+        });
+        assert.throws(() => resolveRegressionShard({ index: 0, count: 3 }), "1-based index");
+        assert.throws(
+            () => resolveRegressionShard({ index: 1, count: maximumRegressionShards + 1 }),
+            "1-based index"
+        );
+        assert.deepEqual(
+            selectRegressionShard(fixtures, { index: 2, count: 3 }).map(({ id }) => id),
+            ["case-1", "case-4"]
+        );
+        assert.deepEqual(evaluateRuntime({ expected: { maxRuntimeMs: 100 } }, { runtimeMs: 101 }), [
+            "runtime: expected at most 100ms, received 101ms"
+        ]);
     });
 
     it("loads labeled fixtures for every supported quality level", async () => {
@@ -157,6 +186,7 @@ describe("Regression framework::", () => {
                         scryfallId: "bbd-101",
                         minNameScore: 0.7,
                         maxPrintCandidates: 2,
+                        maxRuntimeMs: 0,
                         metadata: { typeLine: "Enchantment — Aura", colors: ["W"] }
                     }
                 },
@@ -195,13 +225,19 @@ describe("Regression framework::", () => {
             }
         };
 
+        const dependencies = {
+            ImageProcessor: fakeImageProcessor,
+            MatchName: matchNameModule,
+            Hash: fakeHash,
+            materializeFixture: async (fixture) => fixture.imagePath
+        };
         const report = await runRegression(manifest, {
-            dependencies: {
-                ImageProcessor: fakeImageProcessor,
-                MatchName: matchNameModule,
-                Hash: fakeHash,
-                materializeFixture: async (fixture) => fixture.imagePath
-            }
+            runtimePolicy: "report-only",
+            dependencies
+        });
+        const strictReport = await runRegression(manifest, {
+            runtimePolicy: "strict",
+            dependencies
         });
 
         assert.equal(report.summary.passed, 1);
@@ -233,6 +269,18 @@ describe("Regression framework::", () => {
         assert.isTrue(report.results[0].setVerified);
         assert.deepEqual(report.summary.exactPrints, { total: 1, verified: 1 });
         assert.deepEqual(report.results[0].failures, []);
+        assert.isTrue(report.results[0].correctnessPassed);
+        assert.isFalse(report.results[0].performancePassed);
+        assert.lengthOf(report.results[0].runtimeFailures, 1);
+        assert.equal(report.correctnessGate.failed, 0);
+        assert.equal(report.performanceGate.failed, 1);
+        assert.equal(report.summary.runtimeViolations, 1);
+        assert.equal(report.runtimePolicy, "report-only");
+        assert.equal(strictReport.gate.failed, 1);
+        assert.include(strictReport.results[0].failures[0], "runtime:");
+        assert.isAtLeast(report.results[0].timings.nameResolutionMs, 0);
+        assert.isAtLeast(report.results[0].timings.nameMatchMs, 0);
+        assert.isAtLeast(report.results[0].timings.fallbackOcrMs, 0);
     });
 
     it("recomputes every image hash for every case without caching", async () => {
@@ -650,8 +698,16 @@ describe("Regression framework::", () => {
                     score: 1
                 },
                 setVerified: true,
+                correctnessPassed: true,
+                performancePassed: true,
+                runtimeFailures: [],
                 failures: [],
-                timings: { ocrMs: 8 }
+                timings: {
+                    ocrMs: 8,
+                    fallbackOcrMs: 2,
+                    nameMatchMs: 1,
+                    nameResolutionMs: 3
+                }
             },
             {
                 id: "blur",
@@ -665,6 +721,9 @@ describe("Regression framework::", () => {
                 printCandidateCount: 0,
                 selectedPrint: null,
                 setVerified: false,
+                correctnessPassed: false,
+                performancePassed: true,
+                runtimeFailures: [],
                 failures: ["OCR returned no normalized text"],
                 timings: { ocrMs: 18 }
             }
@@ -679,6 +738,7 @@ describe("Regression framework::", () => {
                 sha256: "b".repeat(64),
                 sizeBytes: 4_113_088
             },
+            runtimePolicy: "report-only",
             isolation: {
                 applicationPersistence: "disabled",
                 imageHashCache: "disabled",
@@ -686,6 +746,8 @@ describe("Regression framework::", () => {
             },
             summary: summarize(results),
             gate: summarizeGate(results),
+            correctnessGate: summarizeGate(results, "correctnessPassed"),
+            performanceGate: summarizeGate(results, "performancePassed"),
             results
         };
         const markdown = formatBenchmarkReport(report);
@@ -699,6 +761,10 @@ describe("Regression framework::", () => {
         assert.include(markdown, "Exact print verified");
         assert.include(markdown, "OCR returned no normalized text");
         assert.include(markdown, "CI gate: PASS");
+        assert.include(markdown, "Runtime policy: report-only");
+        assert.include(markdown, "Correctness gate: PASS");
+        assert.include(markdown, "Performance gate: PASS");
+        assert.include(markdown, "fallback OCR 2 ms");
         assert.include(markdown, "NON-BLOCKING FAIL");
         assert.include(markdown, "image-hash cache disabled");
         assert.include(markdown, "official-eng-fast");

--- a/test/scripts/run-regression.spec.mjs
+++ b/test/scripts/run-regression.spec.mjs
@@ -1,8 +1,11 @@
 import { assert } from "chai";
 import {
     buildProgram,
+    defaultRuntimePolicy,
     defaultWorkers,
     main,
+    parseRuntimePolicy,
+    parseShard,
     parseWorkerCount
 } from "../../scripts/run-regression.mjs";
 
@@ -18,6 +21,28 @@ describe("run-regression CLI::", () => {
         assert.throws(() => parseWorkerCount("0"), "must be an integer from 1 to 3");
         assert.throws(() => parseWorkerCount("4"), "must be an integer from 1 to 3");
         assert.throws(() => parseWorkerCount("2.5"), "must be an integer from 1 to 3");
+    });
+
+    it("parses runtime policy and deterministic manifest shards", () => {
+        const defaults = buildProgram().parse(["node", "run-regression.mjs"]).opts();
+        const explicit = buildProgram()
+            .parse([
+                "node",
+                "run-regression.mjs",
+                "--runtime-policy",
+                "report-only",
+                "--shard",
+                "2/3"
+            ])
+            .opts();
+
+        assert.equal(defaults.runtimePolicy, defaultRuntimePolicy);
+        assert.equal(explicit.runtimePolicy, "report-only");
+        assert.deepEqual(explicit.shard, { index: 2, count: 3 });
+        assert.throws(() => parseRuntimePolicy("ignore"), "strict");
+        assert.throws(() => parseShard("0/3"), "1-based index");
+        assert.throws(() => parseShard("4/3"), "1-based index");
+        assert.throws(() => parseShard("2-of-3"), "INDEX/COUNT");
     });
 
     it("parses an explicit OCR candidate manifest and candidate ID", () => {
@@ -47,6 +72,9 @@ describe("run-regression CLI::", () => {
         const report = {
             summary: { passed: 1, total: 1, passRate: 100 },
             gate: { passed: 1, total: 1, failed: 0, nonBlocking: 0, nonBlockingFailed: 0 },
+            performanceGate: { passed: 1, total: 1, failed: 0 },
+            runtimePolicy: "strict",
+            selection: { matchedCases: 1, selectedCases: 1, shard: null },
             isolation: {
                 ocrWorkerLifecycle:
                     "shared sequentially for at most 40 cases; adaptive state reset per crop"
@@ -81,6 +109,7 @@ describe("run-regression CLI::", () => {
         assert.strictEqual(result, report);
         assert.strictEqual(receivedOptions.ocrModel, selectedCandidate);
         assert.equal(receivedOptions.workers, defaultWorkers);
+        assert.equal(receivedOptions.runtimePolicy, defaultRuntimePolicy);
         assert.include(lines, "OCR model: official-eng-fast");
         assert.include(
             lines,


### PR DESCRIPTION
## Summary

- separate correctness failures from runtime threshold violations, with strict and report-only runtime policies
- add deterministic manifest sharding and run the full correctness corpus as three parallel CI shards while retaining the stable `Cold-cache OCR regression` check
- enforce runtime thresholds in a representative single-worker performance smoke and report fallback OCR separately from actual name-matching time
- document the new local and CI workflows

## Verification

- `pnpm check:fast`
- `pnpm test` — 485 passing
- isolated performance smoke — 3/3 passing in 26.4s
- full CI-shaped regression — 174 fixtures, 167/167 blocking fixtures passing, 0 runtime violations; slowest shard 158.5s
- `pnpm coverage:check` could not collect locally because this Codex host disables Node inspector instrumentation; its underlying 485-test run passed and CI will run the coverage gate in the normal runner environment

Closes #221