### PR TITLE
Improve set-symbol detection and layout fallback

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,10 @@ Set-symbol extraction searches a bounded area around the expected type-line posi
 contrast finds compact symbol-like components, long frame rules are suppressed, and the selected
 icon is centered in a square crop with padding. If no credible component is found, set-symbol
 hashing is marked low-confidence so matching can use the existing full-card fallback.
+When every Scryfall candidate uses a structurally nonstandard `flip`, `meld`, `planar`, `saga`, or
+`split` layout, matching skips the conventional set-symbol crop and starts with the full-card hash.
+Mixed or unknown candidate layouts remain set-symbol-first so metadata cannot broadly reroute normal
+printings or visual treatments such as full-art, borderless, and showcase cards.
 
 Local image input is capped at 32 MiB, 12,000 pixels per axis, and 40 megapixels. JPEG decoding also
 uses a 256 MiB decoder allocation ceiling. Remote set-symbol images are limited to the approved

--- a/src/image-processing/smart-crop.mjs
+++ b/src/image-processing/smart-crop.mjs
@@ -5,7 +5,7 @@ import { round, clamp } from "../util.mjs";
 
 // Crop geometry is part of a fingerprint's meaning. Bump this value whenever set-symbol
 // normalization changes so cached hashes from incompatible crop algorithms are never compared.
-const setSymbolHashMode = "set-symbol-content-v1";
+const setSymbolHashMode = "set-symbol-content-v3";
 
 // Reusable region registry -- the shared "layer" every crop spot plugs into. setSymbol feeds the
 // image-fingerprint path; name/type/rules-name/default feed OCR (region templates, one or more crop
@@ -27,6 +27,13 @@ const regions = {
         topPercent: 0.515,
         widthPercent: 0.24,
         heightPercent: 0.14
+    },
+    // Modern frames place the symbol farther right than the center of the legacy fallback crop.
+    // This point guides candidate ranking only; older frames can still win on component quality,
+    // and the reviewed legacy crop remains unchanged when detection is inconclusive.
+    setSymbolExpectedCenter: {
+        xPercent: 0.88,
+        yPercent: 0.585
     },
     name: [
         {
@@ -469,7 +476,7 @@ function dilateEdges(edges, width, height, radiusX, radiusY) {
     return dilated;
 }
 
-function findEdgeComponents(edgeMap) {
+function findEdgeComponents(edgeMap, options = {}) {
     const { width, height } = edgeMap;
     const edges = edgeMap.edges.slice();
     // A set symbol may overlap a frame rule in the raw search window. Remove only near-continuous
@@ -493,8 +500,8 @@ function findEdgeComponents(edgeMap) {
         edges,
         width,
         height,
-        Math.max(1, round(width * 0.008)),
-        Math.max(1, round(height * 0.008))
+        Math.max(1, round(width * (options.dilationX ?? 0.008))),
+        Math.max(1, round(height * (options.dilationY ?? 0.008)))
     );
     const visited = new Uint8Array(connected.length);
     const components = [];
@@ -542,20 +549,22 @@ function findEdgeComponents(edgeMap) {
  * proximity preference lets older/newer frame offsets move naturally while rejecting type-line
  * rules and unrelated artwork elsewhere in the wider search window.
  */
-function detectSymbolContentBounds(img, expectedCenter = { x: 0.5, y: 0.5 }) {
+function detectSymbolContentBounds(img, expectedCenter = { x: 0.5, y: 0.5 }, options = {}) {
     const edgeMap = buildColorContrastMap(img);
     const { width, height } = edgeMap;
-    const components = findEdgeComponents(edgeMap).filter((component) => {
+    const components = findEdgeComponents(edgeMap, options).filter((component) => {
         const componentWidth = component.right - component.left + 1;
         const componentHeight = component.bottom - component.top + 1;
         const aspectRatio = componentWidth / componentHeight;
         return (
-            componentWidth >= Math.max(6, width * 0.025) &&
-            componentHeight >= Math.max(6, height * 0.025) &&
-            componentWidth <= width * 0.58 &&
-            componentHeight <= height * 0.58 &&
-            aspectRatio >= 0.6 &&
-            aspectRatio <= 1.9
+            componentWidth >=
+                Math.max(options.minimumPixels ?? 6, width * (options.minWidth ?? 0.025)) &&
+            componentHeight >=
+                Math.max(options.minimumPixels ?? 6, height * (options.minHeight ?? 0.025)) &&
+            componentWidth <= width * (options.maxWidth ?? 0.58) &&
+            componentHeight <= height * (options.maxHeight ?? 0.58) &&
+            aspectRatio >= (options.minAspectRatio ?? 0.6) &&
+            aspectRatio <= (options.maxAspectRatio ?? 1.9)
         );
     });
     if (components.length === 0) {
@@ -574,7 +583,14 @@ function detectSymbolContentBounds(img, expectedCenter = { x: 0.5, y: 0.5 }) {
             const proximity = Math.max(0, 1 - distance / 0.42);
             const shape = Math.max(0, 1 - Math.abs(Math.log(componentWidth / componentHeight)));
             const fill = Math.min(1, component.area / (componentWidth * componentHeight * 0.55));
-            return { ...component, rank: proximity * 4 + shape + fill };
+            const scale = Math.min(
+                1,
+                Math.sqrt((componentWidth * componentHeight) / (width * height)) / 0.24
+            );
+            return {
+                ...component,
+                rank: proximity * 4 + shape + fill + scale * (options.scaleWeight ?? 0)
+            };
         })
         .sort((left, right) => right.rank - left.rank);
     const selected = ranked[0];
@@ -582,6 +598,144 @@ function detectSymbolContentBounds(img, expectedCenter = { x: 0.5, y: 0.5 }) {
         return null;
     }
     return scaleBounds(selected, edgeMap, img.bitmap);
+}
+
+function relativeCropGeometry(region, sourceDimensions) {
+    return {
+        centerX: (region.left + region.width / 2) / sourceDimensions.width,
+        centerY: (region.top + region.height / 2) / sourceDimensions.height,
+        width: region.width / sourceDimensions.width,
+        height: region.height / sourceDimensions.height
+    };
+}
+
+function localPixelContrast(data, width, x, y) {
+    const index = (y * width + x) * 4;
+    const right = index + 4;
+    const below = index + width * 4;
+    let difference = 0;
+    for (let channel = 0; channel < 3; channel++) {
+        difference += Math.abs(data[index + channel] - data[right + channel]);
+        difference += Math.abs(data[index + channel] - data[below + channel]);
+    }
+    return difference / 6;
+}
+
+function horizontalContrastBands(img, bandCount = 5) {
+    const { width, height, data } = img.bitmap;
+    const totals = new Array(bandCount).fill(0);
+    const counts = new Array(bandCount).fill(0);
+    for (let y = 1; y < height - 1; y++) {
+        for (let x = 1; x < width - 1; x++) {
+            const band = Math.min(bandCount - 1, Math.floor((x * bandCount) / width));
+            totals[band] += localPixelContrast(data, width, x, y);
+            counts[band] += 1;
+        }
+    }
+    return totals.map((total, index) => (counts[index] > 0 ? total / counts[index] : 0));
+}
+
+function boundaryContrast(img, side) {
+    const { width, height, data } = img.bitmap;
+    let total = 0;
+    let count = 0;
+    for (let y = 1; y < height - 1; y++) {
+        for (let x = 1; x < width - 1; x++) {
+            const insideBoundary =
+                (side === "left" && x < 4) ||
+                (side === "right" && x > width - 5) ||
+                (side === "bottom" && y > height - 5);
+            if (!insideBoundary) continue;
+            total += localPixelContrast(data, width, x, y);
+            count += 1;
+        }
+    }
+    return count > 0 ? total / count : 0;
+}
+
+function shouldUseModernSetSymbolFallback(result, sourceDimensions) {
+    const geometry = relativeCropGeometry(result.region, sourceDimensions);
+    const contrastBands = horizontalContrastBands(result.image);
+    const leftContrast = boundaryContrast(result.image, "left");
+    const rightContrast = boundaryContrast(result.image, "right");
+    const bottomContrast = boundaryContrast(result.image, "bottom");
+    const clippedFallback =
+        result.lowConfidence &&
+        contrastBands[4] - contrastBands[0] > 10 &&
+        contrastBands[4] >= contrastBands[2] - 1;
+    const implausiblyLeft = !result.lowConfidence && geometry.centerX < 0.84;
+    const tinyOffCenterFragment =
+        !result.lowConfidence &&
+        (geometry.width < 0.055 || geometry.height < 0.04) &&
+        (geometry.centerX < 0.86 || geometry.centerX >= 0.868);
+    const highRightFragment =
+        !result.lowConfidence && geometry.centerY < 0.555 && geometry.centerX > 0.86;
+    const clippedLowSymbol =
+        !result.lowConfidence &&
+        geometry.centerX > 0.88 &&
+        geometry.centerY < 0.58 &&
+        geometry.width < 0.09 &&
+        bottomContrast > 20;
+    const clippedWideLogo =
+        !result.lowConfidence &&
+        geometry.width >= 0.12 &&
+        geometry.width < 0.14 &&
+        leftContrast > 20 &&
+        rightContrast < 20;
+    return (
+        clippedFallback ||
+        implausiblyLeft ||
+        tinyOffCenterFragment ||
+        highRightFragment ||
+        clippedLowSymbol ||
+        clippedWideLogo
+    );
+}
+
+function cropModernSetSymbolFallback(img, searchRegion) {
+    const size = Math.max(1, round(img.bitmap.width * 0.17));
+    const centerX = img.bitmap.width * regions.setSymbolExpectedCenter.xPercent;
+    const centerY = img.bitmap.height * regions.setSymbolExpectedCenter.yPercent;
+    const left = clamp(round(centerX - size / 2), 0, img.bitmap.width - size);
+    const top = clamp(round(centerY - size / 2), 0, img.bitmap.height - size);
+    const region = { left, top, width: size, height: size };
+    return {
+        image: img.clone().crop({ x: left, y: top, w: size, h: size }),
+        region,
+        searchRegion,
+        contentDetected: false
+    };
+}
+
+function shouldRefineSetSymbol(result, sourceDimensions) {
+    const geometry = relativeCropGeometry(result.region, sourceDimensions);
+    // Review evidence separates complete symbols from the common failure modes here: a tiny
+    // fragment, a component left of the modern symbol column, or a visually flat crop.
+    return (
+        result.lowConfidence ||
+        geometry.centerX < 0.86 ||
+        geometry.width < 0.05 ||
+        geometry.height < 0.04
+    );
+}
+
+function isAcceptableRefinedSetSymbol(result, sourceDimensions) {
+    if (result.lowConfidence) return false;
+    const geometry = relativeCropGeometry(result.region, sourceDimensions);
+    // Fail closed around the reviewed modern-frame envelope. Wide core-set logos may start a bit
+    // farther left, but neither candidate family may consume the card edge or neighboring rules.
+    const centeredCandidate = geometry.centerX >= 0.87 && geometry.width >= 0.05;
+    const wideLogoCandidate = geometry.centerX >= 0.85 && geometry.width >= 0.13;
+    return (
+        (centeredCandidate || wideLogoCandidate) &&
+        geometry.centerX <= 0.91 &&
+        geometry.centerX + geometry.width / 2 <= 0.98 &&
+        geometry.centerY >= 0.56 &&
+        geometry.centerY <= 0.61 &&
+        geometry.width <= 0.23 &&
+        geometry.height >= 0.035 &&
+        geometry.height <= 0.17
+    );
 }
 
 function expandBounds(bounds, sourceDimensions, options = {}) {
@@ -730,7 +884,7 @@ function assessConfidence(croppedImg) {
  */
 function cropSetSymbolFromImage(img) {
     const search = cropRegion(img, regions.setSymbolSearch);
-    const expectedCenter = {
+    const legacyExpectedCenter = {
         x:
             (regions.setSymbol.leftPercent +
                 regions.setSymbol.widthPercent / 2 -
@@ -742,10 +896,53 @@ function cropSetSymbolFromImage(img) {
                 regions.setSymbolSearch.topPercent) /
             regions.setSymbolSearch.heightPercent
     };
-    const bounds = detectSymbolContentBounds(search.image, expectedCenter);
-    if (!bounds) {
+    const cropOptions = {
+        paddingX: 0.2,
+        paddingY: 0.2,
+        minimumPadding: 3,
+        square: true
+    };
+    const primaryBounds = detectSymbolContentBounds(search.image, legacyExpectedCenter);
+    let result = primaryBounds
+        ? cropDetectedBounds(img, search.region, primaryBounds, cropOptions)
+        : null;
+    if (result) {
+        result = { ...result, ...assessConfidence(result.image) };
+    }
+
+    if (!result || shouldRefineSetSymbol(result, img.bitmap)) {
+        const modernExpectedCenter = {
+            x:
+                (regions.setSymbolExpectedCenter.xPercent - regions.setSymbolSearch.leftPercent) /
+                regions.setSymbolSearch.widthPercent,
+            y:
+                (regions.setSymbolExpectedCenter.yPercent - regions.setSymbolSearch.topPercent) /
+                regions.setSymbolSearch.heightPercent
+        };
+        const refinedBounds = detectSymbolContentBounds(search.image, modernExpectedCenter, {
+            dilationX: 0.018,
+            dilationY: 0.018,
+            minimumPixels: 8,
+            minWidth: 0.06,
+            minHeight: 0.06,
+            maxWidth: 0.68,
+            maxHeight: 0.68,
+            minAspectRatio: 0.45,
+            maxAspectRatio: 3.2,
+            scaleWeight: 1
+        });
+        if (refinedBounds) {
+            const refined = cropDetectedBounds(img, search.region, refinedBounds, cropOptions);
+            const assessedRefined = { ...refined, ...assessConfidence(refined.image) };
+            if (isAcceptableRefinedSetSymbol(assessedRefined, img.bitmap)) {
+                result = assessedRefined;
+            }
+        }
+    }
+
+    if (!result) {
         const legacy = cropRegion(img, regions.setSymbol);
-        return {
+        result = {
             ...legacy,
             searchRegion: search.region,
             contentDetected: false,
@@ -753,13 +950,15 @@ function cropSetSymbolFromImage(img) {
             reason: "set symbol edges were not detected"
         };
     }
-    const result = cropDetectedBounds(img, search.region, bounds, {
-        paddingX: 0.2,
-        paddingY: 0.2,
-        minimumPadding: 3,
-        square: true
-    });
-    return { ...result, ...assessConfidence(result.image) };
+
+    if (shouldUseModernSetSymbolFallback(result, img.bitmap)) {
+        const modernFallback = cropModernSetSymbolFallback(img, search.region);
+        const confidence = assessConfidence(modernFallback.image);
+        if (!confidence.lowConfidence) {
+            return { ...modernFallback, ...confidence };
+        }
+    }
+    return result;
 }
 
 /**

--- a/src/matcher/matching-processor.mjs
+++ b/src/matcher/matching-processor.mjs
@@ -17,6 +17,21 @@ const defaultDependencies = Object.freeze({
     writeSetSymbolSnippet: imageProcessing.smartCrop.writeSetSymbolSnippet
 });
 
+const nonstandardSetSymbolLayouts = new Set(["flip", "meld", "planar", "saga", "split"]);
+
+function nonstandardLayoutSummary(cards = []) {
+    const candidates = cards.map(normalizePrintCandidate);
+    if (
+        candidates.length === 0 ||
+        candidates.some(
+            (candidate) => !candidate.layout || !nonstandardSetSymbolLayouts.has(candidate.layout)
+        )
+    ) {
+        return "";
+    }
+    return [...new Set(candidates.map((candidate) => candidate.layout))].sort().join(", ");
+}
+
 const schema = joi.object().keys({
     name: joi.string().required(),
     filePath: joi.string().required(),
@@ -86,6 +101,14 @@ class MatcherProcessor {
     }
 
     async _hashLocalCardAsync() {
+        const layoutSummary = nonstandardLayoutSummary(this.cards);
+        if (layoutSummary) {
+            this.logger.info(
+                `All printings for "${this.name}" use nonstandard layouts (${layoutSummary}); using full card image`
+            );
+            return this._hashFromPathAsync(this.filePath);
+        }
+
         let directory;
         try {
             directory = await this.dependencies.createDirectory();

--- a/test/image-processing/smart-crop.spec.mjs
+++ b/test/image-processing/smart-crop.spec.mjs
@@ -169,6 +169,83 @@ describe("Smart crop::", () => {
             assert.isBelow(result.region.width, search.width / 2);
         });
 
+        it("prefers a full modern symbol over a small legacy-center distractor", () => {
+            const img = new Jimp({ width: 600, height: 800, color: 0xb8b8b8ff });
+            const search = cropRegion(img, regions.setSymbolSearch).region;
+            const distractor = {
+                left: search.left + 66,
+                top: search.top + 51,
+                width: 9,
+                height: 10
+            };
+            fillRectangle(
+                img,
+                distractor.left,
+                distractor.top,
+                distractor.width,
+                distractor.height,
+                0x151515ff
+            );
+            const icon = {
+                left: search.left + 88,
+                top: search.top + 40,
+                width: 34,
+                height: 32
+            };
+            fillRectangle(img, icon.left, icon.top, 15, icon.height, 0x151515ff);
+            fillRectangle(img, icon.left + 19, icon.top, 15, icon.height, 0x151515ff);
+
+            const result = cropSetSymbolFromImage(img);
+
+            assert.isTrue(result.contentDetected);
+            assert.isFalse(result.lowConfidence);
+            assert.isBelow(result.region.left, icon.left);
+            assert.isAbove(result.region.left + result.region.width, icon.left + icon.width);
+            assert.isBelow(result.region.top, icon.top);
+            assert.isAbove(result.region.top + result.region.height, icon.top + icon.height);
+            assert.isAtLeast(result.region.left, distractor.left + distractor.width);
+        });
+
+        it("joins a wide multipart set logo into one crop", () => {
+            const img = new Jimp({ width: 600, height: 800, color: 0xd0d0d0ff });
+            const search = cropRegion(img, regions.setSymbolSearch).region;
+            const logo = {
+                left: search.left + 82,
+                top: search.top + 43,
+                width: 32,
+                height: 26
+            };
+            fillRectangle(img, logo.left, logo.top, 14, logo.height, 0x202020ff);
+            fillRectangle(img, logo.left + 18, logo.top, 14, logo.height, 0x202020ff);
+
+            const result = cropSetSymbolFromImage(img);
+
+            assert.isTrue(result.contentDetected);
+            assert.isFalse(result.lowConfidence);
+            assert.isBelow(result.region.left, logo.left);
+            assert.isAbove(result.region.left + result.region.width, logo.left + logo.width);
+            assert.isBelow(result.region.top, logo.top);
+            assert.isAbove(result.region.top + result.region.height, logo.top + logo.height);
+        });
+
+        it("uses a bounded modern fallback when detection selects a far-left fragment", () => {
+            const img = new Jimp({ width: 600, height: 800, color: 0xc8c8c8ff });
+            const search = cropRegion(img, regions.setSymbolSearch).region;
+            fillRectangle(img, search.left + 26, search.top + 43, 10, 10, 0x202020ff);
+            // The very wide mark is intentionally outside the component aspect-ratio limits. It
+            // still gives the reviewed fallback enough contrast to be a useful fingerprint crop.
+            fillRectangle(img, 498, 463, 60, 10, 0x151515ff);
+
+            const result = cropSetSymbolFromImage(img);
+
+            assert.isFalse(result.contentDetected);
+            assert.isFalse(result.lowConfidence);
+            assert.equal(result.region.width, 102);
+            assert.equal(result.region.height, 102);
+            assert.closeTo(result.region.left + result.region.width / 2, 600 * 0.88, 1);
+            assert.closeTo(result.region.top + result.region.height / 2, 800 * 0.585, 1);
+        });
+
         it("marks an ambiguous symbol search as low confidence", () => {
             const img = new Jimp({ width: 600, height: 800, color: 0x808080ff });
 

--- a/test/matcher/matching-processor.spec.mjs
+++ b/test/matcher/matching-processor.spec.mjs
@@ -312,6 +312,70 @@ describe("MatcherProcessor::", () => {
         });
     });
 
+    it("uses the full card when all candidate printings have nonstandard layouts", async () => {
+        const processHashesInstance = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().resolves([{ setName: "DSK" }])
+        };
+        sandbox.stub(dependencies, "searchPrintings").resolves([
+            { set_name: "DSK", layout: "split" },
+            { set_name: "DSK Promos", layout: "split" }
+        ]);
+        const hashStub = sandbox.stub(dependencies, "hashImage").resolves("FULL_CARD_HASH");
+        const createDirectoryStub = sandbox.stub(dependencies, "createDirectory");
+        const cropStub = sandbox.stub(dependencies, "writeSetSymbolSnippet");
+        const processHashesStub = sandbox
+            .stub(dependencies.processHashes, "create")
+            .returns(processHashesInstance);
+        const info = sandbox.stub();
+
+        const result = await create({
+            name: "Underwater Tunnel // Slimy Aquarium",
+            filePath: "/tmp/room.jpg",
+            logger: { info, error: sandbox.stub() }
+        }).executeAsync();
+
+        assert.deepEqual(result, ["DSK"]);
+        assert.isTrue(hashStub.calledOnceWithExactly("/tmp/room.jpg"));
+        assert.isTrue(createDirectoryStub.notCalled);
+        assert.isTrue(cropStub.notCalled);
+        assert.equal(processHashesStub.firstCall.args[0].hashMode, "full-card");
+        assert.isTrue(info.calledWithMatch(sinon.match(/nonstandard layouts \(split\)/)));
+    });
+
+    it("keeps set-symbol hashing when candidate layouts do not all support full-card routing", async () => {
+        const processHashesInstance = {
+            compareDbHashes: sandbox.stub().resolves([]),
+            compareRemoteImages: sandbox.stub().resolves([{ setName: "MIX" }])
+        };
+        sandbox.stub(dependencies, "searchPrintings").resolves([
+            { set_name: "MIX", layout: "normal" },
+            { set_name: "MIX Promos", layout: "split" }
+        ]);
+        const hashStub = sandbox.stub(dependencies, "hashImage").resolves("SET_SYMBOL_HASH");
+        const createDirectoryStub = sandbox
+            .stub(dependencies, "createDirectory")
+            .resolves("/tmp/set-symbol-dir");
+        const cropStub = sandbox
+            .stub(dependencies, "writeSetSymbolSnippet")
+            .resolves("/tmp/set-symbol-dir/set-symbol.png");
+        sandbox.stub(dependencies, "cleanUpFiles").resolves();
+        const processHashesStub = sandbox
+            .stub(dependencies.processHashes, "create")
+            .returns(processHashesInstance);
+
+        const result = await create({
+            name: "Mixed Layout Example",
+            filePath: "/tmp/mixed.jpg"
+        }).executeAsync();
+
+        assert.deepEqual(result, ["MIX"]);
+        assert.isTrue(createDirectoryStub.calledOnce);
+        assert.isTrue(cropStub.calledOnce);
+        assert.isTrue(hashStub.calledOnceWithExactly("/tmp/set-symbol-dir/set-symbol.png"));
+        assert.equal(processHashesStub.firstCall.args[0].hashMode, "set-symbol-content-v3");
+    });
+
     it("retries with full-card fingerprints when set-symbol matching is inconclusive", async () => {
         const setSymbolHasher = {
             compareDbHashes: sandbox.stub().resolves([]),
@@ -352,7 +416,7 @@ describe("MatcherProcessor::", () => {
         assert.deepEqual(result, ["M21"]);
         assert.isTrue(hashStub.calledTwice);
         assert.equal(hashStub.secondCall.args[0], "/tmp/pacifism.jpg");
-        assert.equal(processHashesStub.firstCall.args[0].hashMode, "set-symbol-content-v1");
+        assert.equal(processHashesStub.firstCall.args[0].hashMode, "set-symbol-content-v3");
         assert.equal(processHashesStub.secondCall.args[0].hashMode, "full-card");
         assert.equal(processHashesStub.secondCall.args[0].localHash, "FULL_CARD_HASH");
     });


### PR DESCRIPTION
## Summary

- refine set-symbol component detection around the modern symbol position, including multipart logos and bounded fallbacks
- version the normalized symbol fingerprint mode as `set-symbol-content-v3` so incompatible cached crops are not reused
- route unanimously nonstandard `flip`, `meld`, `planar`, `saga`, and `split` candidates directly to full-card hashing
- preserve set-symbol-first behavior for normal, mixed, and unknown candidate layouts
- document the matching contract and add focused crop and matcher coverage

## Why

Human review showed that ordinary card frames now match reliably, while the repeat crop failures cluster around fragments, unusual symbol positions, multipart logos, and structurally nonstandard layouts. The crop refinements address the normal-frame failure modes without broadly rerouting special treatments, while the metadata fallback avoids known-bad conventional crops for structural layouts.

Image-only detection for full-art, showcase, borderless, horizontal, and other unusual treatments remains separate follow-up work in #223.

## Validation

- `pnpm check:fast`
- `pnpm test` — 490 passing
- `pnpm test:regression` — 167/167 blocking fixtures passed; the same 2 of 7 non-blocking fixtures failed
